### PR TITLE
allow specify reader monad explicitly.

### DIFF
--- a/katz/src/main/kotlin/katz/data/Reader.kt
+++ b/katz/src/main/kotlin/katz/data/Reader.kt
@@ -14,13 +14,13 @@ fun <D, A> ReaderT<Id.F, D, A>.runId(d: D): A =
 
 object Reader {
 
-    inline operator fun <D, A> invoke(noinline run: (D) -> A, MF: Monad<Id.F> = monad<Id.F>()): ReaderT<Id.F, D, A> =
+    operator fun <D, A> invoke(run: (D) -> A, MF: Monad<Id.F> = Id): ReaderT<Id.F, D, A> =
             Kleisli(run.andThen { Id(it) }, MF)
 
-    fun <D, A> pure(x: A, MF: Monad<Id.F> = monad<Id.F>()): ReaderT<Id.F, D, A> =
+    fun <D, A> pure(x: A, MF: Monad<Id.F> = Id): ReaderT<Id.F, D, A> =
             Kleisli.pure<Id.F, D, A>(x, MF)
 
-    fun <D> ask(MF: Monad<Id.F> = monad<Id.F>()): ReaderT<Id.F, D, D> =
+    fun <D> ask(MF: Monad<Id.F> = Id): ReaderT<Id.F, D, D> =
             Kleisli.ask<Id.F, D>(MF)
 
 }

--- a/katz/src/main/kotlin/katz/data/Reader.kt
+++ b/katz/src/main/kotlin/katz/data/Reader.kt
@@ -7,20 +7,20 @@ infix fun <A, B, C> ((A) -> B).andThen(g: (B) -> C): (A) -> C =
         { a: A -> g(this(a)) }
 
 fun <D, A> ((D) -> A).reader(): ReaderT<Id.F, D, A> =
-        Reader(this)
+        Reader(this, Id)
 
 fun <D, A> ReaderT<Id.F, D, A>.runId(d: D): A =
         this.run(d).value()
 
 object Reader {
 
-    operator fun <D, A> invoke(run: (D) -> A): ReaderT<Id.F, D, A> =
-            Kleisli(run.andThen { Id(it) })
+    inline operator fun <D, A> invoke(noinline run: (D) -> A, MF: Monad<Id.F> = monad<Id.F>()): ReaderT<Id.F, D, A> =
+            Kleisli(run.andThen { Id(it) }, MF)
 
-    fun <D, A> pure(x: A): ReaderT<Id.F, D, A> =
-            Kleisli.pure<Id.F, D, A>(x)
+    fun <D, A> pure(x: A, MF: Monad<Id.F> = monad<Id.F>()): ReaderT<Id.F, D, A> =
+            Kleisli.pure<Id.F, D, A>(x, MF)
 
-    fun <D> ask(): ReaderT<Id.F, D, D> =
-            Kleisli.ask<Id.F, D>()
+    fun <D> ask(MF: Monad<Id.F> = monad<Id.F>()): ReaderT<Id.F, D, D> =
+            Kleisli.ask<Id.F, D>(MF)
 
 }

--- a/katz/src/test/kotlin/katz/data/ReaderTest.kt
+++ b/katz/src/test/kotlin/katz/data/ReaderTest.kt
@@ -8,7 +8,7 @@ import org.junit.runner.RunWith
 class ReaderTest : UnitSpec() {
     init {
         "map should return mapped value" {
-            Reader<Int, Int> { it -> it * 2 }.map { it -> it * 3 }.runId(2) shouldBe 12
+            Reader<Int, Int> ({ it -> it * 2 }).map { it -> it * 3 }.runId(2) shouldBe 12
         }
 
         "flatMap should map over the inner value" {


### PR DESCRIPTION
Using actual Reader implementation
```
FATAL EXCEPTION: main
 Process: com.github.jorgecastillo.kotlinandroid, PID: 32610
 java.lang.NoSuchMethodError: No interface method getTypeName()Ljava/lang/String; in class Ljava/lang/reflect/Type; or its super classes (declaration of 'java.lang.reflect.Type' appears in /system/framework/core-oj.jar)
    at katz.InstanceParametrizedType.toString(Typeclass.kt:88)
    at java.lang.String.valueOf(String.java:2683)
    at java.lang.StringBuilder.append(StringBuilder.java:129)
    at katz.TypeClassInstanceNotFound.<init>(Typeclass.kt:172)
    at katz.TypeclassKt.instance(Typeclass.kt:185)
    at katz.Reader.ask(Reader.kt:27)
```

something happens with implicits, but in order to not block I detect a defect in Reader API that does not allow pass the monad explicitly. this change fix that.