### PR TITLE
Stack-safe CoYoneda

### DIFF
--- a/kategory/src/main/kotlin/kategory/free/CoYoneda.kt
+++ b/kategory/src/main/kotlin/kategory/free/CoYoneda.kt
@@ -7,14 +7,21 @@ typealias CoYonedaF<U, P> = HK2<CoYoneda.F, U, P>
 fun <U, A, B> CoYonedaKind<U, A, B>.ev(): CoYoneda<U, A, B> =
         this as CoYoneda<U, A, B>
 
-data class CoYoneda<FU, P, A>(val function: (P) -> A, val pivot: HK<FU, P>) : CoYonedaKind<FU, P, A> {
+data class CoYoneda<FU, P, A>(val pivot: HK<FU, P>, internal val ks: List<(Any?) -> Any?>) : CoYonedaKind<FU, P, A> {
     class F private constructor()
 
-    fun lower(FF: Functor<FU>): HK<FU, A> =
-            FF.map(pivot, function)
+    private val transform: (P) -> A = {
+        var curr: Any? = it
+        ks.forEach { curr = it(curr) }
+        curr as A
+    }
 
+    fun lower(FF: Functor<FU>): HK<FU, A> =
+            FF.map(pivot, transform)
+
+    @Suppress("UNCHECKED_CAST")
     fun <B> map(f: (A) -> B): CoYoneda<FU, P, B> =
-            CoYoneda({ f(function(it)) }, pivot)
+            CoYoneda(pivot, ks + f as (Any?) -> Any)
 
     fun toYoneda(FF: Functor<FU>): Yoneda<FU, A> =
             object : Yoneda<FU, A> {
@@ -22,8 +29,12 @@ data class CoYoneda<FU, P, A>(val function: (P) -> A, val pivot: HK<FU, P>) : Co
             }
 
     companion object {
+        @Suppress("UNCHECKED_CAST")
         inline fun <reified U, A, B> apply(fa: HK<U, A>, noinline f: (A) -> B): CoYoneda<U, A, B> =
-                CoYoneda(f, fa)
+                usafeApply(fa, listOf(f as (Any?) -> Any))
+
+        inline fun <reified U, A, B> usafeApply(fa: HK<U, A>, f: List<(Any?) -> Any?>): CoYoneda<U, A, B> =
+                CoYoneda(fa, f)
 
         fun <U, P> functor(): Functor<CoYonedaF<U, P>> = object : CoYonedaInstances<U, P> {}
 

--- a/kategory/src/main/kotlin/kategory/free/CoYoneda.kt
+++ b/kategory/src/main/kotlin/kategory/free/CoYoneda.kt
@@ -7,7 +7,9 @@ typealias CoYonedaF<U, P> = HK2<CoYoneda.F, U, P>
 fun <U, A, B> CoYonedaKind<U, A, B>.ev(): CoYoneda<U, A, B> =
         this as CoYoneda<U, A, B>
 
-data class CoYoneda<FU, P, A>(val pivot: HK<FU, P>, internal val ks: List<(Any?) -> Any?>) : CoYonedaKind<FU, P, A> {
+private typealias AnyFunc = (Any?) -> Any?
+
+data class CoYoneda<FU, P, A>(val pivot: HK<FU, P>, internal val ks: List<AnyFunc>) : CoYonedaKind<FU, P, A> {
     class F private constructor()
 
     private val transform: (P) -> A = {
@@ -21,7 +23,7 @@ data class CoYoneda<FU, P, A>(val pivot: HK<FU, P>, internal val ks: List<(Any?)
 
     @Suppress("UNCHECKED_CAST")
     fun <B> map(f: (A) -> B): CoYoneda<FU, P, B> =
-            CoYoneda(pivot, ks + f as (Any?) -> Any)
+            CoYoneda(pivot, ks + f as AnyFunc)
 
     fun toYoneda(FF: Functor<FU>): Yoneda<FU, A> =
             object : Yoneda<FU, A> {
@@ -31,9 +33,9 @@ data class CoYoneda<FU, P, A>(val pivot: HK<FU, P>, internal val ks: List<(Any?)
     companion object {
         @Suppress("UNCHECKED_CAST")
         inline fun <reified U, A, B> apply(fa: HK<U, A>, noinline f: (A) -> B): CoYoneda<U, A, B> =
-                usafeApply(fa, listOf(f as (Any?) -> Any))
+                usafeApply(fa, listOf(f as AnyFunc))
 
-        inline fun <reified U, A, B> usafeApply(fa: HK<U, A>, f: List<(Any?) -> Any?>): CoYoneda<U, A, B> =
+        inline fun <reified U, A, B> usafeApply(fa: HK<U, A>, f: List<AnyFunc>): CoYoneda<U, A, B> =
                 CoYoneda(fa, f)
 
         fun <U, P> functor(): Functor<CoYonedaF<U, P>> = object : CoYonedaInstances<U, P> {}

--- a/kategory/src/main/kotlin/kategory/free/CoYoneda.kt
+++ b/kategory/src/main/kotlin/kategory/free/CoYoneda.kt
@@ -9,7 +9,7 @@ fun <U, A, B> CoYonedaKind<U, A, B>.ev(): CoYoneda<U, A, B> =
 
 private typealias AnyFunc = (Any?) -> Any?
 
-data class CoYoneda<FU, P, A>(val pivot: HK<FU, P>, internal val ks: List<AnyFunc>) : CoYonedaKind<FU, P, A> {
+data class CoYoneda<F, P, A>(val pivot: HK<F, P>, internal val ks: List<AnyFunc>) : CoYonedaKind<F, P, A> {
     class F private constructor()
 
     private val transform: (P) -> A = {
@@ -18,16 +18,16 @@ data class CoYoneda<FU, P, A>(val pivot: HK<FU, P>, internal val ks: List<AnyFun
         curr as A
     }
 
-    fun lower(FF: Functor<FU>): HK<FU, A> =
+    fun lower(FF: Functor<F>): HK<F, A> =
             FF.map(pivot, transform)
 
     @Suppress("UNCHECKED_CAST")
-    fun <B> map(f: (A) -> B): CoYoneda<FU, P, B> =
+    fun <B> map(f: (A) -> B): CoYoneda<F, P, B> =
             CoYoneda(pivot, ks + f as AnyFunc)
 
-    fun toYoneda(FF: Functor<FU>): Yoneda<FU, A> =
-            object : Yoneda<FU, A> {
-                override fun <B> apply(f: (A) -> B): HK<FU, B> = map(f).lower(FF)
+    fun toYoneda(FF: Functor<F>): Yoneda<F, A> =
+            object : Yoneda<F, A> {
+                override fun <B> apply(f: (A) -> B): HK<F, B> = map(f).lower(FF)
             }
 
     companion object {

--- a/kategory/src/main/kotlin/kategory/free/CoYoneda.kt
+++ b/kategory/src/main/kotlin/kategory/free/CoYoneda.kt
@@ -33,9 +33,9 @@ data class CoYoneda<FU, P, A>(val pivot: HK<FU, P>, internal val ks: List<AnyFun
     companion object {
         @Suppress("UNCHECKED_CAST")
         inline fun <reified U, A, B> apply(fa: HK<U, A>, noinline f: (A) -> B): CoYoneda<U, A, B> =
-                usafeApply(fa, listOf(f as AnyFunc))
+                unsafeApply(fa, listOf(f as AnyFunc))
 
-        inline fun <reified U, A, B> usafeApply(fa: HK<U, A>, f: List<AnyFunc>): CoYoneda<U, A, B> =
+        inline fun <reified U, A, B> unsafeApply(fa: HK<U, A>, f: List<AnyFunc>): CoYoneda<U, A, B> =
                 CoYoneda(fa, f)
 
         fun <U, P> functor(): Functor<CoYonedaF<U, P>> = object : CoYonedaInstances<U, P> {}

--- a/kategory/src/main/kotlin/kategory/free/Yoneda.kt
+++ b/kategory/src/main/kotlin/kategory/free/Yoneda.kt
@@ -23,7 +23,7 @@ interface Yoneda<FU, A> : HK<HK<Yoneda.F, FU>, A> {
             }
 
     fun toCoYoneda(): CoYoneda<FU, A, A> =
-            CoYoneda({ it }, lower())
+            CoYoneda(lower(), listOf({ a: Any? -> a }))
 
     companion object {
         inline fun <reified U, A> apply(fa: HK<U, A>, FF: Functor<U> = functor()): Yoneda<U, A> =

--- a/kategory/src/main/kotlin/kategory/free/Yoneda.kt
+++ b/kategory/src/main/kotlin/kategory/free/Yoneda.kt
@@ -1,28 +1,28 @@
 package kategory
 
-typealias YonedaKind<U, A> = HK2<Yoneda.F, U, A>
+typealias YonedaKind<F, A> = HK2<Yoneda.F, F, A>
 
-typealias YonedaF<U> = HK<Yoneda.F, U>
+typealias YonedaF<F> = HK<Yoneda.F, F>
 
-fun <U, A> YonedaKind<U, A>.ev(): Yoneda<U, A> =
-        this as Yoneda<U, A>
+fun <F, A> YonedaKind<F, A>.ev(): Yoneda<F, A> =
+        this as Yoneda<F, A>
 
 // FIXME using YonedaKind throws a compiler error, but not the expanded form
-interface Yoneda<FU, A> : HK<HK<Yoneda.F, FU>, A> {
+interface Yoneda<F, A> : HK<HK<Yoneda.F, F>, A> {
 
     class F private constructor()
 
-    fun <B> apply(f: (A) -> B): HK<FU, B>
+    fun <B> apply(f: (A) -> B): HK<F, B>
 
-    fun lower(): HK<FU, A> =
+    fun lower(): HK<F, A> =
             apply { a -> a }
 
-    fun <B> map(ff: (A) -> B, FF: Functor<FU>): Yoneda<FU, B> =
-            object : Yoneda<FU, B> {
-                override fun <C> apply(f: (B) -> C): HK<FU, C> = this@Yoneda.apply({ f(ff(it)) })
+    fun <B> map(ff: (A) -> B, FF: Functor<F>): Yoneda<F, B> =
+            object : Yoneda<F, B> {
+                override fun <C> apply(f: (B) -> C): HK<F, C> = this@Yoneda.apply({ f(ff(it)) })
             }
 
-    fun toCoYoneda(): CoYoneda<FU, A, A> =
+    fun toCoYoneda(): CoYoneda<F, A, A> =
             CoYoneda(lower(), listOf({ a: Any? -> a }))
 
     companion object {

--- a/kategory/src/test/kotlin/kategory/free/CoYonedaTest.kt
+++ b/kategory/src/test/kotlin/kategory/free/CoYonedaTest.kt
@@ -8,10 +8,26 @@ import org.junit.runner.RunWith
 class CoYonedaTest : UnitSpec() {
 
     init {
+        val EQ = object : Eq<CoYonedaKind<Id.F, Int, Int>> {
+            override fun eqv(a: CoYonedaKind<Id.F, Int, Int>, b: CoYonedaKind<Id.F, Int, Int>): Boolean =
+                    a.ev().lower(Id) == a.ev().lower(Id)
+
+        }
+        testLaws(FunctorLaws.laws(object : Applicative<CoYonedaF<Id.F, Int>> {
+            override fun <A> pure(a: A): CoYonedaKind<Id.F, Int, A> =
+                    CoYoneda.apply(Id(0), { a })
+
+            override fun <A, B> map(fa: CoYonedaKind<Id.F, Int, A>, f: (A) -> B): CoYonedaKind<Id.F, Int, B> =
+                    fa.ev().map(f)
+
+            override fun <A, B> ap(fa: CoYonedaKind<Id.F, Int, A>, ff: CoYonedaKind<Id.F, Int, (A) -> B>): CoYonedaKind<Id.F, Int, B> =
+                    throw IllegalStateException("Operation not allowed")
+        }, EQ))
+
         "map should modify the content of any HK1" {
             forAll { x: Int ->
                 val op = CoYoneda.apply(Id(x), { _ -> "" })
-                val mapped = op.map { _ -> true }.lower(functor<Id.F>())
+                val mapped = op.map { _ -> true }.lower(Id)
                 val expected = Id(true)
 
                 expected == mapped
@@ -21,17 +37,35 @@ class CoYonedaTest : UnitSpec() {
         "instance map should be consistent with CoYonedaFunctor#map" {
             forAll { x: Int ->
                 val op = CoYoneda.apply(Id(x), { _ -> "" })
-                val mapped = op.map { _ -> true }.lower(functor<Id.F>())
-                val expected = CoYoneda.functor<Id.F, Int>().map(op, { _ -> true}).ev().lower(functor<Id.F>())
+                val mapped = op.map { _ -> true }.lower(Id)
+                val expected = CoYoneda.functor<Id.F, Int>().map(op, { _ -> true }).ev().lower(Id)
 
                 expected == mapped
             }
         }
 
+        "map should retain function application ordering" {
+            forAll { x: Int ->
+                val op = CoYoneda.apply(Id(x), { it })
+                val mapped = op.map { it + 1 }.map { it * 3 }.lower(Id).ev()
+                val expected = Id((x + 1) * 3)
+
+                expected == mapped
+            }
+        }
+
+        "map should be stack-safe" {
+            fun loop(n: Int, acc: CoYoneda<Option.F, Int, Int>): CoYoneda<Option.F, Int, Int> =
+                    if (n <= 0) acc
+                    else loop(n - 1, acc.map { it + 1 })
+
+            loop(10000, CoYoneda.apply(Option.Some(1), { it })).lower(Option)
+        }
+
         "toYoneda should convert to an equivalent Yoneda" {
             forAll { x: Int ->
                 val op = CoYoneda.apply(Id(x), Int::toString)
-                val toYoneda = op.toYoneda(functor<Id.F>()).lower().ev()
+                val toYoneda = op.toYoneda(Id).lower().ev()
                 val expected = Yoneda.apply(Id(x.toString())).lower().ev()
 
                 expected == toYoneda

--- a/kategory/src/test/kotlin/kategory/free/CoYonedaTest.kt
+++ b/kategory/src/test/kotlin/kategory/free/CoYonedaTest.kt
@@ -1,6 +1,7 @@
 package kategory
 
 import io.kotlintest.KTestJUnitRunner
+import io.kotlintest.matchers.shouldBe
 import io.kotlintest.properties.forAll
 import org.junit.runner.RunWith
 
@@ -55,11 +56,16 @@ class CoYonedaTest : UnitSpec() {
         }
 
         "map should be stack-safe" {
+            val loops = 5000
+
             fun loop(n: Int, acc: CoYoneda<Option.F, Int, Int>): CoYoneda<Option.F, Int, Int> =
                     if (n <= 0) acc
                     else loop(n - 1, acc.map { it + 1 })
 
-            loop(10000, CoYoneda.apply(Option.Some(1), { it })).lower(Option)
+            val result = loop(loops, CoYoneda.apply(Option.Some(0), { it })).lower(Option)
+            val expected = Option.Some(loops)
+
+            expected shouldBe result
         }
 
         "toYoneda should convert to an equivalent Yoneda" {

--- a/kategory/src/test/kotlin/kategory/free/CoYonedaTest.kt
+++ b/kategory/src/test/kotlin/kategory/free/CoYonedaTest.kt
@@ -7,6 +7,8 @@ import org.junit.runner.RunWith
 
 @RunWith(KTestJUnitRunner::class)
 class CoYonedaTest : UnitSpec() {
+    val F = CoYoneda.functor<Id.F, Int>()
+
     val EQ = object : Eq<CoYonedaKind<Id.F, Int, Int>> {
         override fun eqv(a: CoYonedaKind<Id.F, Int, Int>, b: CoYonedaKind<Id.F, Int, Int>): Boolean =
                 a.ev().lower(Id) == a.ev().lower(Id)
@@ -18,7 +20,7 @@ class CoYonedaTest : UnitSpec() {
                 CoYoneda.apply(Id(0), { a })
 
         override fun <A, B> map(fa: CoYonedaKind<Id.F, Int, A>, f: (A) -> B): CoYonedaKind<Id.F, Int, B> =
-                fa.ev().map(f)
+               F.map(fa, f)
 
         override fun <A, B> ap(fa: CoYonedaKind<Id.F, Int, A>, ff: CoYonedaKind<Id.F, Int, (A) -> B>): CoYonedaKind<Id.F, Int, B> =
                 throw IllegalStateException("Operation not allowed")

--- a/kategory/src/test/kotlin/kategory/free/CoYonedaTest.kt
+++ b/kategory/src/test/kotlin/kategory/free/CoYonedaTest.kt
@@ -9,17 +9,6 @@ import org.junit.runner.RunWith
 class CoYonedaTest : UnitSpec() {
     val F = CoYoneda.functor<Id.F, Int>()
 
-    val AP: Applicative<CoYonedaF<Id.F, Int>> = object : Applicative<CoYonedaF<Id.F, Int>> {
-        override fun <A> pure(a: A): CoYonedaKind<Id.F, Int, A> =
-                CoYoneda.apply(Id(0), { a })
-
-        override fun <A, B> map(fa: CoYonedaKind<Id.F, Int, A>, f: (A) -> B): CoYonedaKind<Id.F, Int, B> =
-               F.map(fa, f)
-
-        override fun <A, B> ap(fa: CoYonedaKind<Id.F, Int, A>, ff: CoYonedaKind<Id.F, Int, (A) -> B>): CoYonedaKind<Id.F, Int, B> =
-                throw IllegalStateException("Operation not allowed")
-    }
-
     val EQ = object : Eq<CoYonedaKind<Id.F, Int, Int>> {
         override fun eqv(a: CoYonedaKind<Id.F, Int, Int>, b: CoYonedaKind<Id.F, Int, Int>): Boolean =
                 a.ev().lower(Id) == a.ev().lower(Id)
@@ -28,7 +17,7 @@ class CoYonedaTest : UnitSpec() {
 
     init {
 
-        testLaws(FunctorLaws.laws(AP, EQ))
+        testLaws(FunctorLaws.laws(CoYoneda.functor(), { CoYoneda.apply(Id(0), { it }) }, EQ))
 
         "map should modify the content of any HK1" {
             forAll { x: Int ->

--- a/kategory/src/test/kotlin/kategory/free/CoYonedaTest.kt
+++ b/kategory/src/test/kotlin/kategory/free/CoYonedaTest.kt
@@ -9,12 +9,6 @@ import org.junit.runner.RunWith
 class CoYonedaTest : UnitSpec() {
     val F = CoYoneda.functor<Id.F, Int>()
 
-    val EQ = object : Eq<CoYonedaKind<Id.F, Int, Int>> {
-        override fun eqv(a: CoYonedaKind<Id.F, Int, Int>, b: CoYonedaKind<Id.F, Int, Int>): Boolean =
-                a.ev().lower(Id) == a.ev().lower(Id)
-
-    }
-
     val AP: Applicative<CoYonedaF<Id.F, Int>> = object : Applicative<CoYonedaF<Id.F, Int>> {
         override fun <A> pure(a: A): CoYonedaKind<Id.F, Int, A> =
                 CoYoneda.apply(Id(0), { a })
@@ -24,6 +18,12 @@ class CoYonedaTest : UnitSpec() {
 
         override fun <A, B> ap(fa: CoYonedaKind<Id.F, Int, A>, ff: CoYonedaKind<Id.F, Int, (A) -> B>): CoYonedaKind<Id.F, Int, B> =
                 throw IllegalStateException("Operation not allowed")
+    }
+
+    val EQ = object : Eq<CoYonedaKind<Id.F, Int, Int>> {
+        override fun eqv(a: CoYonedaKind<Id.F, Int, Int>, b: CoYonedaKind<Id.F, Int, Int>): Boolean =
+                a.ev().lower(Id) == a.ev().lower(Id)
+
     }
 
     init {

--- a/kategory/src/test/kotlin/kategory/free/YonedaTest.kt
+++ b/kategory/src/test/kotlin/kategory/free/YonedaTest.kt
@@ -9,24 +9,13 @@ class YonedaTest : UnitSpec() {
 
     val F = Yoneda.functor(Id)
 
-    val AP = object : Applicative<YonedaF<Id.F>> {
-        override fun <A> pure(a: A): HK<YonedaF<Id.F>, A> =
-                Yoneda.apply(Id(a))
-
-        override fun <A, B> map(fa: HK<YonedaF<Id.F>, A>, f: (A) -> B): HK<YonedaF<Id.F>, B> =
-                F.map(fa, f)
-
-        override fun <A, B> ap(fa: HK<YonedaF<Id.F>, A>, ff: HK<YonedaF<Id.F>, (A) -> B>): HK<YonedaF<Id.F>, B> =
-                throw IllegalStateException("Operation not allowed")
-    }
-
     val EQ = object : Eq<YonedaKind<Id.F, Int>> {
         override fun eqv(a: YonedaKind<Id.F, Int>, b: YonedaKind<Id.F, Int>): Boolean =
                 a.ev().lower() == b.ev().lower()
     }
 
     init {
-        testLaws(FunctorLaws.laws(AP, EQ))
+        testLaws(FunctorLaws.laws(F, { Yoneda.apply(kategory.Id(it)) }, EQ))
 
         "map should modify the content of any HK1" {
             forAll { x: Int ->

--- a/kategory/src/test/kotlin/kategory/free/YonedaTest.kt
+++ b/kategory/src/test/kotlin/kategory/free/YonedaTest.kt
@@ -7,11 +7,31 @@ import org.junit.runner.RunWith
 @RunWith(KTestJUnitRunner::class)
 class YonedaTest : UnitSpec() {
 
+    val F = Yoneda.functor(Id)
+
+    val AP = object : Applicative<YonedaF<Id.F>> {
+        override fun <A> pure(a: A): HK<YonedaF<Id.F>, A> =
+                Yoneda.apply(Id(a))
+
+        override fun <A, B> map(fa: HK<YonedaF<Id.F>, A>, f: (A) -> B): HK<YonedaF<Id.F>, B> =
+                F.map(fa, f)
+
+        override fun <A, B> ap(fa: HK<YonedaF<Id.F>, A>, ff: HK<YonedaF<Id.F>, (A) -> B>): HK<YonedaF<Id.F>, B> =
+                throw IllegalStateException("Operation not allowed")
+    }
+
+    val EQ = object : Eq<YonedaKind<Id.F, Int>> {
+        override fun eqv(a: YonedaKind<Id.F, Int>, b: YonedaKind<Id.F, Int>): Boolean =
+                a.ev().lower() == b.ev().lower()
+    }
+
     init {
+        testLaws(FunctorLaws.laws(AP, EQ))
+
         "map should modify the content of any HK1" {
             forAll { x: Int ->
                 val op = Yoneda.apply(Id(x))
-                val mapped = op.map({ _ -> true }, functor<Id.F>()).lower()
+                val mapped = op.map({ _ -> true }, Id).lower()
                 val expected = Id(true)
 
                 expected == mapped
@@ -21,8 +41,8 @@ class YonedaTest : UnitSpec() {
         "instance map should be consistent with YonedaFunctor#map" {
             forAll { x: Int ->
                 val op = Yoneda.apply(Id(x))
-                val mapped = op.map({ _ -> true }, functor()).lower()
-                val expected = Yoneda.functor<Id.F>(functor()).map(op, { _ -> true}).ev().lower()
+                val mapped = op.map({ _ -> true }, Id).lower()
+                val expected = Yoneda.functor(Id).map(op, { _ -> true }).ev().lower()
 
                 expected == mapped
             }
@@ -31,8 +51,8 @@ class YonedaTest : UnitSpec() {
         "toCoYoneda should convert to an equivalent CoYoneda" {
             forAll { x: Int ->
                 val op = Yoneda.apply(Id(x.toString()))
-                val toYoneda = op.toCoYoneda().lower(functor<Id.F>()).ev()
-                val expected = CoYoneda.apply(Id(x), Int::toString).lower(functor<Id.F>()).ev()
+                val toYoneda = op.toCoYoneda().lower(Id).ev()
+                val expected = CoYoneda.apply(Id(x), Int::toString).lower(Id).ev()
 
                 expected == toYoneda
             }

--- a/kategory/src/test/kotlin/kategory/laws/FunctorLaws.kt
+++ b/kategory/src/test/kotlin/kategory/laws/FunctorLaws.kt
@@ -6,23 +6,26 @@ import io.kotlintest.properties.forAll
 object FunctorLaws {
 
     inline fun <reified F> laws(AP: Applicative<F> = applicative<F>(), EQ: Eq<HK<F, Int>>): List<Law> =
+            laws(AP, AP::pure, EQ)
+
+    inline fun <reified F> laws(FF: Functor<F> = functor<F>(), crossinline f: (Int) -> HK<F, Int>, EQ: Eq<HK<F, Int>>): List<Law> =
             listOf(
-                    Law("Functor Laws: Covariant Identity", { covariantIdentity(AP, EQ) }),
-                    Law("Functor Laws: Covariant Composition", { covariantComposition(AP, EQ) })
+                    Law("Functor Laws: Covariant Identity", { covariantIdentity(FF, f, EQ) }),
+                    Law("Functor Laws: Covariant Composition", { covariantComposition(FF, f, EQ) })
             )
 
-    inline fun <reified F> covariantIdentity(AP: Applicative<F> = applicative<F>(), EQ: Eq<HK<F, Int>> = Eq.any()): Unit =
-            forAll(genApplicative(Gen.int(), AP), { fa: HK<F, Int> ->
-                AP.map(fa, ::identity).equalUnderTheLaw(fa, EQ)
+    inline fun <reified F> covariantIdentity(FF: Functor<F> = functor<F>(), crossinline f: (Int) -> HK<F, Int>, EQ: Eq<HK<F, Int>> = Eq.any()): Unit =
+            forAll(genConstructor(Gen.int(), f), { fa: HK<F, Int> ->
+                FF.map(fa, ::identity).equalUnderTheLaw(fa, EQ)
             })
 
-    inline fun <reified F> covariantComposition(AP: Applicative<F> = applicative<F>(), EQ: Eq<HK<F, Int>> = Eq.any()): Unit =
+    inline fun <reified F> covariantComposition(FF: Functor<F> = functor<F>(), crossinline f: (Int) -> HK<F, Int>, EQ: Eq<HK<F, Int>> = Eq.any()): Unit =
             forAll(
-                    genApplicative(Gen.int(), AP),
+                    genConstructor(Gen.int(), f),
                     genFunctionAToB<Int, Int>(Gen.int()),
                     genFunctionAToB<Int, Int>(Gen.int()),
                     { fa: HK<F, Int>, f, g ->
-                        AP.map(AP.map(fa, f), g).equalUnderTheLaw(AP.map(fa, f andThen g), EQ)
+                        FF.map(FF.map(fa, f), g).equalUnderTheLaw(FF.map(fa, f andThen g), EQ)
                     }
             )
 

--- a/kategory/src/test/kotlin/kategory/laws/FunctorLaws.kt
+++ b/kategory/src/test/kotlin/kategory/laws/FunctorLaws.kt
@@ -6,7 +6,10 @@ import io.kotlintest.properties.forAll
 object FunctorLaws {
 
     inline fun <reified F> laws(AP: Applicative<F> = applicative<F>(), EQ: Eq<HK<F, Int>>): List<Law> =
-            laws(AP, AP::pure, EQ)
+            listOf(
+                    Law("Functor Laws: Covariant Identity", { covariantIdentity(AP, AP::pure, EQ) }),
+                    Law("Functor Laws: Covariant Composition", { covariantComposition(AP, AP::pure, EQ) })
+            )
 
     inline fun <reified F> laws(FF: Functor<F> = functor<F>(), crossinline f: (Int) -> HK<F, Int>, EQ: Eq<HK<F, Int>>): List<Law> =
             listOf(


### PR DESCRIPTION
This PR introduces the stack-safe implementation of CoYoneda that's also used in cats. Thanks to @edmundnoble for the implementation.

At higher numbers for the test (i.e. 20k), it causes a StackOverflow due to some function checks by JetBrains. See the following issue until it's fixed:  https://youtrack.jetbrains.com/issue/KT-19499

Closes #167 