### PR TITLE
Either generics for Left and Right now include both sides

### DIFF
--- a/kategory/src/main/kotlin/kategory/data/Either.kt
+++ b/kategory/src/main/kotlin/kategory/data/Either.kt
@@ -121,17 +121,29 @@ sealed class Either<out A, out B> : EitherKind<A, B> {
     /**
      * The left side of the disjoint union, as opposed to the [Right] side.
      */
-    data class Left<out A>(val a: A) : Either<A, Nothing>() {
+    data class Left<out A, out B>(val a: A, val dummy: Unit) : Either<A, B>() {
         override val isLeft = true
         override val isRight = false
+
+        companion object {
+            inline operator fun <A> invoke(a: A): Either<A, Nothing> =
+                    Left(a, Unit)
+
+        }
     }
 
     /**
      * The right side of the disjoint union, as opposed to the [Left] side.
      */
-    data class Right<out B>(val b: B) : Either<Nothing, B>() {
+    data class Right<out A, out B>(val b: B, val dummy: Unit) : Either<A, B>() {
         override val isLeft = false
         override val isRight = true
+
+        companion object {
+            inline operator fun <B> invoke(b: B): Either<Nothing, B> =
+                    Right(b, Unit)
+
+        }
     }
 
     companion object {

--- a/kategory/src/main/kotlin/kategory/data/Either.kt
+++ b/kategory/src/main/kotlin/kategory/data/Either.kt
@@ -18,25 +18,15 @@ sealed class Either<out A, out B> : EitherKind<A, B> {
 
     /**
      * Returns `true` if this is a [Right], `false` otherwise.
-     *
-     * Example:
-     * ```
-     * Left("tulip").isRight           // Result: false
-     * Right("venus fly-trap").isRight // Result: true
-     * ```
+     * Used only for performance instead of fold.
      */
-    abstract val isRight: Boolean
+    internal abstract val isRight: Boolean
 
     /**
      * Returns `true` if this is a [Left], `false` otherwise.
-     *
-     * Example:
-     * ```
-     * Left("tulip").isLeft           // Result: true
-     * Right("venus fly-trap").isLeft // Result: false
-     * ```
+     * Used only for performance instead of fold.
      */
-    abstract val isLeft: Boolean
+    internal abstract val isLeft: Boolean
 
     /**
      * Applies `fa` if this is a [Left] or `fb` if this is a [Right].
@@ -121,28 +111,26 @@ sealed class Either<out A, out B> : EitherKind<A, B> {
     /**
      * The left side of the disjoint union, as opposed to the [Right] side.
      */
-    data class Left<out A, out B>(val a: A, val dummy: Unit) : Either<A, B>() {
-        override val isLeft = true
-        override val isRight = false
+    data class Left<out A, out B>(val a: A, private val dummy: Unit) : Either<A, B>() {
+        override internal val isLeft = true
+        override internal val isRight = false
 
         companion object {
             inline operator fun <A> invoke(a: A): Either<A, Nothing> =
                     Left(a, Unit)
-
         }
     }
 
     /**
      * The right side of the disjoint union, as opposed to the [Left] side.
      */
-    data class Right<out A, out B>(val b: B, val dummy: Unit) : Either<A, B>() {
-        override val isLeft = false
-        override val isRight = true
+    data class Right<out A, out B>(val b: B, private val dummy: Unit) : Either<A, B>() {
+        override internal val isLeft = false
+        override internal val isRight = true
 
         companion object {
             inline operator fun <B> invoke(b: B): Either<Nothing, B> =
                     Right(b, Unit)
-
         }
     }
 

--- a/kategory/src/main/kotlin/kategory/data/Option.kt
+++ b/kategory/src/main/kotlin/kategory/data/Option.kt
@@ -40,9 +40,10 @@ sealed class Option<out A> : OptionKind<A> {
     }
 
     /**
-     * Returns true if the option is $none, false otherwise.
+     * Returns true if the option is [None], false otherwise.
+     * Used only for performance instead of fold.
      */
-    abstract val isEmpty: Boolean
+    internal abstract val isEmpty: Boolean
 
     /**
      * Returns true if the option is an instance of $some, false otherwise.
@@ -128,11 +129,11 @@ sealed class Option<out A> : OptionKind<A> {
     inline fun forall(p: (A) -> Boolean): Boolean = exists(p)
 
     data class Some<out A>(val value: A) : Option<A>() {
-        override val isEmpty = false
+        override internal val isEmpty = false
     }
 
     object None : Option<Nothing>() {
-        override val isEmpty = true
+        override internal val isEmpty = true
     }
 
 }

--- a/kategory/src/main/kotlin/kategory/instances/EitherTInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/EitherTInstances.kt
@@ -21,12 +21,14 @@ interface EitherTInstances<F, L> :
             EitherT(MF(), MF().tailRecM(a, {
                 MF().map(f(it).ev().value) { recursionControl ->
                     when (recursionControl) {
-                        is Either.Left<L> -> Either.Right(Either.Left(recursionControl.a))
-                        is Either.Right<Either<A, B>> ->
-                            when (recursionControl.b) {
-                                is Either.Left<A> -> Either.Left(recursionControl.b.a)
-                                is Either.Right<B> -> Either.Right(Either.Right(recursionControl.b.b))
+                        is Either.Left<L, Either<A, B>> -> Either.Right(Either.Left(recursionControl.a))
+                        is Either.Right<L, Either<A, B>> -> {
+                            val b: Either<A, B> = recursionControl.b
+                            when (b) {
+                                is Either.Left<A, B> -> Either.Left(b.a)
+                                is Either.Right<A, B> -> Either.Right(Either.Right(b.b))
                             }
+                        }
                     }
                 }
             }))

--- a/kategory/src/main/kotlin/kategory/instances/IdInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/IdInstances.kt
@@ -18,10 +18,10 @@ interface IdInstances :
             fa.ev().map(f)
 
     tailrec override fun <A, B> tailRecM(a: A, f: (A) -> IdKind<Either<A, B>>): Id<B> {
-        val x = f(a).ev().value
+        val x: Either<A, B> = f(a).ev().value
         return when (x) {
-            is Either.Left<A> -> tailRecM(x.a, f)
-            is Either.Right<B> -> Id(x.b)
+            is Either.Left<A, B> -> tailRecM(x.a, f)
+            is Either.Right<A, B> -> Id(x.b)
         }
     }
 

--- a/kategory/src/main/kotlin/kategory/instances/NonEmptyListInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/NonEmptyListInstances.kt
@@ -20,16 +20,17 @@ interface NonEmptyListInstances :
             buf: ArrayList<B>,
             f: (A) -> HK<NonEmptyList.F, Either<A, B>>,
             v: NonEmptyList<Either<A, B>>) {
-        when (v.head) {
-            is Either.Right<*> -> {
-                buf += v.head.b as B
+        val head: Either<A, B> = v.head
+        when (head) {
+            is Either.Right<A, B> -> {
+                buf += head.b
                 val x = NonEmptyList.fromList(v.tail)
                 when (x) {
                     is Option.Some<NonEmptyList<Either<A, B>>> -> go(buf, f, x.value)
                     is Option.None -> Unit
                 }
             }
-            is Either.Left<*> -> go(buf, f, f(v.head.a as A).ev() + v.tail)
+            is Either.Left<A, B> -> go(buf, f, f(head.a).ev() + v.tail)
         }
     }
 

--- a/kategory/src/main/kotlin/kategory/instances/WriterTInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/WriterTInstances.kt
@@ -22,8 +22,8 @@ interface WriterTInstances<F, W> :
             WriterT(MM(), MM().tailRecM(a, {
                 MM().map(f(it).ev().value) {
                     when (it.b) {
-                        is Either.Left<A> -> Either.Left(it.b.a)
-                        is Either.Right<B> -> Either.Right(it.a toT it.b.b)
+                        is Either.Left<A, B> -> Either.Left(it.b.a)
+                        is Either.Right<A, B> -> Either.Right(it.a toT it.b.b)
                     }
                 }
             }))


### PR DESCRIPTION
By using a smart constructor, the problem where the IDE couldn't keep up with inference of L or R generic due to the use of None should be fixed.