### PR TITLE
Add instance lookup for Foldable and Traverse methods

### DIFF
--- a/kategory/src/main/kotlin/kategory/instances/Traverse.kt
+++ b/kategory/src/main/kotlin/kategory/instances/Traverse.kt
@@ -11,18 +11,18 @@ interface Traverse<F> : Functor<F>, Foldable<F>, Typeclass {
      */
     fun <G, A, B> traverse(fa: HK<F, A>, f: (A) -> HK<G, B>, GA: Applicative<G>): HK<G, HK<F, B>>
 
-    /**
-     * Thread all the G effects through the F structure to invert the structure from F<G<A>> to G<F<A>>.
-     */
-    fun <G, A> sequence(fga: HK<F, HK<G, A>>, GA: Applicative<G>): HK<G, HK<F, A>> =
-            traverse(fga, { it }, GA)
-
-    fun <G, A, B> flatTraverse(fa: HK<F, A>, f: (A) -> HK<G, HK<F, B>>, GA: Applicative<G>, FM: Monad<F>): HK<G, HK<F, B>> =
-            GA.map(traverse(fa, f, GA), { FM.flatten(it) })
-
     override fun <A, B> map(fa: HK<F, A>, f: (A) -> B): HK<F, B> =
             traverse(fa, { Id(f(it)) }, Id).value()
 }
+
+inline fun <reified F, reified G, A, B> Traverse<F>.flatTraverse(fa: HK<F, A>, noinline f: (A) -> HK<G, HK<F, B>>, GA: Applicative<G> = applicative(), FM: Monad<F> = monad()): HK<G, HK<F, B>> =
+        GA.map(traverse(fa, f, GA), { FM.flatten(it) })
+
+/**
+ * Thread all the G effects through the F structure to invert the structure from F<G<A>> to G<F<A>>.
+ */
+inline fun <F, reified G, A> Traverse<F>.sequence(fga: HK<F, HK<G, A>>, GA: Applicative<G> = applicative()): HK<G, HK<F, A>> =
+        traverse(fga, { it }, GA)
 
 inline fun <reified F> traverse(): Traverse<F> =
         instance(InstanceParametrizedType(Traverse::class.java, listOf(F::class.java)))

--- a/kategory/src/main/kotlin/kategory/typeclasses/Foldable.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/Foldable.kt
@@ -124,8 +124,8 @@ interface Foldable<in F> : Typeclass {
  *
  * Similar to foldM, but using a Monoid<B>.
  */
-inline fun <F, reified G, A, B> Foldable<F>.foldMapM(MG: Monad<G>, bb: Monoid<B>, fa: HK<F, A>, noinline f: (A) -> HK<G, B>): HK<G, B> =
-        foldM(MG, fa, bb.empty(), { b, a -> MG.map(f(a)) { bb.combine(b, it) } })
+inline fun <F, reified G, A, reified B> Foldable<F>.foldMapM(fa: HK<F, A>, noinline f: (A) -> HK<G, B>, MG: Monad<G> = monad(), bb: Monoid<B> = monoid()): HK<G, B> =
+        foldM(fa, bb.empty(), { b, a -> MG.map(f(a)) { bb.combine(b, it) } }, MG)
 
 /**
  * Left associative monadic folding on F.
@@ -134,7 +134,7 @@ inline fun <F, reified G, A, B> Foldable<F>.foldMapM(MG: Monad<G>, bb: Monoid<B>
  * Certain structures are able to implement this in such a way that folds can be short-circuited (not traverse the
  * entirety of the structure), depending on the G result produced at a given step.
  */
-inline fun <F, reified G, A, B> Foldable<F>.foldM(MG: Monad<G> = monad(), fa: HK<F, A>, z: B, crossinline f: (B, A) -> HK<G, B>): HK<G, B> =
+inline fun <F, reified G, A, B> Foldable<F>.foldM(fa: HK<F, A>, z: B, crossinline f: (B, A) -> HK<G, B>, MG: Monad<G> = monad()): HK<G, B> =
         foldL(fa, MG.pure(z), { gb, a -> MG.flatMap(gb) { f(it, a) } })
 
 inline fun <reified F> foldable(): Foldable<F> =

--- a/kategory/src/test/kotlin/kategory/laws/FoldableLaws.kt
+++ b/kategory/src/test/kotlin/kategory/laws/FoldableLaws.kt
@@ -74,7 +74,7 @@ object FoldableLaws {
     inline fun <reified F> foldMIdIsFoldL(FF: Foldable<F>, crossinline cf: (Int) -> HK<F, Int>, EQ: Eq<Any?>) =
             forAll(genFunctionAToB<Int, Int>(genIntSmall()), genConstructor(genIntSmall(), cf), { f: (Int) -> Int, fa: HK<F, Int> ->
                 val foldL: Int = FF.foldL(fa, IntMonoid.empty(), { acc, a -> IntMonoid.combine(acc, f(a)) })
-                val foldM: Int = FF.foldM(Id, fa, IntMonoid.empty(), { acc, a -> Id(IntMonoid.combine(acc, f(a))) } ).value()
+                val foldM: Int = FF.foldM(fa, IntMonoid.empty(), { acc, a -> Id(IntMonoid.combine(acc, f(a))) }, Id).value()
                 foldM.equalUnderTheLaw(foldL, EQ)
             })
 }


### PR DESCRIPTION
This PR converts some methods that require typeclass instances into inline extension functions that allow for implicit lookup using our helpers.