### PR TITLE
Replace invoke() extfun with operator invoke() extfun

### DIFF
--- a/kategory/src/main/kotlin/kategory/arrow/Function0.kt
+++ b/kategory/src/main/kotlin/kategory/arrow/Function0.kt
@@ -6,15 +6,12 @@ fun <A> (() -> A).k(): Function0<A> =
 fun <A> HK<Function0.F, A>.ev(): () -> A =
         (this as Function0<A>).f
 
-fun <A> HK<Function0.F, A>.invoke(): A =
+operator fun <A> HK<Function0.F, A>.invoke(): A =
         (this as Function0<A>).f()
 
 // We don't want an inherited class to avoid equivalence issues, so a simple HK wrapper will do
 data class Function0<out A>(internal val f: () -> A) : HK<Function0.F, A> {
     class F private constructor()
-
-    operator fun invoke(): A =
-            f()
 
     companion object : Bimonad<Function0.F>, GlobalInstance<Bimonad<Function0.F>>() {
 
@@ -28,10 +25,10 @@ data class Function0<out A>(internal val f: () -> A) : HK<Function0.F, A> {
                 { a }.k()
 
         override fun <A> extract(fa: HK<Function0.F, A>): A =
-                fa.invoke()
+                fa()
 
         override fun <A, B> map(fa: HK<F, A>, f: (A) -> B): Function0<B> =
-                pure(f(fa.invoke()))
+                pure(f(fa()))
 
         override fun <A, B> tailRecM(a: A, f: (A) -> HK<F, Either<A, B>>): Function0<B> =
                 Function0 {

--- a/kategory/src/main/kotlin/kategory/arrow/Function0.kt
+++ b/kategory/src/main/kotlin/kategory/arrow/Function0.kt
@@ -16,7 +16,7 @@ data class Function0<out A>(internal val f: () -> A) : HK<Function0.F, A> {
     companion object : Bimonad<Function0.F>, GlobalInstance<Bimonad<Function0.F>>() {
 
         override fun <A, B> flatMap(fa: HK<Function0.F, A>, f: (A) -> HK<Function0.F, B>): Function0<B> =
-                Function0(f(fa.invoke()).ev())
+                Function0(f(fa()).ev())
 
         override fun <A, B> coflatMap(fa: HK<Function0.F, A>, f: (HK<Function0.F, A>) -> B): Function0<B> =
                 { f(fa) }.k()

--- a/kategory/src/main/kotlin/kategory/arrow/Function1.kt
+++ b/kategory/src/main/kotlin/kategory/arrow/Function1.kt
@@ -9,15 +9,12 @@ fun <P, R> ((P) -> R).k(): Function1<P, R> =
 fun <P, R> Function1F<R>.ev(): (P) -> R =
         (this as Function1<P, R>).f
 
-fun <P, R> Function1F<R>.invoke(p: P): R =
+operator fun <P, R> Function1F<R>.invoke(p: P): R =
         this.ev<P, R>().invoke(p)
 
 // We don't want an inherited class to avoid equivalence issues, so a simple HK wrapper will do
 data class Function1<in A, out R>(val f: (A) -> R) : Function1F<R> {
     class F private constructor()
-
-    operator fun invoke(a: A): R =
-            f(a)
 
     companion object {
         fun <P> functor() = object : Function1Instances<P> {}

--- a/kategory/src/main/kotlin/kategory/instances/Function1Instances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/Function1Instances.kt
@@ -10,16 +10,16 @@ interface Function1Instances<P> :
             { a: P -> a }.k()
 
     override fun <A> local(f: (P) -> P, fa: HK<Function1.F, A>): Function1<P, A> =
-            f.andThen { fa.invoke(it) }.k()
+            f.andThen { fa(it) }.k()
 
     override fun <A> pure(a: A): Function1<P, A> =
             { _: P -> a }.k()
 
     override fun <A, B> map(fa: HK<Function1.F, A>, f: (A) -> B): Function1<P, B> =
-            f.compose { a: P -> fa.invoke(a) }.k()
+            f.compose { a: P -> fa(a) }.k()
 
     override fun <A, B> flatMap(fa: HK<Function1.F, A>, f: (A) -> HK<Function1.F, B>): Function1<P, B> =
-            Function1 { p -> f(fa.invoke(p)).invoke(p) }
+            Function1 { p -> f(fa(p)).invoke(p) }
 
     override fun <A, B> tailRecM(a: A, f: (A) -> HK<Function1.F, Either<A, B>>): Function1<P, B> =
             Function1 { p ->

--- a/kategory/src/test/kotlin/kategory/data/Function0Test.kt
+++ b/kategory/src/test/kotlin/kategory/data/Function0Test.kt
@@ -10,7 +10,7 @@ class Function0Test : UnitSpec() {
 
         testLaws(MonadLaws.laws(Function0, object : Eq<HK<Function0.F, Int>> {
             override fun eqv(a: HK<Function0.F, Int>, b: HK<Function0.F, Int>): Boolean =
-                    a.ev()() == b.ev()()
+                    a() == b()
         }))
 
         "Function0Monad.binding should for comprehend over all values of multiple Function0" {
@@ -32,8 +32,8 @@ class Function0Test : UnitSpec() {
         }
 
         "Function0Comonad.duplicate should create an instance of Function0<Function0<A>>" {
-            Function0.duplicate(Function0 { 3 }).ev().invoke().ev().invoke() shouldBe
-                    Function0 { Function0 { 3 } }.ev().invoke().ev().invoke()
+            Function0.duplicate(Function0 { 3 }).invoke().invoke() shouldBe
+                    Function0 { Function0 { 3 } }.invoke().invoke()
         }
     }
 }

--- a/kategory/src/test/kotlin/kategory/data/Function1Test.kt
+++ b/kategory/src/test/kotlin/kategory/data/Function1Test.kt
@@ -9,7 +9,7 @@ class Function1Test : UnitSpec() {
     init {
         testLaws(MonadLaws.laws(Function1.monad<Int>(), object : Eq<HK<Function1.F, Int>> {
             override fun eqv(a: HK<Function1.F, Int>, b: HK<Function1.F, Int>): Boolean =
-                    a.invoke(1) == b.invoke(1)
+                    a(1) == b(1)
         }))
 
         "Function1Monad.binding should for comprehend over all values of multiple Function0" {


### PR DESCRIPTION
Simple change to add invoke as operator rather than a function, and replacing all instances where it made sense.