### PR TITLE
PartialFunction + match(case ..) statements

### DIFF
--- a/kategory/src/main/kotlin/kategory/arrow/PartialFunction.kt
+++ b/kategory/src/main/kotlin/kategory/arrow/PartialFunction.kt
@@ -47,7 +47,7 @@ fun <B> default(f: (Any) -> B): (Any) -> B = f
 class match<A>(val a: A) {
     operator fun <B> invoke(vararg cases: PartialFunction<*, B>, default: (A) -> B): B {
         val maybeB = collectLoop(a, cases.toList() as List<PartialFunction<A, B>>, Option.None)
-        return maybeB.fold({default(a)}, {it})
+        return maybeB.fold({ default(a) }, { it })
     }
 }
 

--- a/kategory/src/main/kotlin/kategory/arrow/PartialFunction.kt
+++ b/kategory/src/main/kotlin/kategory/arrow/PartialFunction.kt
@@ -4,39 +4,34 @@ abstract class PartialFunction<in A, out B> : (A) -> B {
     abstract fun isDefinedAt(a: A): Boolean
 }
 
-fun <A, B> PartialFunction<A, B>.orElse(f: PartialFunction<A, B>): PartialFunction<A, B> {
-    val fthis = this
-    return object : PartialFunction<A, B>() {
+fun <A, B> PartialFunction<A, B>.orElse(f: PartialFunction<A, B>): PartialFunction<A, B> =
+        object : PartialFunction<A, B>() {
+            override fun isDefinedAt(a: A): Boolean =
+                    this@orElse.isDefinedAt(a) || f.isDefinedAt(a)
 
-        override fun isDefinedAt(a: A): Boolean =
-                fthis.isDefinedAt(a) || f.isDefinedAt(a)
+            override fun invoke(x: A): B =
+                    if (this@orElse.isDefinedAt(x)) {
+                        this@orElse(x)
+                    } else {
+                        f(x)
+                    }
 
-        override fun invoke(x: A): B =
-                if (fthis.isDefinedAt(x)) {
-                    fthis(x)
-                } else {
-                    f(x)
-                }
+        }
 
-    }
-}
+fun <A, B, C> PartialFunction<A, B>.andThen(f: (B) -> C): PartialFunction<A, C> =
+        object : PartialFunction<A, C>() {
+            override fun isDefinedAt(a: A): Boolean = this@andThen.isDefinedAt(a)
+            override fun invoke(a: A): C = f(this@andThen(a))
+        }
 
-fun <A, B, C> PartialFunction<A, B>.andThen(f: (B) -> C): PartialFunction<A, C> {
-    val fthis = this
-    return object : PartialFunction<A, C>() {
-        override fun isDefinedAt(a: A): Boolean = fthis.isDefinedAt(a)
-        override fun invoke(a: A): C = f(fthis(a))
-    }
-}
-
-fun <A : Any?, B> case(ff: Tuple2<(A) -> Boolean, (A) -> B>): PartialFunction<A, B> =
+fun <A, B> case(ff: Tuple2<(A) -> Boolean, (A) -> B>): PartialFunction<A, B> =
         object : PartialFunction<A, B>() {
             override fun isDefinedAt(a: A): Boolean = ff.a(a)
             override fun invoke(a: A): B = ff.b(a)
         }
 
-inline fun <reified A> typeOf() : (A) -> Boolean = {
-    Try({ it as A }).fold({ false }, { true })
+inline fun <reified A> typeOf(): (A) -> Boolean = {
+    Try({ it }).fold({ false }, { true })
 }
 
 infix fun <A, B> ((A) -> Boolean).then(f: (A) -> B): Tuple2<(A) -> Boolean, (A) -> B> = Tuple2(this, f)
@@ -44,7 +39,7 @@ infix fun <A, B> ((A) -> Boolean).then(f: (A) -> B): Tuple2<(A) -> Boolean, (A) 
 fun <B> default(f: (Any) -> B): (Any) -> B = f
 
 @Suppress("UNCHECKED_CAST")
-class match<A>(val a: A) {
+class match<out A>(val a: A) {
     operator fun <B> invoke(vararg cases: PartialFunction<*, B>, default: (A) -> B): B {
         val maybeB = collectLoop(a, cases.toList() as List<PartialFunction<A, B>>, Option.None)
         return maybeB.fold({ default(a) }, { it })

--- a/kategory/src/main/kotlin/kategory/arrow/PartialFunction.kt
+++ b/kategory/src/main/kotlin/kategory/arrow/PartialFunction.kt
@@ -44,9 +44,10 @@ infix fun <A, B> ((A) -> Boolean).then(f: (A) -> B): Tuple2<(A) -> Boolean, (A) 
 
 fun <A, B> default(f: (A) -> B): (A) -> B = f
 
+@Suppress("UNCHECKED_CAST")
 class match<A>(val a: A) {
-    operator fun <B> invoke(vararg cases: PartialFunction<A, B>, default: (A) -> B): B {
-        val f = cases.reduce { a, b -> a.orElse(b) }
+    operator fun <B> invoke(vararg cases: PartialFunction<*, B>, default: (A) -> B): B {
+        val f = cases.reduce { a, b -> a.orElse(b) } as PartialFunction<A, B>
         return if (f.isDefinedAt(a)) f(a) else default(a)
     }
 }

--- a/kategory/src/main/kotlin/kategory/arrow/PartialFunction.kt
+++ b/kategory/src/main/kotlin/kategory/arrow/PartialFunction.kt
@@ -1,0 +1,53 @@
+package kategory
+
+abstract class PartialFunction<in A, out B> : (A) -> B {
+    abstract fun isDefinedAt(a: A): Boolean
+}
+
+fun <A, B> PartialFunction<A, B>.orElse(f: PartialFunction<A, B>): PartialFunction<A, B> {
+    val fthis = this
+    return object : PartialFunction<A, B>() {
+
+        override fun isDefinedAt(a: A): Boolean =
+                fthis.isDefinedAt(a) || f.isDefinedAt(a)
+
+        override fun invoke(x: A): B =
+                if (fthis.isDefinedAt(x)) {
+                    fthis(x)
+                } else {
+                    f(x)
+                }
+
+    }
+}
+
+fun <A, B, C> PartialFunction<A, B>.andThen(f: (B) -> C): PartialFunction<A, C> {
+    val fthis = this
+    return object : PartialFunction<A, C>() {
+
+        override fun isDefinedAt(a: A): Boolean = fthis.isDefinedAt(a)
+
+        override fun invoke(a: A): C = f(fthis(a))
+
+    }
+}
+
+fun <A: Any?, B> case(ff: Tuple2<(A) -> Boolean, (A) -> B>): PartialFunction<A, B> =
+        object : PartialFunction<A, B>() {
+            override fun isDefinedAt(a: A): Boolean = ff.a(a)
+            override fun invoke(a: A): B = ff.b(a)
+        }
+
+inline fun <reified A> typeOf(): (A) -> Boolean = { it is A }
+
+infix fun <A, B> ((A) -> Boolean).then(f: (A) -> B): Tuple2<(A) -> Boolean, (A) -> B> = Tuple2(this, f)
+
+fun <A, B> default(f: (A) -> B): (A) -> B = f
+
+class match<A>(val a: A) {
+    operator fun <B> invoke(vararg cases: PartialFunction<A, B>, default: (A) -> B): B {
+        val f = cases.reduce { a, b -> a.orElse(b) }
+        return if (f.isDefinedAt(a)) f(a) else default(a)
+    }
+}
+

--- a/kategory/src/main/kotlin/kategory/arrow/PartialFunction.kt
+++ b/kategory/src/main/kotlin/kategory/arrow/PartialFunction.kt
@@ -24,15 +24,12 @@ fun <A, B> PartialFunction<A, B>.orElse(f: PartialFunction<A, B>): PartialFuncti
 fun <A, B, C> PartialFunction<A, B>.andThen(f: (B) -> C): PartialFunction<A, C> {
     val fthis = this
     return object : PartialFunction<A, C>() {
-
         override fun isDefinedAt(a: A): Boolean = fthis.isDefinedAt(a)
-
         override fun invoke(a: A): C = f(fthis(a))
-
     }
 }
 
-fun <A: Any?, B> case(ff: Tuple2<(A) -> Boolean, (A) -> B>): PartialFunction<A, B> =
+fun <A : Any?, B> case(ff: Tuple2<(A) -> Boolean, (A) -> B>): PartialFunction<A, B> =
         object : PartialFunction<A, B>() {
             override fun isDefinedAt(a: A): Boolean = ff.a(a)
             override fun invoke(a: A): B = ff.b(a)

--- a/kategory/src/main/kotlin/kategory/instances/IterableInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/IterableInstances.kt
@@ -7,7 +7,7 @@ tailrec fun <A, B> collectLoop(a: A, l : List<PartialFunction<A, B>>, acc: Optio
             val head = l[0]
             val tail = l.drop(1)
             val result =
-                    if (Try({head.isDefinedAt(a)}).fold({false}, {true})) {
+                    if (Try({ head.isDefinedAt(a) }).fold({ false }, { true })) {
                         Try({ head(a) }).fold({ e -> Option.None }, { b -> Option.Some(b) })
                     } else { Option.None }
             collectLoop(a, tail, result)
@@ -18,6 +18,6 @@ tailrec fun <A, B> collectLoop(a: A, l : List<PartialFunction<A, B>>, acc: Optio
 fun <A: Any, B> Iterable<A>.collect(vararg cases: PartialFunction<*, B>): List<B> {
     return flatMap { a ->
         val c = cases.toList() as List<PartialFunction<A, B>>
-        collectLoop(a, c, Option.None).fold({ emptyList<B>() }, { listOf(it)})
+        collectLoop(a, c, Option.None).fold({ emptyList<B>() }, { listOf(it) })
     }
 }

--- a/kategory/src/main/kotlin/kategory/instances/IterableInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/IterableInstances.kt
@@ -1,0 +1,8 @@
+package kategory
+
+@Suppress("UNCHECKED_CAST")
+fun <A: Any, B> Iterable<A>.collect(vararg cases: PartialFunction<*, B>): List<B> {
+    val f: PartialFunction<A, B> = cases.reduce { a, b -> a.orElse(b) } as PartialFunction<A, B>
+    return filter(f::isDefinedAt).map(f)
+}
+

--- a/kategory/src/main/kotlin/kategory/instances/IterableInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/IterableInstances.kt
@@ -1,8 +1,23 @@
 package kategory
 
+tailrec fun <A, B> collectLoop(a: A, l : List<PartialFunction<A, B>>, acc: Option<B>): Option<B> =
+    when {
+        l.isEmpty() || acc.isDefined -> acc
+        else -> {
+            val head = l[0]
+            val tail = l.drop(1)
+            val result =
+                    if (Try({head.isDefinedAt(a)}).fold({false}, {true})) {
+                        Try({ head(a) }).fold({ e -> Option.None }, { b -> Option.Some(b) })
+                    } else { Option.None }
+            collectLoop(a, tail, result)
+        }
+    }
+
 @Suppress("UNCHECKED_CAST")
 fun <A: Any, B> Iterable<A>.collect(vararg cases: PartialFunction<*, B>): List<B> {
-    val f: PartialFunction<A, B> = cases.reduce { a, b -> a.orElse(b) } as PartialFunction<A, B>
-    return filter(f::isDefinedAt).map(f)
+    return flatMap { a ->
+        val c = cases.toList() as List<PartialFunction<A, B>>
+        collectLoop(a, c, Option.None).fold({ emptyList<B>() }, { listOf(it)})
+    }
 }
-

--- a/kategory/src/test/kotlin/kategory/data/IterableTests.kt
+++ b/kategory/src/test/kotlin/kategory/data/IterableTests.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Kategory Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package kategory
 
 import io.kotlintest.KTestJUnitRunner

--- a/kategory/src/test/kotlin/kategory/data/IterableTests.kt
+++ b/kategory/src/test/kotlin/kategory/data/IterableTests.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2017 The Kategory Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kategory
+
+import io.kotlintest.KTestJUnitRunner
+import io.kotlintest.matchers.shouldBe
+import org.junit.runner.RunWith
+
+@RunWith(KTestJUnitRunner::class)
+class IterableTests : UnitSpec() {
+
+    init {
+
+        "Iterable.collect can filter and transform" {
+            listOf(1, 2, 3, 4, 5).collect(
+                    case({ n: Int -> n > 0 } then { (it * 2).toString() })
+            ) shouldBe listOf("2", "4", "6", "8", "10")
+        }
+
+        "Iterable.collect can match and coalesce on multiple cases" {
+            val l: List<Int> = listOf("1", Option.Some(1), 1).collect(
+                    case(typeOf<String>() then { (it).toInt() }),
+                    case(typeOf<Option.Some<Int>>() then { it.value }),
+                    case(typeOf<Int>() then { it })
+            )
+            l shouldBe listOf(1, 1, 1)
+        }
+
+        "Iterable.collect returns emptyList when no matches are found" {
+            listOf(1).collect(
+                    case(typeOf<String>() then { (it).toInt() })
+            ) shouldBe emptyList<Int>()
+        }
+
+        "Iterable.collect picks a matching partial function from the ones provided" {
+            listOf(1).collect(
+                    case(typeOf<String>() then { (it).toInt() }),
+                    case(typeOf<Int>() then { it })
+            ) shouldBe listOf(1)
+        }
+
+    }
+}

--- a/kategory/src/test/kotlin/kategory/data/PartialFunctionTests.kt
+++ b/kategory/src/test/kotlin/kategory/data/PartialFunctionTests.kt
@@ -35,11 +35,12 @@ class PartialFunctionTests : UnitSpec() {
             val result: Any? = match("1".some())(
                     case(typeOf<String>() then { (it).toInt() }),
                     case(typeOf<Option.Some<Int>>() then { it.value + 1 }),
+                    case(typeOf<Option.Some<String>>() then { it.value.toInt() * 10 }),
                     case(typeOf<Option.Some<Double>>() then { it.value.toInt() }),
                     case(typeOf<Int>() then { it }),
                     default = { 0 }
             )
-            result shouldBe 1
+            result shouldBe 10
         }
 
     }

--- a/kategory/src/test/kotlin/kategory/data/PartialFunctionTests.kt
+++ b/kategory/src/test/kotlin/kategory/data/PartialFunctionTests.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2017 The Kategory Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kategory
+
+import io.kotlintest.KTestJUnitRunner
+import io.kotlintest.matchers.shouldBe
+import org.junit.runner.RunWith
+
+@RunWith(KTestJUnitRunner::class)
+class PartialFunctionTests : UnitSpec() {
+
+    init {
+
+        "case syntax can be used to create partial functions" {
+            val predicate = {n : Int -> n > 0 }
+            val fa = case({n : Int -> n > 0 } then { it * 2 })
+            val fb = object: PartialFunction<Int, Int>() {
+                override fun isDefinedAt(a: Int): Boolean = predicate(a)
+                override fun invoke(p1: Int): Int = p1 * 2
+            }
+            fa(1) shouldBe fb(1)
+            fa.isDefinedAt(-1) shouldBe false
+        }
+
+    }
+}

--- a/kategory/src/test/kotlin/kategory/data/PartialFunctionTests.kt
+++ b/kategory/src/test/kotlin/kategory/data/PartialFunctionTests.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Kategory Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package kategory
 
 import io.kotlintest.KTestJUnitRunner

--- a/kategory/src/test/kotlin/kategory/data/PartialFunctionTests.kt
+++ b/kategory/src/test/kotlin/kategory/data/PartialFunctionTests.kt
@@ -36,5 +36,15 @@ class PartialFunctionTests : UnitSpec() {
             fa.isDefinedAt(-1) shouldBe false
         }
 
+        "match statements " {
+            val result: Int = match("1")(
+                case(typeOf<String>() then { (it).toInt() }),
+                case(typeOf<Option.Some<Int>>() then { it.value }),
+                case(typeOf<Int>() then { it }),
+                default = { it.toInt() }
+            )
+            result shouldBe 1
+        }
+
     }
 }

--- a/kategory/src/test/kotlin/kategory/data/PartialFunctionTests.kt
+++ b/kategory/src/test/kotlin/kategory/data/PartialFunctionTests.kt
@@ -21,11 +21,12 @@ class PartialFunctionTests : UnitSpec() {
         }
 
         "match statements " {
-            val result: Int = match("1")(
+            val value: Any = "1"
+            val result: Int = match(value)(
                 case(typeOf<String>() then { (it).toInt() }),
                 case(typeOf<Option.Some<Int>>() then { it.value }),
                 case(typeOf<Int>() then { it }),
-                default = { it.toInt() }
+                default = { 0 }
             )
             result shouldBe 1
         }
@@ -34,8 +35,9 @@ class PartialFunctionTests : UnitSpec() {
             val result: Any? = match("1".some())(
                     case(typeOf<String>() then { (it).toInt() }),
                     case(typeOf<Option.Some<Int>>() then { it.value + 1 }),
+                    case(typeOf<Option.Some<Double>>() then { it.value.toInt() }),
                     case(typeOf<Int>() then { it }),
-                    default = { it.fold({ "" },{ it }).toInt() }
+                    default = { 0 }
             )
             result shouldBe 1
         }

--- a/kategory/src/test/kotlin/kategory/data/PartialFunctionTests.kt
+++ b/kategory/src/test/kotlin/kategory/data/PartialFunctionTests.kt
@@ -30,5 +30,15 @@ class PartialFunctionTests : UnitSpec() {
             result shouldBe 1
         }
 
+        "match nested statements" {
+            val result: Any? = match("1".some())(
+                    case(typeOf<String>() then { (it).toInt() }),
+                    case(typeOf<Option.Some<Int>>() then { it.value + 1 }),
+                    case(typeOf<Int>() then { it }),
+                    default = { it.fold({ "" },{ it }).toInt() }
+            )
+            result shouldBe 1
+        }
+
     }
 }

--- a/kategory/src/test/kotlin/kategory/data/PartialFunctionTests.kt
+++ b/kategory/src/test/kotlin/kategory/data/PartialFunctionTests.kt
@@ -32,7 +32,7 @@ class PartialFunctionTests : UnitSpec() {
         }
 
         "match nested statements" {
-            val result: Any? = match("1".some())(
+            val result: Int = match("1".some())(
                     case(typeOf<String>() then { (it).toInt() }),
                     case(typeOf<Option.Some<Int>>() then { it.value + 1 }),
                     case(typeOf<Option.Some<String>>() then { it.value.toInt() * 10 }),

--- a/kategory/src/test/kotlin/kategory/data/PartialFunctionTests.kt
+++ b/kategory/src/test/kotlin/kategory/data/PartialFunctionTests.kt
@@ -10,9 +10,9 @@ class PartialFunctionTests : UnitSpec() {
     init {
 
         "case syntax can be used to create partial functions" {
-            val predicate = {n : Int -> n > 0 }
-            val fa = case({n : Int -> n > 0 } then { it * 2 })
-            val fb = object: PartialFunction<Int, Int>() {
+            val predicate = { n: Int -> n > 0 }
+            val fa = case({ n: Int -> n > 0 } then { it * 2 })
+            val fb = object : PartialFunction<Int, Int>() {
                 override fun isDefinedAt(a: Int): Boolean = predicate(a)
                 override fun invoke(p1: Int): Int = p1 * 2
             }
@@ -23,10 +23,10 @@ class PartialFunctionTests : UnitSpec() {
         "match statements " {
             val value: Any = "1"
             val result: Int = match(value)(
-                case(typeOf<String>() then { (it).toInt() }),
-                case(typeOf<Option.Some<Int>>() then { it.value }),
-                case(typeOf<Int>() then { it }),
-                default = { 0 }
+                    case(typeOf<String>() then { (it).toInt() }),
+                    case(typeOf<Option.Some<Int>>() then { it.value }),
+                    case(typeOf<Int>() then { it }),
+                    default = { 0 }
             )
             result shouldBe 1
         }
@@ -41,6 +41,21 @@ class PartialFunctionTests : UnitSpec() {
                     default = { 0 }
             )
             result shouldBe 10
+        }
+
+        "match nested statements" {
+            val a: Option<Either<Option<String>, Int>> = "1".some().left().some()
+            val result: Int = match(a)(
+                    case(typeOf<String>() then { (it).toInt() }),
+                    case(typeOf<Option.None>() then { 3 }),
+                    case(typeOf<Option.Some<Int>>() then { it.value + 1 }),
+                    case(typeOf<Option<Either<Option<Int>, Int>>>() then { it.fold({ 111.right() }, { it }).fold({ it.fold({ 222 }, { 333 }) }, { it }) }),
+                    case(typeOf<Option<Either<Option<String>, Int>>>() then { it.fold({ 444.right() }, { it }).fold({ it.fold({ 555 }, { 666 }) }, { it }) }),
+                    case(typeOf<Option.Some<Double>>() then { it.value.toInt() }),
+                    case(typeOf<Int>() then { it }),
+                    default = { 0 }
+            )
+            result shouldBe 666
         }
 
     }

--- a/kategory/src/test/kotlin/kategory/data/PartialFunctionTests.kt
+++ b/kategory/src/test/kotlin/kategory/data/PartialFunctionTests.kt
@@ -58,5 +58,30 @@ class PartialFunctionTests : UnitSpec() {
             result shouldBe 666
         }
 
+        "match with Nothing" {
+            val result: Int = match("1".some())(
+                    case(typeOf<String>() then { (it).toInt() }),
+                    case(typeOf<Option.Some<Nothing?>>() then { 666 }),
+                    case(typeOf<Option.Some<String>>() then { it.value.toInt() * 10 }),
+                    case(typeOf<Option.Some<Double>>() then { it.value.toInt() }),
+                    case(typeOf<Int>() then { it }),
+                    default = { 0 }
+            )
+            result shouldBe 666
+        }
+
+
+        "match with Any?" {
+            val result: Int = match("1".some())(
+                    case(typeOf<String>() then { (it).toInt() }),
+                    case(typeOf<Option.Some<Any?>>() then { 666 }),
+                    case(typeOf<Option.Some<String>>() then { it.value.toInt() * 10 }),
+                    case(typeOf<Option.Some<Double>>() then { it.value.toInt() }),
+                    case(typeOf<Int>() then { it }),
+                    default = { 0 }
+            )
+            result shouldBe 666
+        }
+
     }
 }

--- a/kategory/src/test/kotlin/kategory/data/StateTTests.kt
+++ b/kategory/src/test/kotlin/kategory/data/StateTTests.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Kategory Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package kategory
 
 import io.kotlintest.KTestJUnitRunner

--- a/kategory/src/test/kotlin/kategory/data/StateTests.kt
+++ b/kategory/src/test/kotlin/kategory/data/StateTests.kt
@@ -1,19 +1,3 @@
-/*
- * Copyright (C) 2017 The Kategory Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package kategory
 
 import io.kotlintest.KTestJUnitRunner


### PR DESCRIPTION
The following PR brings supports to PartialFunctions for Kotlin through Kategory.
It includes syntax for `match` and `case` and extensions for `Iterable.collect` so they work like in Scala.

```kotlin
listOf("1", Option.Some(1), 1).collect(
  case(typeOf<String>() then { (it).toInt() }),
  case(typeOf<Option.Some<Int>>() then { it.value }),
  case(typeOf<Int>() then { it })
) shouldBe listOf(1, 1, 1)
```

```kotlin
listOf(1).collect(
  case(typeOf<String>() then { (it).toInt() })
) shouldBe emptyList<Int>()
```

```kotlin
val result: Int = match("1")(
  case(typeOf<String>() then { (it).toInt() }),
  case(typeOf<Option.Some<Int>>() then { it.value }),
  case(typeOf<Int>() then { it }),
  default = { it.toInt() }
)
result shouldBe 1
```