### PR TITLE
Simplify Function0 and Function1 

### DIFF
--- a/kategory/src/main/kotlin/kategory/arrow/Function0.kt
+++ b/kategory/src/main/kotlin/kategory/arrow/Function0.kt
@@ -11,10 +11,10 @@ fun <A> HK<Function0.F, A>.invoke(): A =
 
 // We don't want an inherited class to avoid equivalence issues, so a simple HK wrapper will do
 data class Function0<out A>(internal val f: () -> A) : HK<Function0.F, A> {
+    class F private constructor()
+
     operator fun invoke(): A =
             f()
-
-    class F private constructor()
 
     companion object : Bimonad<Function0.F>, GlobalInstance<Bimonad<Function0.F>>() {
 

--- a/kategory/src/main/kotlin/kategory/arrow/Function0.kt
+++ b/kategory/src/main/kotlin/kategory/arrow/Function0.kt
@@ -6,15 +6,20 @@ fun <A> (() -> A).k(): Function0<A> =
 fun <A> HK<Function0.F, A>.ev(): () -> A =
         (this as Function0<A>).f
 
+fun <A> HK<Function0.F, A>.invoke(): A =
+        (this as Function0<A>).f()
+
 // We don't want an inherited class to avoid equivalence issues, so a simple HK wrapper will do
 data class Function0<out A>(internal val f: () -> A) : HK<Function0.F, A> {
+    operator fun invoke(): A =
+            f()
 
     class F private constructor()
 
     companion object : Bimonad<Function0.F>, GlobalInstance<Bimonad<Function0.F>>() {
 
         override fun <A, B> flatMap(fa: HK<Function0.F, A>, f: (A) -> HK<Function0.F, B>): Function0<B> =
-                f(fa.ev().invoke()).ev().k()
+                Function0(f(fa.invoke()).ev())
 
         override fun <A, B> coflatMap(fa: HK<Function0.F, A>, f: (HK<Function0.F, A>) -> B): Function0<B> =
                 { f(fa) }.k()
@@ -23,15 +28,15 @@ data class Function0<out A>(internal val f: () -> A) : HK<Function0.F, A> {
                 { a }.k()
 
         override fun <A> extract(fa: HK<Function0.F, A>): A =
-                fa.ev().invoke()
+                fa.invoke()
 
         override fun <A, B> map(fa: HK<F, A>, f: (A) -> B): Function0<B> =
-                pure(f(fa.ev().invoke()))
+                pure(f(fa.invoke()))
 
         override fun <A, B> tailRecM(a: A, f: (A) -> HK<F, Either<A, B>>): Function0<B> =
                 Function0 {
                     tailrec fun loop(thisA: A): B =
-                            f(thisA).ev().invoke().fold({ loop(it) }, { it })
+                            f(thisA).invoke().fold({ loop(it) }, { it })
 
                     loop(a)
                 }

--- a/kategory/src/main/kotlin/kategory/arrow/Function1.kt
+++ b/kategory/src/main/kotlin/kategory/arrow/Function1.kt
@@ -14,10 +14,10 @@ fun <P, R> Function1F<R>.invoke(p: P): R =
 
 // We don't want an inherited class to avoid equivalence issues, so a simple HK wrapper will do
 data class Function1<in A, out R>(val f: (A) -> R) : Function1F<R> {
+    class F private constructor()
+
     operator fun invoke(a: A): R =
             f(a)
-
-    class F private constructor()
 
     companion object {
         fun <P> functor() = object : Function1Instances<P> {}

--- a/kategory/src/main/kotlin/kategory/arrow/Function1.kt
+++ b/kategory/src/main/kotlin/kategory/arrow/Function1.kt
@@ -6,8 +6,11 @@ fun <P, R> ((P) -> R).k(): Function1<P, R> =
         Function1(this)
 
 @Suppress("UNCHECKED_CAST")
-fun <P, R> Function1F<R>.ev(): Function1<P, R> =
-        this as Function1<P, R>
+fun <P, R> Function1F<R>.ev(): (P) -> R =
+        (this as Function1<P, R>).f
+
+fun <P, R> Function1F<R>.invoke(p: P): R =
+        this.ev<P, R>().invoke(p)
 
 // We don't want an inherited class to avoid equivalence issues, so a simple HK wrapper will do
 data class Function1<in A, out R>(val f: (A) -> R) : Function1F<R> {

--- a/kategory/src/main/kotlin/kategory/arrow/Function1.kt
+++ b/kategory/src/main/kotlin/kategory/arrow/Function1.kt
@@ -6,15 +6,11 @@ fun <P, R> ((P) -> R).k(): Function1<P, R> =
         Function1(this)
 
 @Suppress("UNCHECKED_CAST")
-fun <R> Function1F<R>.ev(): FunctionInject<R> =
-        this as FunctionInject<R>
+fun <P, R> Function1F<R>.ev(): Function1<P, R> =
+        this as Function1<P, R>
 
 // We don't want an inherited class to avoid equivalence issues, so a simple HK wrapper will do
-data class Function1<in A, out R>(val f: (A) -> R) : FunctionInject<R>, Function1F<R> {
-    override fun <P> invokeInject(p: P): R =
-            f(p as A)
-
-    @Suppress("UNCHECKED_CAST")
+data class Function1<in A, out R>(val f: (A) -> R) : Function1F<R> {
     operator fun invoke(a: A): R =
             f(a)
 

--- a/kategory/src/main/kotlin/kategory/arrow/FunctionBijections.kt
+++ b/kategory/src/main/kotlin/kategory/arrow/FunctionBijections.kt
@@ -1,9 +1,0 @@
-package kategory
-
-interface FunctionInject<out R> {
-    fun <P> invokeInject(p: P): R
-}
-
-interface FunctionSurject<in P> {
-    fun <R> invokeSurject(p: P): R
-}

--- a/kategory/src/main/kotlin/kategory/instances/Function1Instances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/Function1Instances.kt
@@ -6,25 +6,25 @@ interface Function1Instances<P> :
         Monad<Function1.F>,
         MonadReader<Function1.F, P> {
 
-    override fun ask(): HK<Function1.F, P> =
+    override fun ask(): Function1<P, P> =
             { a: P -> a }.k()
 
     override fun <A> local(f: (P) -> P, fa: HK<Function1.F, A>): Function1<P, A> =
-            f.andThen { fa.ev().invokeInject(it) }.k()
+            f.andThen { fa.ev<P, A>().invoke(it) }.k()
 
     override fun <A> pure(a: A): Function1<P, A> =
             { _: P -> a }.k()
 
-    override fun <A, B> map(fa: HK<Function1.F, A>, f: (A) -> B): HK<Function1.F, B> =
-            f.compose { b: B -> fa.ev().invokeInject(b) }.k()
+    override fun <A, B> map(fa: HK<Function1.F, A>, f: (A) -> B): Function1<P, B> =
+            f.compose { a: P -> fa.ev<P, A>().invoke(a) }.k()
 
     override fun <A, B> flatMap(fa: HK<Function1.F, A>, f: (A) -> HK<Function1.F, B>): Function1<P, B> =
-            Function1 { p -> f(fa.ev().invokeInject(p)).ev().invokeInject(p) }
+            Function1 { p -> f(fa.ev<P, A>().invoke(p)).ev<P, B>().invoke(p) }
 
     override fun <A, B> tailRecM(a: A, f: (A) -> HK<Function1.F, Either<A, B>>): Function1<P, B> =
             Function1 { p ->
                 tailrec fun loop(thisA: A): B =
-                        f(thisA).ev().invokeInject(p).fold({ loop(it) }, { it })
+                        f(thisA).ev<P, Either<A, B>>().invoke(p).fold({ loop(it) }, { it })
 
                 loop(a)
             }

--- a/kategory/src/main/kotlin/kategory/instances/Function1Instances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/Function1Instances.kt
@@ -10,21 +10,21 @@ interface Function1Instances<P> :
             { a: P -> a }.k()
 
     override fun <A> local(f: (P) -> P, fa: HK<Function1.F, A>): Function1<P, A> =
-            f.andThen { fa.ev<P, A>().invoke(it) }.k()
+            f.andThen { fa.invoke(it) }.k()
 
     override fun <A> pure(a: A): Function1<P, A> =
             { _: P -> a }.k()
 
     override fun <A, B> map(fa: HK<Function1.F, A>, f: (A) -> B): Function1<P, B> =
-            f.compose { a: P -> fa.ev<P, A>().invoke(a) }.k()
+            f.compose { a: P -> fa.invoke(a) }.k()
 
     override fun <A, B> flatMap(fa: HK<Function1.F, A>, f: (A) -> HK<Function1.F, B>): Function1<P, B> =
-            Function1 { p -> f(fa.ev<P, A>().invoke(p)).ev<P, B>().invoke(p) }
+            Function1 { p -> f(fa.invoke(p)).invoke(p) }
 
     override fun <A, B> tailRecM(a: A, f: (A) -> HK<Function1.F, Either<A, B>>): Function1<P, B> =
             Function1 { p ->
                 tailrec fun loop(thisA: A): B =
-                        f(thisA).ev<P, Either<A, B>>().invoke(p).fold({ loop(it) }, { it })
+                        f(thisA).invoke(p).fold({ loop(it) }, { it })
 
                 loop(a)
             }

--- a/kategory/src/test/kotlin/kategory/data/Function1Test.kt
+++ b/kategory/src/test/kotlin/kategory/data/Function1Test.kt
@@ -9,7 +9,7 @@ class Function1Test : UnitSpec() {
     init {
         testLaws(MonadLaws.laws(Function1.monad<Int>(), object : Eq<HK<Function1.F, Int>> {
             override fun eqv(a: HK<Function1.F, Int>, b: HK<Function1.F, Int>): Boolean =
-                    a.ev<Int, Int>().invoke(1) == b.ev<Int, Int>().invoke(1)
+                    a.invoke(1) == b.invoke(1)
         }))
 
         "bla" {
@@ -23,7 +23,7 @@ class Function1Test : UnitSpec() {
                 val y = !Function1 { _: Int -> 2 }
                 val z = bind { Function1 { _: Int -> 3 } }
                 yields(x + y + z)
-            }.ev<Int, Int>().invoke(0) shouldBe 6
+            }.invoke(0) shouldBe 6
         }
     }
 }

--- a/kategory/src/test/kotlin/kategory/data/Function1Test.kt
+++ b/kategory/src/test/kotlin/kategory/data/Function1Test.kt
@@ -9,7 +9,7 @@ class Function1Test : UnitSpec() {
     init {
         testLaws(MonadLaws.laws(Function1.monad<Int>(), object : Eq<HK<Function1.F, Int>> {
             override fun eqv(a: HK<Function1.F, Int>, b: HK<Function1.F, Int>): Boolean =
-                    a.ev().invokeInject(1) == b.ev().invokeInject(1)
+                    a.ev<Int, Int>().invoke(1) == b.ev<Int, Int>().invoke(1)
         }))
 
         "bla" {
@@ -23,7 +23,7 @@ class Function1Test : UnitSpec() {
                 val y = !Function1 { _: Int -> 2 }
                 val z = bind { Function1 { _: Int -> 3 } }
                 yields(x + y + z)
-            }.ev().invokeInject(0) shouldBe 6
+            }.ev<Int, Int>().invoke(0) shouldBe 6
         }
     }
 }

--- a/kategory/src/test/kotlin/kategory/data/Function1Test.kt
+++ b/kategory/src/test/kotlin/kategory/data/Function1Test.kt
@@ -12,10 +12,6 @@ class Function1Test : UnitSpec() {
                     a.invoke(1) == b.invoke(1)
         }))
 
-        "bla" {
-           { a: Int -> a + 1 }.k().invoke(1)
-        }
-
         "Function1Monad.binding should for comprehend over all values of multiple Function0" {
             val M = Function1.monad<Int>()
             M.binding {


### PR DESCRIPTION
After a chat with @raulraja I realized I had overblown the implementation of Function1. There was a simpler solution all along using extension functions. Who would have thought.

This PR adds a new function invoke() that's an alias for ev().invoke(). This fixes an existing problem with the inference for ev() because one of the parameters couldn't be decided by the compiler and had to be injected manually.