### PR TITLE
Remove yields() from cobinding

### DIFF
--- a/kategory/src/main/kotlin/kategory/typeclasses/Comonad.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/Comonad.kt
@@ -58,10 +58,6 @@ open class ComonadContinuation<F, A : Any>(val CM: Comonad<F>) : Serializable, C
         }))
         COROUTINE_SUSPENDED
     }
-
-    infix fun <B> yields(b: B) = yields { b }
-
-    infix fun <B> yields(b: () -> B) = b()
 }
 
 /**

--- a/kategory/src/test/kotlin/kategory/data/CoproductTest.kt
+++ b/kategory/src/test/kotlin/kategory/data/CoproductTest.kt
@@ -32,8 +32,7 @@ class CoproductTest : UnitSpec() {
                     val a = !Coproduct(Either.Right(Coproduct(Either.Right(Id(num.toString())))), Id, Coproduct.comonad<Id.F, Id.F>())
                     val parseA = Integer.parseInt(a)
                     val b = Coproduct<NonEmptyList.F, NonEmptyList.F, Int>(Either.Left(NonEmptyList.of(parseA * 2, parseA * 100))).extract()
-                    val c = extract { Coproduct<Id.F, Id.F, Int>(Either.Left(Id(b * 3))) }
-                    yields(c)
+                    extract { Coproduct<Id.F, Id.F, Int>(Either.Left(Id(b * 3))) }
                 }
                 cobinding == num * 6
             }

--- a/kategory/src/test/kotlin/kategory/data/Function0Test.kt
+++ b/kategory/src/test/kotlin/kategory/data/Function0Test.kt
@@ -27,7 +27,7 @@ class Function0Test : UnitSpec() {
                 val x = Function0 { 1 }.extract()
                 val y = !Function0 { 2 }
                 val z = extract { Function0 { 3 } }
-                yields(x + y + z)
+                x + y + z
             } shouldBe 6
         }
 

--- a/kategory/src/test/kotlin/kategory/data/IdTest.kt
+++ b/kategory/src/test/kotlin/kategory/data/IdTest.kt
@@ -25,7 +25,7 @@ class IdTest : UnitSpec() {
                 val x = Id(1).extract()
                 val y = !Id(2)
                 val z = extract { Id(3) }
-                yields(x + y + z)
+                x + y + z
             } shouldBe 6
         }
 

--- a/kategory/src/test/kotlin/kategory/data/NonEmptyListTest.kt
+++ b/kategory/src/test/kotlin/kategory/data/NonEmptyListTest.kt
@@ -73,7 +73,7 @@ class NonEmptyListTest : UnitSpec() {
                 val x = !NonEmptyList.of(1)
                 val y = NonEmptyList.of(2).extract()
                 val z = extract { NonEmptyList.of(3) }
-                yields(x + y + z)
+                x + y + z
             }
             result shouldBe 6
         }
@@ -83,7 +83,7 @@ class NonEmptyListTest : UnitSpec() {
                 val x = !NonEmptyList.of(1, 2)
                 val y = NonEmptyList.of(3).extract()
                 val z = extract { NonEmptyList.of(4) }
-                yields(x + y + z)
+                x + y + z
             }
             result shouldBe 8
         }
@@ -97,7 +97,7 @@ class NonEmptyListTest : UnitSpec() {
                     val x = !nel
                     val y = nel2.extract()
                     val z = extract { nel3 }
-                    yields(x + y + z)
+                    x + y + z
                 }
                 result == 1 + 3 + a
             }

--- a/kategory/src/test/kotlin/kategory/free/CofreeTest.kt
+++ b/kategory/src/test/kotlin/kategory/free/CofreeTest.kt
@@ -149,7 +149,7 @@ class CofreeTest : UnitSpec() {
                 })
                 val value: Int = !program.run()
                 val tail: Int = !program.runTail()
-                yields(value + tail)
+                value + tail
             }
             program shouldBe 0
             loops.counter shouldBe limit + 1


### PR DESCRIPTION
Cobinding doesn't need a yields(), which was only a passthrough function to mimic Monad#binding API.