### PR TITLE
Update detekt to M13

### DIFF
--- a/detekt.gradle
+++ b/detekt.gradle
@@ -13,10 +13,10 @@ repositories {
         classpath = configurations.detekt
         def input = "$project.projectDir.absolutePath"
         def config = "$project.projectDir/detekt.yml"
-        def reports = "$project.projectDir.absolutePath/reports/"
+        def reports = "$project.projectDir.absolutePath/reports/report.detekt"
         def filters = ".*test.*"
         def rulesets = ""
-        def params = ['-p', input, '-c', config, '-f', filters, '-r', rulesets, '-o', '-rp', reports]
+        def params = ['-p', input, '-c', config, '-f', filters, '-r', rulesets, '-o', reports]
         args(params)
     }
 
@@ -26,16 +26,16 @@ repositories {
         classpath = configurations.detekt
         def input = "$project.projectDir.absolutePath"
         def config = "$project.projectDir/detekt.yml"
-        def reports = "$project.projectDir.absolutePath/reports/"
+        def reports = "$project.projectDir.absolutePath/reports/report.detekt"
         def filters = ".*test.*"
         def rulesets = ""
-        def params = ['-p', input, '-c', config, '-f', filters, '-r', rulesets, '-o', '-rp', reports, '--baseline']
+        def params = ['-p', input, '-c', config, '-f', filters, '-r', rulesets, '-o', reports, '--baseline']
         args(params)
     }
 
     dependencies {
 
-        detekt 'io.gitlab.arturbosch.detekt:detekt-cli:1.0.0.M7'
-        detekt 'io.gitlab.arturbosch.detekt:detekt-formatting:1.0.0.M7'
+        detekt 'io.gitlab.arturbosch.detekt:detekt-cli:1.0.0.M13'
+        detekt 'io.gitlab.arturbosch.detekt:detekt-formatting:1.0.0.M13'
     }
 }

--- a/detekt.gradle
+++ b/detekt.gradle
@@ -14,9 +14,10 @@ repositories {
         def input = "$project.projectDir.absolutePath"
         def config = "$project.projectDir/detekt.yml"
         def reports = "$project.projectDir.absolutePath/reports/report.detekt"
+        def baseline = "$project.projectDir.absolutePath/reports/baseline.xml"
         def filters = ".*test.*"
         def rulesets = ""
-        def params = ['-p', input, '-c', config, '-f', filters, '-r', rulesets, '-o', reports]
+        def params = ['-p', input, '-c', config, '-f', filters, '-r', rulesets, '-o', reports, '-b', baseline]
         args(params)
     }
 

--- a/detekt.gradle
+++ b/detekt.gradle
@@ -28,9 +28,10 @@ repositories {
         def input = "$project.projectDir.absolutePath"
         def config = "$project.projectDir/detekt.yml"
         def reports = "$project.projectDir.absolutePath/reports/report.detekt"
+        def baseline = "$project.projectDir.absolutePath/reports/baseline.xml"
         def filters = ".*test.*"
         def rulesets = ""
-        def params = ['-p', input, '-c', config, '-f', filters, '-r', rulesets, '-o', reports, '--baseline']
+        def params = ['-p', input, '-c', config, '-f', filters, '-r', rulesets, '-o', reports, '-b', baseline, '-cb']
         args(params)
     }
 

--- a/detekt.yml
+++ b/detekt.yml
@@ -9,7 +9,7 @@ potential-bugs:
   NoElseInWhenExpression:
     active: false
   UnsafeCast:
-    active: false
+    active: true
 
 exceptions:
   active: true
@@ -32,7 +32,7 @@ complexity:
   TooManyFunctions:
     active: false
   LabeledExpression:
-    active: false
+    active: true
 
 code-smell:
   active: true

--- a/detekt.yml
+++ b/detekt.yml
@@ -94,7 +94,8 @@ style:
   NamingConventionViolation:
     active: false
   MaxLineLength:
-    active: false
+    active: true
+    maxLineLength: 150
 
 comments:
   active: true

--- a/detekt.yml
+++ b/detekt.yml
@@ -74,6 +74,12 @@ formatting:
   OptionalUnit:
     active: true
     autoCorrect: false
+  ExpressionBodySyntax:
+    active: true
+    autoCorrect: true
+  ExpressionBodySyntaxLineBreaks:
+      active: false
+      autoCorrect: false
 
 style:
   active: true

--- a/detekt.yml
+++ b/detekt.yml
@@ -8,6 +8,8 @@ potential-bugs:
   active: true
   NoElseInWhenExpression:
     active: false
+  UnsafeCast:
+    active: false
 
 exceptions:
   active: true
@@ -26,7 +28,11 @@ complexity:
   ComplexMethod:
     threshold: 10
   NestedBlockDepth:
-    threshold: 3
+    threshold: 5
+  TooManyFunctions:
+    active: false
+  LabeledExpression:
+    active: false
 
 code-smell:
   active: true
@@ -78,14 +84,16 @@ formatting:
     active: true
     autoCorrect: true
   ExpressionBodySyntaxLineBreaks:
-      active: false
-      autoCorrect: false
+      active: true
+      autoCorrect: true
 
 style:
   active: true
   WildcardImport:
     active: true
   NamingConventionViolation:
+    active: false
+  MaxLineLength:
     active: false
 
 comments:
@@ -94,7 +102,7 @@ comments:
     active: true
   CommentOverPrivateProperty:
     active: true
-  NoDocOverPublicClass:
+  UndocumentedPublicClass:
     active: false
-  NoDocOverPublicMethod:
+  UndocumentedPublicFunction:
     active: false

--- a/detekt.yml
+++ b/detekt.yml
@@ -84,8 +84,8 @@ formatting:
     active: true
     autoCorrect: true
   ExpressionBodySyntaxLineBreaks:
-      active: true
-      autoCorrect: true
+      active: false
+      autoCorrect: false
 
 style:
   active: true

--- a/detekt.yml
+++ b/detekt.yml
@@ -84,8 +84,8 @@ formatting:
     active: true
     autoCorrect: true
   ExpressionBodySyntaxLineBreaks:
-      active: false
-      autoCorrect: false
+      active: true
+      autoCorrect: true
 
 style:
   active: true
@@ -95,7 +95,7 @@ style:
     active: false
   MaxLineLength:
     active: true
-    maxLineLength: 150
+    maxLineLength: 160
 
 comments:
   active: true

--- a/kategory/src/main/kotlin/kategory/Maps.kt
+++ b/kategory/src/main/kotlin/kategory/Maps.kt
@@ -1,4 +1,3 @@
 package kategory
 
-fun <K, V> mapOf(vararg tuple: Tuple2<K, V>): Map<K, V> =
-        if (tuple.isNotEmpty()) tuple.map { it.a to it.b }.toMap() else emptyMap()
+fun <K, V> mapOf(vararg tuple: Tuple2<K, V>): Map<K, V> = if (tuple.isNotEmpty()) tuple.map { it.a to it.b }.toMap() else emptyMap()

--- a/kategory/src/main/kotlin/kategory/arrow/Function0.kt
+++ b/kategory/src/main/kotlin/kategory/arrow/Function0.kt
@@ -1,13 +1,10 @@
 package kategory
 
-fun <A> (() -> A).k(): Function0<A> =
-        Function0(this)
+fun <A> (() -> A).k(): Function0<A> = Function0(this)
 
-fun <A> HK<Function0.F, A>.ev(): () -> A =
-        (this as Function0<A>).f
+fun <A> HK<Function0.F, A>.ev(): () -> A = (this as Function0<A>).f
 
-operator fun <A> HK<Function0.F, A>.invoke(): A =
-        (this as Function0<A>).f()
+operator fun <A> HK<Function0.F, A>.invoke(): A = (this as Function0<A>).f()
 
 // We don't want an inherited class to avoid equivalence issues, so a simple HK wrapper will do
 data class Function0<out A>(internal val f: () -> A) : HK<Function0.F, A> {
@@ -15,20 +12,15 @@ data class Function0<out A>(internal val f: () -> A) : HK<Function0.F, A> {
 
     companion object : Bimonad<Function0.F>, GlobalInstance<Bimonad<Function0.F>>() {
 
-        override fun <A, B> flatMap(fa: HK<Function0.F, A>, f: (A) -> HK<Function0.F, B>): Function0<B> =
-                Function0(f(fa()).ev())
+        override fun <A, B> flatMap(fa: HK<Function0.F, A>, f: (A) -> HK<Function0.F, B>): Function0<B> = Function0(f(fa()).ev())
 
-        override fun <A, B> coflatMap(fa: HK<Function0.F, A>, f: (HK<Function0.F, A>) -> B): Function0<B> =
-                { f(fa) }.k()
+        override fun <A, B> coflatMap(fa: HK<Function0.F, A>, f: (HK<Function0.F, A>) -> B): Function0<B> = { f(fa) }.k()
 
-        override fun <A> pure(a: A): Function0<A> =
-                { a }.k()
+        override fun <A> pure(a: A): Function0<A> = { a }.k()
 
-        override fun <A> extract(fa: HK<Function0.F, A>): A =
-                fa()
+        override fun <A> extract(fa: HK<Function0.F, A>): A = fa()
 
-        override fun <A, B> map(fa: HK<F, A>, f: (A) -> B): Function0<B> =
-                pure(f(fa()))
+        override fun <A, B> map(fa: HK<F, A>, f: (A) -> B): Function0<B> = pure(f(fa()))
 
         tailrec fun <A, B> loop(a: A, f: (A) -> HK<F, Either<A, B>>): B {
             val fa = f(a).ev()()
@@ -38,8 +30,7 @@ data class Function0<out A>(internal val f: () -> A) : HK<Function0.F, A> {
             }
         }
 
-        override fun <A, B> tailRecM(a: A, f: (A) -> HK<F, Either<A, B>>): Function0<B> =
-                { loop(a, f) }.k()
+        override fun <A, B> tailRecM(a: A, f: (A) -> HK<F, Either<A, B>>): Function0<B> = { loop(a, f) }.k()
 
         fun bimonad(): Bimonad<Function0.F> = this
 

--- a/kategory/src/main/kotlin/kategory/arrow/Function1.kt
+++ b/kategory/src/main/kotlin/kategory/arrow/Function1.kt
@@ -3,14 +3,11 @@ package kategory
 typealias Function1Kind<I, O> = HK2<Function1.F, I, O>
 typealias Function1F<I> = HK<Function1.F, I>
 
-fun <I, O> ((I) -> O).k(): Function1<I, O> =
-        Function1(this)
+fun <I, O> ((I) -> O).k(): Function1<I, O> = Function1(this)
 
-fun <I, O> Function1Kind<I, O>.ev(): Function1<I, O> =
-        this as Function1<I, O>
+fun <I, O> Function1Kind<I, O>.ev(): Function1<I, O> = this as Function1<I, O>
 
-operator fun <I, O> Function1Kind<I, O>.invoke(i: I): O =
-        this.ev().f(i)
+operator fun <I, O> Function1Kind<I, O>.invoke(i: I): O = this.ev().f(i)
 
 class Function1<I, out O>(val f: (I) -> O) : Function1Kind<I, O> {
 

--- a/kategory/src/main/kotlin/kategory/arrow/Kleisli.kt
+++ b/kategory/src/main/kotlin/kategory/arrow/Kleisli.kt
@@ -6,14 +6,12 @@ typealias KleisliFD<F, D> = HK2<Kleisli.F, F, D>
 typealias KleisliFun<F, D, A> = (D) -> HK<F, A>
 typealias ReaderT<F, D, A> = Kleisli<F, D, A>
 
-fun <F, D, A> KleisliTKind<F, D, A>.ev(): Kleisli<F, D, A> =
-        this as Kleisli<F, D, A>
+fun <F, D, A> KleisliTKind<F, D, A>.ev(): Kleisli<F, D, A> = this as Kleisli<F, D, A>
 
 class Kleisli<F, D, A>(val MF: Monad<F>, val run: KleisliFun<F, D, A>) : KleisliTKind<F, D, A> {
     class F private constructor()
 
-    fun <B> map(f: (A) -> B): Kleisli<F, D, B> =
-            Kleisli(MF, { a -> MF.map(run(a), f) })
+    fun <B> map(f: (A) -> B): Kleisli<F, D, B> = Kleisli(MF, { a -> MF.map(run(a), f) })
 
     fun <B> flatMap(f: (A) -> Kleisli<F, D, B>): Kleisli<F, D, B> =
             Kleisli(MF, { d ->
@@ -25,28 +23,21 @@ class Kleisli<F, D, A>(val MF: Monad<F>, val run: KleisliFun<F, D, A>) : Kleisli
                 o.map({ b -> Tuple2(a, b) })
             })
 
-    fun <DD> local(f: (DD) -> D): Kleisli<F, DD, A> =
-            Kleisli(MF, { dd -> run(f(dd)) })
+    fun <DD> local(f: (DD) -> D): Kleisli<F, DD, A> = Kleisli(MF, { dd -> run(f(dd)) })
 
-    infix fun <C> andThen(f: Kleisli<F, A, C>): Kleisli<F, D, C> =
-            andThen(f.run)
+    infix fun <C> andThen(f: Kleisli<F, A, C>): Kleisli<F, D, C> = andThen(f.run)
 
-    infix fun <B> andThen(f: (A) -> HK<F, B>): Kleisli<F, D, B> =
-            Kleisli(MF, { MF.flatMap(run(it), f) })
+    infix fun <B> andThen(f: (A) -> HK<F, B>): Kleisli<F, D, B> = Kleisli(MF, { MF.flatMap(run(it), f) })
 
-    infix fun <B> andThen(a: HK<F, B>): Kleisli<F, D, B> =
-            andThen({ a })
+    infix fun <B> andThen(a: HK<F, B>): Kleisli<F, D, B> = andThen({ a })
 
     companion object {
 
-        inline operator fun <reified F, D, A> invoke(noinline run: KleisliFun<F, D, A>, MF: Monad<F> = monad<F>()): Kleisli<F, D, A> =
-                Kleisli(MF, run)
+        inline operator fun <reified F, D, A> invoke(noinline run: KleisliFun<F, D, A>, MF: Monad<F> = monad<F>()): Kleisli<F, D, A> = Kleisli(MF, run)
 
-        @JvmStatic inline fun <reified F, D, A> pure(x: A, MF: Monad<F> = monad<F>()): Kleisli<F, D, A> =
-                Kleisli(MF, { _ -> MF.pure(x) })
+        @JvmStatic inline fun <reified F, D, A> pure(x: A, MF: Monad<F> = monad<F>()): Kleisli<F, D, A> = Kleisli(MF, { _ -> MF.pure(x) })
 
-        @JvmStatic inline fun <reified F, D> ask(MF: Monad<F> = monad<F>()): Kleisli<F, D, D> =
-                Kleisli(MF, { MF.pure(it) })
+        @JvmStatic inline fun <reified F, D> ask(MF: Monad<F> = monad<F>()): Kleisli<F, D, D> = Kleisli(MF, { MF.pure(it) })
 
         fun <F, D> instances(MF : Monad<F>): KleisliInstances<F, D> = object : KleisliInstances<F, D> {
             override fun MF(): Monad<F> = MF
@@ -67,8 +58,6 @@ class Kleisli<F, D, A>(val MF: Monad<F>, val run: KleisliFun<F, D, A>) : Kleisli
 
 }
 
-inline fun <reified F, D, A> Kleisli<F, D, Kleisli<F, D, A>>.flatten(): Kleisli<F, D, A> =
-        flatMap({ it })
+inline fun <reified F, D, A> Kleisli<F, D, Kleisli<F, D, A>>.flatten(): Kleisli<F, D, A> = flatMap({ it })
 
-inline fun <reified F, reified D, A> KleisliFun<F, D, A>.kleisli(FT: Monad<F> = monad()): Kleisli<F, D, A> =
-        Kleisli(FT, this)
+inline fun <reified F, reified D, A> KleisliFun<F, D, A>.kleisli(FT: Monad<F> = monad()): Kleisli<F, D, A> = Kleisli(FT, this)

--- a/kategory/src/main/kotlin/kategory/data/Cokleisli.kt
+++ b/kategory/src/main/kotlin/kategory/data/Cokleisli.kt
@@ -7,45 +7,33 @@ typealias CokleisiFun<F, A, B> = (HK<F, A>) -> B
 
 typealias CoreaderT<F, A, B> = Cokleisli<F, A, B>
 
-fun <F, A, B> CokleisiTKind<F, A, B>.ev(): Cokleisli<F, A, B> =
-        this as Cokleisli<F, A, B>
+fun <F, A, B> CokleisiTKind<F, A, B>.ev(): Cokleisli<F, A, B> = this as Cokleisli<F, A, B>
 
 data class Cokleisli<F, A, B>(val MM: Comonad<F>, val run: CokleisiFun<F, A, B>) : CokleisiTKind<F, A, B> {
     class F private constructor()
 
-    inline fun <C, D> bimap(noinline g: (D) -> A, crossinline f: (B) -> C): Cokleisli<F, D, C> =
-            Cokleisli(MM, { f(run(MM.map(it, g))) })
+    inline fun <C, D> bimap(noinline g: (D) -> A, crossinline f: (B) -> C): Cokleisli<F, D, C> = Cokleisli(MM, { f(run(MM.map(it, g))) })
 
-    fun <D> lmap(g: (D) -> A): Cokleisli<F, D, B> =
-            Cokleisli(MM, { run(MM.map(it, g)) })
+    fun <D> lmap(g: (D) -> A): Cokleisli<F, D, B> = Cokleisli(MM, { run(MM.map(it, g)) })
 
-    inline fun <C> map(crossinline f: (B) -> C): Cokleisli<F, A, C> =
-            Cokleisli(MM, { f(run(it)) })
+    inline fun <C> map(crossinline f: (B) -> C): Cokleisli<F, A, C> = Cokleisli(MM, { f(run(it)) })
 
-    inline fun <C> contramapValue(crossinline f: (HK<F, C>) -> HK<F, A>): Cokleisli<F, C, B> =
-            Cokleisli(MM, { run(f(it)) })
+    inline fun <C> contramapValue(crossinline f: (HK<F, C>) -> HK<F, A>): Cokleisli<F, C, B> = Cokleisli(MM, { run(f(it)) })
 
-    fun <D> compose(a: Cokleisli<F, D, A>): Cokleisli<F, D, B> =
-            Cokleisli(MM, { run(MM.coflatMap(it, a.run)) })
+    fun <D> compose(a: Cokleisli<F, D, A>): Cokleisli<F, D, B> = Cokleisli(MM, { run(MM.coflatMap(it, a.run)) })
 
     @JvmName("andThenK")
-    fun <C> andThen(a: HK<F, C>): Cokleisli<F, A, C> =
-            Cokleisli(MM, { MM.extract(a) })
+    fun <C> andThen(a: HK<F, C>): Cokleisli<F, A, C> = Cokleisli(MM, { MM.extract(a) })
 
-    fun <C> andThen(a: Cokleisli<F, B, C>): Cokleisli<F, A, C> =
-            a.compose(this)
+    fun <C> andThen(a: Cokleisli<F, B, C>): Cokleisli<F, A, C> = a.compose(this)
 
-    inline fun <C> flatMap(crossinline f: (B) -> Cokleisli<F, A, C>): Cokleisli<F, A, C> =
-            Cokleisli(MM, { f(run(it)).run(it) })
+    inline fun <C> flatMap(crossinline f: (B) -> Cokleisli<F, A, C>): Cokleisli<F, A, C> = Cokleisli(MM, { f(run(it)).run(it) })
 
     companion object {
-        inline operator fun <reified F, A, B> invoke(noinline run: (HK<F, A>) -> B, MF: Comonad<F> = comonad<F>()): Cokleisli<F, A, B> =
-                Cokleisli(MF, run)
+        inline operator fun <reified F, A, B> invoke(noinline run: (HK<F, A>) -> B, MF: Comonad<F> = comonad<F>()): Cokleisli<F, A, B> = Cokleisli(MF, run)
 
-        inline fun <reified F, A, B> pure(b: B, MF: Comonad<F> = comonad<F>()): Cokleisli<F, A, B> =
-                Cokleisli(MF, { b })
+        inline fun <reified F, A, B> pure(b: B, MF: Comonad<F> = comonad<F>()): Cokleisli<F, A, B> = Cokleisli(MF, { b })
 
-        inline fun <reified F, B> ask(MF: Comonad<F> = comonad<F>()): Cokleisli<F, B, B> =
-                Cokleisli(MF, { MF.extract(it) })
+        inline fun <reified F, B> ask(MF: Comonad<F> = comonad<F>()): Cokleisli<F, B, B> = Cokleisli(MF, { MF.extract(it) })
     }
 }

--- a/kategory/src/main/kotlin/kategory/data/Composed.kt
+++ b/kategory/src/main/kotlin/kategory/data/Composed.kt
@@ -6,62 +6,48 @@ package kategory
 interface ComposedType<out F, out G>
 
 @Suppress("UNCHECKED_CAST")
-fun <F, G, A> HK<F, HK<G, A>>.lift(): HK<ComposedType<F, G>, A> =
-        this as HK<ComposedType<F, G>, A>
+fun <F, G, A> HK<F, HK<G, A>>.lift(): HK<ComposedType<F, G>, A> = this as HK<ComposedType<F, G>, A>
 
 @Suppress("UNCHECKED_CAST")
-fun <F, G, A> HK<ComposedType<F, G>, A>.lower(): HK<F, HK<G, A>> =
-        this as HK<F, HK<G, A>>
+fun <F, G, A> HK<ComposedType<F, G>, A>.lower(): HK<F, HK<G, A>> = this as HK<F, HK<G, A>>
 
 data class ComposedFoldable<in F, in G>(val FF: Foldable<F>, val GF: Foldable<G>) : Foldable<ComposedType<F, G>> {
-    override fun <A, B> foldL(fa: HK<ComposedType<F, G>, A>, b: B, f: (B, A) -> B): B =
-            FF.foldL(fa.lower(), b, { bb, aa -> GF.foldL(aa, bb, f) })
+    override fun <A, B> foldL(fa: HK<ComposedType<F, G>, A>, b: B, f: (B, A) -> B): B = FF.foldL(fa.lower(), b, { bb, aa -> GF.foldL(aa, bb, f) })
 
-    fun <A, B> foldLC(fa: HK<F, HK<G, A>>, b: B, f: (B, A) -> B): B =
-            foldL(fa.lift(), b, f)
+    fun <A, B> foldLC(fa: HK<F, HK<G, A>>, b: B, f: (B, A) -> B): B = foldL(fa.lift(), b, f)
 
-    override fun <A, B> foldR(fa: HK<ComposedType<F, G>, A>, lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> =
-            FF.foldR(fa.lower(), lb, { laa, lbb -> GF.foldR(laa, lbb, f) })
+    override fun <A, B> foldR(fa: HK<ComposedType<F, G>, A>, lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> = FF.foldR(fa.lower(), lb, { laa, lbb -> GF.foldR(laa, lbb, f) })
 
-    fun <A, B> foldRC(fa: HK<F, HK<G, A>>, lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> =
-            foldR(fa.lift(), lb, f)
+    fun <A, B> foldRC(fa: HK<F, HK<G, A>>, lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> = foldR(fa.lift(), lb, f)
 
     companion object {
-        inline operator fun <reified F, reified G> invoke(FF: Foldable<F> = foldable<F>(), GF: Foldable<G> = foldable<G>()): ComposedFoldable<F, G> =
-                ComposedFoldable(FF, GF)
+        inline operator fun <reified F, reified G> invoke(FF: Foldable<F> = foldable<F>(), GF: Foldable<G> = foldable<G>()): ComposedFoldable<F, G> = ComposedFoldable(FF, GF)
     }
 }
 
-inline fun <F, reified G> Foldable<F>.compose(GT: Foldable<G> = foldable<G>()): ComposedFoldable<F, G> =
-        ComposedFoldable(this, GT)
+inline fun <F, reified G> Foldable<F>.compose(GT: Foldable<G> = foldable<G>()): ComposedFoldable<F, G> = ComposedFoldable(this, GT)
 
 data class ComposedTraverse<F, G>(val FT: Traverse<F>, val GT: Traverse<G>, val GA: Applicative<G>, val CF: ComposedFoldable<F, G> = ComposedFoldable(FT, GT))
     : Traverse<ComposedType<F, G>>, Foldable<ComposedType<F, G>> by CF {
 
-    override fun <H, A, B> traverse(fa: HK<ComposedType<F, G>, A>, f: (A) -> HK<H, B>, HA: Applicative<H>): HK<H, HK<ComposedType<F, G>, B>> =
-            HA.map(FT.traverse(fa.lower(), { ga -> GT.traverse(ga, f, HA) }, HA), { it.lift() })
+    override fun <H, A, B> traverse(fa: HK<ComposedType<F, G>, A>, f: (A) -> HK<H, B>, HA: Applicative<H>): HK<H, HK<ComposedType<F, G>, B>> = HA.map(FT.traverse(fa.lower(), { ga -> GT.traverse(ga, f, HA) }, HA), { it.lift() })
 
-    fun <H, A, B> traverseC(fa: HK<F, HK<G, A>>, f: (A) -> HK<H, B>, HA: Applicative<H>): HK<H, HK<ComposedType<F, G>, B>> =
-            traverse(fa.lift(), f, HA)
+    fun <H, A, B> traverseC(fa: HK<F, HK<G, A>>, f: (A) -> HK<H, B>, HA: Applicative<H>): HK<H, HK<ComposedType<F, G>, B>> = traverse(fa.lift(), f, HA)
 
     companion object {
-        inline operator fun <reified F, reified G> invoke(FF: Traverse<F> = traverse<F>(), GF: Traverse<G> = traverse<G>(), GA: Applicative<G> = applicative<G>()): ComposedTraverse<F, G> =
-                ComposedTraverse(FF, GF, GA)
+        inline operator fun <reified F, reified G> invoke(FF: Traverse<F> = traverse<F>(), GF: Traverse<G> = traverse<G>(), GA: Applicative<G> = applicative<G>()): ComposedTraverse<F, G> = ComposedTraverse(FF, GF, GA)
     }
 }
 
-inline fun <F, reified G> Traverse<F>.compose(GT: Traverse<G> = traverse<G>(), GA: Applicative<G> = applicative<G>()): Traverse<ComposedType<F, G>> =
-        ComposedTraverse(this, GT, GA)
+inline fun <F, reified G> Traverse<F>.compose(GT: Traverse<G> = traverse<G>(), GA: Applicative<G> = applicative<G>()): Traverse<ComposedType<F, G>> = ComposedTraverse(this, GT, GA)
 
 interface ComposedSemigroupK<F, G> : SemigroupK<ComposedType<F, G>> {
 
     fun F(): SemigroupK<F>
 
-    override fun <A> combineK(x: HK<ComposedType<F, G>, A>, y: HK<ComposedType<F, G>, A>): HK<ComposedType<F, G>, A> =
-            F().combineK(x.lower(), y.lower()).lift()
+    override fun <A> combineK(x: HK<ComposedType<F, G>, A>, y: HK<ComposedType<F, G>, A>): HK<ComposedType<F, G>, A> = F().combineK(x.lower(), y.lower()).lift()
 
-    fun <A> combineKC(x: HK<F, HK<G, A>>, y: HK<F, HK<G, A>>): HK<ComposedType<F, G>, A> =
-            combineK(x.lift(), y.lift())
+    fun <A> combineKC(x: HK<F, HK<G, A>>, y: HK<F, HK<G, A>>): HK<ComposedType<F, G>, A> = combineK(x.lift(), y.lift())
 }
 
 inline fun <F, reified G> SemigroupK<F>.compose(): SemigroupK<ComposedType<F, G>> = object : ComposedSemigroupK<F, G> {

--- a/kategory/src/main/kotlin/kategory/data/Coproduct.kt
+++ b/kategory/src/main/kotlin/kategory/data/Coproduct.kt
@@ -4,15 +4,13 @@ typealias CoproductF<F> = HK<Coproduct.F, F>
 typealias CoproductFG<F, G> = HK2<Coproduct.F, F, G>
 typealias CoproductKind<F, G, A> = HK3<Coproduct.F, F, G, A>
 
-fun <F, G, A> CoproductKind<F, G, A>.ev(): Coproduct<F, G, A> =
-        this as Coproduct<F, G, A>
+fun <F, G, A> CoproductKind<F, G, A>.ev(): Coproduct<F, G, A> = this as Coproduct<F, G, A>
 
 data class Coproduct<F, G, A>(val CF: Comonad<F>, val CG: Comonad<G>, val run: Either<HK<F, A>, HK<G, A>>) : CoproductKind<F, G, A> {
 
     class F private constructor()
 
-    fun <B> map(f: (A) -> B): Coproduct<F, G, B> =
-            Coproduct(CF, CG, run.bimap(CF.lift(f), CG.lift(f)))
+    fun <B> map(f: (A) -> B): Coproduct<F, G, B> = Coproduct(CF, CG, run.bimap(CF.lift(f), CG.lift(f)))
 
     fun <B> coflatMap(f: (Coproduct<F, G, A>) -> B): Coproduct<F, G, B> =
             Coproduct(CF, CG, run.bimap(
@@ -20,17 +18,13 @@ data class Coproduct<F, G, A>(val CF: Comonad<F>, val CG: Comonad<G>, val run: E
                     { CG.coflatMap(it, { f(Coproduct(CF, CG, Either.Right(it))) }) }
             ))
 
-    fun extract(): A =
-            run.fold({ CF.extract(it) }, { CG.extract(it) })
+    fun extract(): A = run.fold({ CF.extract(it) }, { CG.extract(it) })
 
-    fun <H> fold(f: FunctionK<F, H>, g: FunctionK<G, H>): HK<H, A> =
-            run.fold({ f(it) }, { g(it) })
+    fun <H> fold(f: FunctionK<F, H>, g: FunctionK<G, H>): HK<H, A> = run.fold({ f(it) }, { g(it) })
 
-    fun <B> foldL(b: B, f: (B, A) -> B, FF: Foldable<F>, FG: Foldable<G>): B =
-            run.fold({ FF.foldL(it, b, f) }, { FG.foldL(it, b, f) })
+    fun <B> foldL(b: B, f: (B, A) -> B, FF: Foldable<F>, FG: Foldable<G>): B = run.fold({ FF.foldL(it, b, f) }, { FG.foldL(it, b, f) })
 
-    fun <B> foldR(lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>, FF: Foldable<F>, FG: Foldable<G>): Eval<B> =
-            run.fold({ FF.foldR(it, lb, f) }, { FG.foldR(it, lb, f) })
+    fun <B> foldR(lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>, FF: Foldable<F>, FG: Foldable<G>): Eval<B> = run.fold({ FF.foldR(it, lb, f) }, { FG.foldR(it, lb, f) })
 
     fun <H, B> traverse(f: (A) -> HK<H, B>, GA: Applicative<H>, FT: Traverse<F>, GT: Traverse<G>): HK<H, Coproduct<F, G, B>> =
             run.fold({
@@ -40,8 +34,7 @@ data class Coproduct<F, G, A>(val CF: Comonad<F>, val CG: Comonad<G>, val run: E
             })
 
     companion object {
-        inline operator fun <reified F, reified G, A> invoke(run: Either<HK<F, A>, HK<G, A>>, CF: Comonad<F> = comonad<F>(), CG: Comonad<G> = comonad<G>()): Coproduct<F, G, A> =
-                Coproduct(CF, CG, run)
+        inline operator fun <reified F, reified G, A> invoke(run: Either<HK<F, A>, HK<G, A>>, CF: Comonad<F> = comonad<F>(), CG: Comonad<G> = comonad<G>()): Coproduct<F, G, A> = Coproduct(CF, CG, run)
 
         fun <F, G> comonad(): CoproductComonad<F, G> = object : CoproductComonad<F, G> {}
 
@@ -56,5 +49,4 @@ data class Coproduct<F, G, A>(val CF: Comonad<F>, val CG: Comonad<G>, val run: E
 
 }
 
-inline fun <reified F, reified G, A> Either<HK<F, A>, HK<G, A>>.coproduct(CF: Comonad<F> = comonad(), CG: Comonad<G> = comonad()): Coproduct<F, G, A> =
-        Coproduct(CF, CG, this)
+inline fun <reified F, reified G, A> Either<HK<F, A>, HK<G, A>>.coproduct(CF: Comonad<F> = comonad(), CG: Comonad<G> = comonad()): Coproduct<F, G, A> = Coproduct(CF, CG, this)

--- a/kategory/src/main/kotlin/kategory/data/Coreader.kt
+++ b/kategory/src/main/kotlin/kategory/data/Coreader.kt
@@ -1,18 +1,13 @@
 package kategory
 
-fun <A, B> ((A) -> B).coreader(): CoreaderT<Id.F, A, B> =
-        Coreader(this)
+fun <A, B> ((A) -> B).coreader(): CoreaderT<Id.F, A, B> = Coreader(this)
 
-fun <A, B> CoreaderT<Id.F, A, B>.runId(d: A): B =
-        this.run(Id(d))
+fun <A, B> CoreaderT<Id.F, A, B>.runId(d: A): B = this.run(Id(d))
 
 object Coreader {
-    operator fun <A, B> invoke(run: (A) -> B): CoreaderT<Id.F, A, B> =
-            Cokleisli({ a: IdKind<A> -> run(a.ev().value) })
+    operator fun <A, B> invoke(run: (A) -> B): CoreaderT<Id.F, A, B> = Cokleisli({ a: IdKind<A> -> run(a.ev().value) })
 
-    fun <A, B> pure(x: B): CoreaderT<Id.F, A, B> =
-            Cokleisli.pure<Id.F, A, B>(x)
+    fun <A, B> pure(x: B): CoreaderT<Id.F, A, B> = Cokleisli.pure<Id.F, A, B>(x)
 
-    fun <B> ask(): CoreaderT<Id.F, B, B> =
-            Cokleisli.ask<Id.F, B>()
+    fun <B> ask(): CoreaderT<Id.F, B, B> = Cokleisli.ask<Id.F, B>()
 }

--- a/kategory/src/main/kotlin/kategory/data/Either.kt
+++ b/kategory/src/main/kotlin/kategory/data/Either.kt
@@ -3,8 +3,7 @@ package kategory
 typealias EitherKind<A, B> = HK2<Either.F, A, B>
 typealias EitherF<L> = HK<Either.F, L>
 
-fun <A, B> EitherKind<A, B>.ev(): Either<A, B> =
-        this as Either<A, B>
+fun <A, B> EitherKind<A, B>.ev(): Either<A, B> = this as Either<A, B>
 
 /**
  * Port of https://github.com/scala/scala/blob/v2.12.1/src/library/scala/util/Either.scala
@@ -58,8 +57,7 @@ sealed class Either<out A, out B> : EitherKind<A, B> {
      * Right("right").swap() // Result: Left("right")
      * ```
      */
-    fun swap(): Either<B, A> =
-            fold({ Right(it) }, { Left(it) })
+    fun swap(): Either<B, A> = fold({ Right(it) }, { Left(it) })
 
     /**
      * The given function is applied if this is a `Right`.
@@ -70,14 +68,12 @@ sealed class Either<out A, out B> : EitherKind<A, B> {
      * Left(12).map { "flower" }  // Result: Left(12)
      * ```
      */
-    inline fun <C> map(crossinline f: (B) -> C): Either<A, C> =
-            fold({ Left(it) }, { Right(f(it)) })
+    inline fun <C> map(crossinline f: (B) -> C): Either<A, C> = fold({ Left(it) }, { Right(f(it)) })
 
     /**
      * Map over Left and Right of this Either
      */
-    inline fun <C, D> bimap(crossinline fa: (A) -> C, crossinline fb: (B) -> D): Either<C, D> =
-            fold({ Left(fa(it)) }, { Right(fb(it)) })
+    inline fun <C, D> bimap(crossinline fa: (A) -> C, crossinline fb: (B) -> D): Either<C, D> = fold({ Left(fa(it)) }, { Right(fb(it)) })
 
     /**
      * Returns `false` if [Left] or returns the result of the application of
@@ -92,8 +88,7 @@ sealed class Either<out A, out B> : EitherKind<A, B> {
      * left.exists { it > 10 }      // Result: false
      * ```
      */
-    inline fun exists(crossinline predicate: (B) -> Boolean): Boolean =
-            fold({ false }, { predicate(it) })
+    inline fun exists(crossinline predicate: (B) -> Boolean): Boolean = fold({ false }, { predicate(it) })
 
     /**
      * Returns a [Option.Some] containing the [Right] value
@@ -105,8 +100,7 @@ sealed class Either<out A, out B> : EitherKind<A, B> {
      * Left(12).toOption()  // Result: None
      * ```
      */
-    fun toOption(): Option<B> =
-            fold({ Option.None }, { Option.Some(it) })
+    fun toOption(): Option<B> = fold({ Option.None }, { Option.Some(it) })
 
     /**
      * The left side of the disjoint union, as opposed to the [Right] side.
@@ -116,8 +110,7 @@ sealed class Either<out A, out B> : EitherKind<A, B> {
         override internal val isRight = false
 
         companion object {
-            inline operator fun <A> invoke(a: A): Either<A, Nothing> =
-                    Left(a, Unit)
+            inline operator fun <A> invoke(a: A): Either<A, Nothing> = Left(a, Unit)
         }
     }
 
@@ -129,8 +122,7 @@ sealed class Either<out A, out B> : EitherKind<A, B> {
         override internal val isRight = true
 
         companion object {
-            inline operator fun <B> invoke(b: B): Either<Nothing, B> =
-                    Right(b, Unit)
+            inline operator fun <B> invoke(b: B): Either<Nothing, B> = Right(b, Unit)
         }
     }
 
@@ -165,8 +157,7 @@ sealed class Either<out A, out B> : EitherKind<A, B> {
  *
  * @param f The function to bind across [Either.Right].
  */
-inline fun <A, B, C> Either<A, B>.flatMap(crossinline f: (B) -> Either<A, C>): Either<A, C> =
-        fold({ Either.Left(it) }, { f(it) })
+inline fun <A, B, C> Either<A, B>.flatMap(crossinline f: (B) -> Either<A, C>): Either<A, C> = fold({ Either.Left(it) }, { f(it) })
 
 /**
  * Returns the value from this [Either.Right] or the given argument if this is a [Either.Left].
@@ -177,8 +168,7 @@ inline fun <A, B, C> Either<A, B>.flatMap(crossinline f: (B) -> Either<A, C>): E
  * Left(12).getOrElse(17)  // Result: 17
  * ```
  */
-inline fun <B> Either<*, B>.getOrElse(crossinline default: () -> B): B =
-        fold({ default() }, { it })
+inline fun <B> Either<*, B>.getOrElse(crossinline default: () -> B): B = fold({ default() }, { it })
 
 /**
  * * Returns [Either.Right] with the existing value of [Either.Right] if this is a [Either.Right] and the given predicate
@@ -196,8 +186,7 @@ inline fun <B> Either<*, B>.getOrElse(crossinline default: () -> B): B =
  * left.filterOrElse({ it > 10 }, { -1 })      // Result: Left(12)
  * ```
  */
-inline fun <A, B> Either<A, B>.filterOrElse(crossinline predicate: (B) -> Boolean, crossinline default: () -> A): Either<A, B> =
-        fold({ Either.Left(it) }, { if (predicate(it)) Either.Right(it) else Either.Left(default()) })
+inline fun <A, B> Either<A, B>.filterOrElse(crossinline predicate: (B) -> Boolean, crossinline default: () -> A): Either<A, B> = fold({ Either.Left(it) }, { if (predicate(it)) Either.Right(it) else Either.Left(default()) })
 
 /**
  * Returns `true` if this is a [Either.Right] and its value is equal to `elem` (as determined by `==`),
@@ -213,8 +202,7 @@ inline fun <A, B> Either<A, B>.filterOrElse(crossinline predicate: (B) -> Boolea
  * @param elem the element to test.
  * @return `true` if the option has an element that is equal (as determined by `==`) to `elem`, `false` otherwise.
  */
-fun <A, B> Either<A, B>.contains(elem: B): Boolean =
-        fold({ false }, { it == elem })
+fun <A, B> Either<A, B>.contains(elem: B): Boolean = fold({ false }, { it == elem })
 
 fun <A> A.left(): Either<A, Nothing> = Either.Left(this)
 

--- a/kategory/src/main/kotlin/kategory/data/EitherT.kt
+++ b/kategory/src/main/kotlin/kategory/data/EitherT.kt
@@ -3,8 +3,7 @@ package kategory
 typealias EitherTKind<F, A, B> = HK3<EitherT.F, F, A, B>
 typealias EitherTF<F, L> = HK2<EitherT.F, F, L>
 
-fun <F, A, B> EitherTKind<F, A, B>.ev(): EitherT<F, A, B> =
-        this as EitherT<F, A, B>
+fun <F, A, B> EitherTKind<F, A, B>.ev(): EitherT<F, A, B> = this as EitherT<F, A, B>
 
 /**
  * [EitherT]`<F, A, B>` is a light wrapper on an `F<`[Either]`<A, B>>` with some
@@ -18,20 +17,15 @@ data class EitherT<F, A, B>(val MF: Monad<F>, val value: HK<F, Either<A, B>>) : 
 
     companion object {
 
-        inline operator fun <reified F, A, B> invoke(value: HK<F, Either<A, B>>, MF: Monad<F> = monad<F>()): EitherT<F, A, B> =
-                EitherT(MF, value)
+        inline operator fun <reified F, A, B> invoke(value: HK<F, Either<A, B>>, MF: Monad<F> = monad<F>()): EitherT<F, A, B> = EitherT(MF, value)
 
-        @JvmStatic inline fun <reified F, A, B> pure(b: B, MF: Monad<F> = monad<F>()): EitherT<F, A, B> =
-                right(b, MF)
+        @JvmStatic inline fun <reified F, A, B> pure(b: B, MF: Monad<F> = monad<F>()): EitherT<F, A, B> = right(b, MF)
 
-        @JvmStatic inline fun <reified F, A, B> right(b: B, MF: Monad<F> = monad<F>()): EitherT<F, A, B> =
-                EitherT(MF, MF.pure(Either.Right(b)))
+        @JvmStatic inline fun <reified F, A, B> right(b: B, MF: Monad<F> = monad<F>()): EitherT<F, A, B> = EitherT(MF, MF.pure(Either.Right(b)))
 
-        @JvmStatic inline fun <reified F, A, B> left(a: A, MF: Monad<F> = monad<F>()): EitherT<F, A, B> =
-                EitherT(MF, MF.pure(Either.Left(a)))
+        @JvmStatic inline fun <reified F, A, B> left(a: A, MF: Monad<F> = monad<F>()): EitherT<F, A, B> = EitherT(MF, MF.pure(Either.Left(a)))
 
-        @JvmStatic inline fun <reified F, A, B> fromEither(value: Either<A, B>, MF: Monad<F> = monad<F>()): EitherT<F, A, B> =
-                EitherT(MF, MF.pure(value))
+        @JvmStatic inline fun <reified F, A, B> fromEither(value: Either<A, B>, MF: Monad<F> = monad<F>()): EitherT<F, A, B> = EitherT(MF, MF.pure(value))
 
         inline fun <F, L> instances(MF: Monad<F>): EitherTInstances<F, L> = object : EitherTInstances<F, L> {
             override fun MF(): Monad<F> = MF
@@ -58,44 +52,31 @@ data class EitherT<F, A, B>(val MF: Monad<F>, val value: HK<F, Either<A, B>>) : 
         }
     }
 
-    inline fun <C> fold(crossinline l: (A) -> C, crossinline r: (B) -> C): HK<F, C> =
-            MF.map(value, { either -> either.fold(l, r) })
+    inline fun <C> fold(crossinline l: (A) -> C, crossinline r: (B) -> C): HK<F, C> = MF.map(value, { either -> either.fold(l, r) })
 
-    inline fun <C> flatMap(crossinline f: (B) -> EitherT<F, A, C>): EitherT<F, A, C> =
-            flatMapF({ it -> f(it).value })
+    inline fun <C> flatMap(crossinline f: (B) -> EitherT<F, A, C>): EitherT<F, A, C> = flatMapF({ it -> f(it).value })
 
-    inline fun <C> flatMapF(crossinline f: (B) -> HK<F, Either<A, C>>): EitherT<F, A, C> =
-            EitherT(MF, MF.flatMap(value, { either -> either.fold({ MF.pure(Either.Left(it)) }, { f(it) }) }))
+    inline fun <C> flatMapF(crossinline f: (B) -> HK<F, Either<A, C>>): EitherT<F, A, C> = EitherT(MF, MF.flatMap(value, { either -> either.fold({ MF.pure(Either.Left(it)) }, { f(it) }) }))
 
-    inline fun <C> cata(crossinline l: (A) -> C, crossinline r: (B) -> C): HK<F, C> =
-            fold(l, r)
+    inline fun <C> cata(crossinline l: (A) -> C, crossinline r: (B) -> C): HK<F, C> = fold(l, r)
 
-    fun <C> liftF(fa: HK<F, C>): EitherT<F, A, C> =
-            EitherT(MF, MF.map(fa, { Either.Right(it) }))
+    fun <C> liftF(fa: HK<F, C>): EitherT<F, A, C> = EitherT(MF, MF.map(fa, { Either.Right(it) }))
 
-    inline fun <C> semiflatMap(crossinline f: (B) -> HK<F, C>): EitherT<F, A, C> =
-            flatMap({ liftF(f(it)) })
+    inline fun <C> semiflatMap(crossinline f: (B) -> HK<F, C>): EitherT<F, A, C> = flatMap({ liftF(f(it)) })
 
-    inline fun <C> map(crossinline f: (B) -> C): EitherT<F, A, C> =
-            EitherT(MF, MF.map(value, { it.map(f) }))
+    inline fun <C> map(crossinline f: (B) -> C): EitherT<F, A, C> = EitherT(MF, MF.map(value, { it.map(f) }))
 
-    inline fun exists(crossinline p: (B) -> Boolean): HK<F, Boolean> =
-            MF.map(value, { it.exists(p) })
+    inline fun exists(crossinline p: (B) -> Boolean): HK<F, Boolean> = MF.map(value, { it.exists(p) })
 
-    inline fun <C, D> transform(crossinline f: (Either<A, B>) -> Either<C, D>): EitherT<F, C, D> =
-            EitherT(MF, MF.map(value, { f(it) }))
+    inline fun <C, D> transform(crossinline f: (Either<A, B>) -> Either<C, D>): EitherT<F, C, D> = EitherT(MF, MF.map(value, { f(it) }))
 
-    inline fun <C> subflatMap(crossinline f: (B) -> Either<A, C>): EitherT<F, A, C> =
-            transform({ it.flatMap(f) })
+    inline fun <C> subflatMap(crossinline f: (B) -> Either<A, C>): EitherT<F, A, C> = transform({ it.flatMap(f) })
 
-    fun toOptionT(): OptionT<F, B> =
-            OptionT(MF, MF.map(value, { it.toOption() }))
+    fun toOptionT(): OptionT<F, B> = OptionT(MF, MF.map(value, { it.toOption() }))
 
-    fun <C> foldL(b: C, f: (C, B) -> C, FF: Foldable<F>): C =
-            FF.compose(Either.foldable<A>()).foldLC(value, b, f)
+    fun <C> foldL(b: C, f: (C, B) -> C, FF: Foldable<F>): C = FF.compose(Either.foldable<A>()).foldLC(value, b, f)
 
-    fun <C> foldR(lb: Eval<C>, f: (B, Eval<C>) -> Eval<C>, FF: Foldable<F>): Eval<C> =
-            FF.compose(Either.foldable<A>()).foldRC(value, lb, f)
+    fun <C> foldR(lb: Eval<C>, f: (B, Eval<C>) -> Eval<C>, FF: Foldable<F>): Eval<C> = FF.compose(Either.foldable<A>()).foldRC(value, lb, f)
 
     fun <G, C> traverse(f: (B) -> HK<G, C>, GA: Applicative<G>, FF: Traverse<F>, MF: Monad<F>): HK<G, HK<EitherTF<F, A>, C>> {
         val fa = ComposedTraverse(FF, Either.traverse<A>(), Either.monad<A>()).traverseC(value, f, GA)

--- a/kategory/src/main/kotlin/kategory/data/Eval.kt
+++ b/kategory/src/main/kotlin/kategory/data/Eval.kt
@@ -1,7 +1,6 @@
 package kategory
 
-fun <A> HK<Eval.F, A>.ev(): Eval<A> =
-        this as Eval<A>
+fun <A> HK<Eval.F, A>.ev(): Eval<A> = this as Eval<A>
 
 /**
  * Eval is a monad which controls evaluation of a value or a computation that produces a value.
@@ -37,8 +36,7 @@ sealed class Eval<out A> : HK<Eval.F, A> {
 
     abstract fun memoize(): Eval<A>
 
-    fun <B> map(f: (A) -> B): Eval<B> =
-            flatMap { a -> Now(f(a)) }
+    fun <B> map(f: (A) -> B): Eval<B> = flatMap { a -> Now(f(a)) }
 
     fun <B> flatMap(f: (A) -> Eval<B>): Eval<B> =
             when (this) {
@@ -156,8 +154,7 @@ sealed class Eval<out A> : HK<Eval.F, A> {
 
         abstract fun <S> run(s: S): Eval<A>
 
-        override fun memoize(): Eval<A> =
-                Later { value() }
+        override fun memoize(): Eval<A> = Later { value() }
 
         override fun value(): A {
             var curr: Eval<A> = this

--- a/kategory/src/main/kotlin/kategory/data/Id.kt
+++ b/kategory/src/main/kotlin/kategory/data/Id.kt
@@ -4,18 +4,15 @@ typealias IdKind<A> = HK<Id.F, A>
 
 fun <A> IdKind<A>.ev(): Id<A> = this as Id<A>
 
-fun <A> IdKind<A>.value(): A =
-        this.ev().value
+fun <A> IdKind<A>.value(): A = this.ev().value
 
 data class Id<out A>(val value: A) : IdKind<A> {
 
     class F private constructor()
 
-    inline fun <B> map(f: (A) -> B): Id<B> =
-            Id(f(value))
+    inline fun <B> map(f: (A) -> B): Id<B> = Id(f(value))
 
-    inline fun <B> flatMap(f: (A) -> Id<B>): Id<B> =
-            f(value)
+    inline fun <B> flatMap(f: (A) -> Id<B>): Id<B> = f(value)
 
     companion object : IdInstances, GlobalInstance<Bimonad<Id.F>>() {
         fun functor(): Functor<Id.F> = this

--- a/kategory/src/main/kotlin/kategory/data/Ior.kt
+++ b/kategory/src/main/kotlin/kategory/data/Ior.kt
@@ -7,8 +7,7 @@ typealias IorKind<A, B> = HK2<Ior.F, A, B>
 
 typealias IorF<L> = HK<Ior.F, L>
 
-fun <A, B> IorKind<A, B>.ev(): Ior<A, B> =
-        this as Ior<A, B>
+fun <A, B> IorKind<A, B>.ev(): Ior<A, B> = this as Ior<A, B>
 
 /**
  * Port of https://github.com/typelevel/cats/blob/v0.9.0/core/src/main/scala/cats/data/Ior.scala
@@ -289,14 +288,10 @@ inline fun <A, B, D> Ior<A, B>.flatMap(SA: Semigroup<A>, crossinline f: (B) -> I
 
 inline fun <A, B> Ior<A, B>.getOrElse(crossinline default: () -> B): B = fold({ default() }, { it }, { _, b -> b })
 
-fun <A, B> A.rightIor(): Ior<B, A> =
-        Ior.Right(this)
+fun <A, B> A.rightIor(): Ior<B, A> = Ior.Right(this)
 
-fun <A, B> A.leftIor(): Ior<A, B> =
-        Ior.Left(this)
+fun <A, B> A.leftIor(): Ior<A, B> = Ior.Left(this)
 
-fun <A, B> Pair<A, B>.bothIor(): Ior<A, B> =
-        Ior.Both(this.first, this.second)
+fun <A, B> Pair<A, B>.bothIor(): Ior<A, B> = Ior.Both(this.first, this.second)
 
-fun <A, B> Tuple2<A, B>.bothIor(): Ior<A, B> =
-        Ior.Both(this.a, this.b)
+fun <A, B> Tuple2<A, B>.bothIor(): Ior<A, B> = Ior.Both(this.a, this.b)

--- a/kategory/src/main/kotlin/kategory/data/NonEmptyList.kt
+++ b/kategory/src/main/kotlin/kategory/data/NonEmptyList.kt
@@ -2,8 +2,7 @@ package kategory
 
 typealias NonEmptyListKind<A> = HK<NonEmptyList.F, A>
 
-fun <A> NonEmptyListKind<A>.ev(): NonEmptyList<A> =
-        this as NonEmptyList<A>
+fun <A> NonEmptyListKind<A>.ev(): NonEmptyList<A> = this as NonEmptyList<A>
 
 /**
  * A List that can not be empty
@@ -20,28 +19,21 @@ class NonEmptyList<out A> private constructor(
 
     val size: Int = all.size
 
-    fun contains(element: @UnsafeVariance A): Boolean =
-            (head == element).or(tail.contains(element))
+    fun contains(element: @UnsafeVariance A): Boolean = (head == element).or(tail.contains(element))
 
-    fun containsAll(elements: Collection<@UnsafeVariance A>): Boolean =
-            elements.all { contains(it) }
+    fun containsAll(elements: Collection<@UnsafeVariance A>): Boolean = elements.all { contains(it) }
 
     fun isEmpty(): Boolean = false
 
-    fun <B> map(f: (A) -> B): NonEmptyList<B> =
-            NonEmptyList(f(head), tail.map(f))
+    fun <B> map(f: (A) -> B): NonEmptyList<B> = NonEmptyList(f(head), tail.map(f))
 
-    fun <B> flatMap(f: (A) -> NonEmptyList<B>): NonEmptyList<B> =
-            f(head) + tail.flatMap { f(it).all }
+    fun <B> flatMap(f: (A) -> NonEmptyList<B>): NonEmptyList<B> = f(head) + tail.flatMap { f(it).all }
 
-    operator fun plus(l: NonEmptyList<@UnsafeVariance A>): NonEmptyList<A> =
-            NonEmptyList(all + l.all)
+    operator fun plus(l: NonEmptyList<@UnsafeVariance A>): NonEmptyList<A> = NonEmptyList(all + l.all)
 
-    operator fun plus(l: List<@UnsafeVariance A>): NonEmptyList<A> =
-            NonEmptyList(all + l)
+    operator fun plus(l: List<@UnsafeVariance A>): NonEmptyList<A> = NonEmptyList(all + l)
 
-    operator fun plus(a: @UnsafeVariance A): NonEmptyList<A> =
-            NonEmptyList(all + a)
+    operator fun plus(a: @UnsafeVariance A): NonEmptyList<A> = NonEmptyList(all + a)
 
     fun iterator(): Iterator<A> = all.iterator()
 
@@ -77,5 +69,4 @@ class NonEmptyList<out A> private constructor(
     }
 }
 
-fun <A> A.nel(): NonEmptyList<A> =
-        NonEmptyList.of(this)
+fun <A> A.nel(): NonEmptyList<A> = NonEmptyList.of(this)

--- a/kategory/src/main/kotlin/kategory/data/NonEmptyList.kt
+++ b/kategory/src/main/kotlin/kategory/data/NonEmptyList.kt
@@ -56,13 +56,9 @@ class NonEmptyList<out A> private constructor(
         return true
     }
 
-    override fun hashCode(): Int {
-        return all.hashCode()
-    }
+    override fun hashCode(): Int = all.hashCode()
 
-    override fun toString(): String {
-        return "NonEmptyList(all=$all)"
-    }
+    override fun toString(): String = "NonEmptyList(all=$all)"
 
     companion object : NonEmptyListInstances, GlobalInstance<Bimonad<NonEmptyList.F>>() {
         @JvmStatic fun <A> of(head: A, vararg t: A): NonEmptyList<A> = NonEmptyList(head, t.asList())

--- a/kategory/src/main/kotlin/kategory/data/Option.kt
+++ b/kategory/src/main/kotlin/kategory/data/Option.kt
@@ -2,8 +2,7 @@ package kategory
 
 typealias OptionKind<A> = HK<Option.F, A>
 
-fun <A> OptionKind<A>.ev(): Option<A> =
-        this as Option<A>
+fun <A> OptionKind<A>.ev(): Option<A> = this as Option<A>
 
 /**
  * Port of https://github.com/scala/scala/blob/v2.12.1/src/library/scala/Option.scala
@@ -16,11 +15,9 @@ sealed class Option<out A> : OptionKind<A> {
     class F private constructor()
 
     companion object : OptionInstances, GlobalInstance<Monad<Option.F>>() {
-        @JvmStatic fun <A : Any> fromNullable(a: A?): Option<A> =
-                if (a != null) Option.Some(a) else Option.None
+        @JvmStatic fun <A : Any> fromNullable(a: A?): Option<A> = if (a != null) Option.Some(a) else Option.None
 
-        operator fun <A> invoke(a: A): Option<A> =
-                Option.Some(a)
+        operator fun <A> invoke(a: A): Option<A> = Option.Some(a)
 
         fun functor(): Functor<Option.F> = this
 
@@ -152,11 +149,8 @@ fun <B> Option<B>.getOrElse(default: () -> B): B = fold({ default() }, { it })
  *
  * @param default the default option if this is empty.
  */
-fun <A, B : A> Option<B>.orElse(alternative: () -> Option<B>): Option<B> =
-    if (isEmpty) alternative() else this
+fun <A, B : A> Option<B>.orElse(alternative: () -> Option<B>): Option<B> = if (isEmpty) alternative() else this
 
-fun <A> A.some(): Option<A> =
-        Option.Some(this)
+fun <A> A.some(): Option<A> = Option.Some(this)
 
-fun <A> none(): Option<A> =
-        Option.None
+fun <A> none(): Option<A> = Option.None

--- a/kategory/src/main/kotlin/kategory/data/OptionT.kt
+++ b/kategory/src/main/kotlin/kategory/data/OptionT.kt
@@ -3,8 +3,7 @@ package kategory
 typealias OptionTKind<F, A> = HK2<OptionT.F, F, A>
 typealias OptionTF<F> = HK<OptionT.F, F>
 
-fun <F, A> OptionTKind<F, A>.ev(): OptionT<F, A> =
-        this as OptionT<F, A>
+fun <F, A> OptionTKind<F, A>.ev(): OptionT<F, A> = this as OptionT<F, A>
 
 /**
  * [OptionT]`<F, A>` is a light wrapper on an `F<`[Option]`<A>>` with some
@@ -18,17 +17,13 @@ data class OptionT<F, A>(val MF: Monad<F>, val value: HK<F, Option<A>>) : Option
 
     companion object {
 
-        inline operator fun <reified F, A> invoke(value: HK<F, Option<A>>, MF: Monad<F> = kategory.monad<F>()): OptionT<F, A> =
-                OptionT(MF, value)
+        inline operator fun <reified F, A> invoke(value: HK<F, Option<A>>, MF: Monad<F> = kategory.monad<F>()): OptionT<F, A> = OptionT(MF, value)
 
-        @JvmStatic inline fun <reified F, A> pure(a: A, MF: Monad<F> = kategory.monad<F>()): OptionT<F, A> =
-                OptionT(MF, MF.pure(Option.Some(a)))
+        @JvmStatic inline fun <reified F, A> pure(a: A, MF: Monad<F> = kategory.monad<F>()): OptionT<F, A> = OptionT(MF, MF.pure(Option.Some(a)))
 
-        @JvmStatic inline fun <reified F> none(MF: Monad<F> = kategory.monad<F>()): OptionT<F, Nothing> =
-                OptionT(MF, MF.pure(Option.None))
+        @JvmStatic inline fun <reified F> none(MF: Monad<F> = kategory.monad<F>()): OptionT<F, Nothing> = OptionT(MF, MF.pure(Option.None))
 
-        @JvmStatic inline fun <reified F, A> fromOption(value: Option<A>, MF: Monad<F> = kategory.monad<F>()): OptionT<F, A> =
-                OptionT(MF, MF.pure(value))
+        @JvmStatic inline fun <reified F, A> fromOption(value: Option<A>, MF: Monad<F> = kategory.monad<F>()): OptionT<F, A> = OptionT(MF, MF.pure(value))
 
         inline fun <reified F> instances(MF: Monad<F> = kategory.monad<F>()): OptionTInstances<F> = object : OptionTInstances<F> {
             override fun MF(): Monad<F> = MF
@@ -57,45 +52,33 @@ data class OptionT<F, A>(val MF: Monad<F>, val value: HK<F, Option<A>>) : Option
         }
     }
 
-    inline fun <B> fold(crossinline default: () -> B, crossinline f: (A) -> B): HK<F, B> =
-            MF.map(value, { option -> option.fold(default, f) })
+    inline fun <B> fold(crossinline default: () -> B, crossinline f: (A) -> B): HK<F, B> = MF.map(value, { option -> option.fold(default, f) })
 
-    inline fun <B> cata(crossinline default: () -> B, crossinline f: (A) -> B): HK<F, B> =
-            fold(default, f)
+    inline fun <B> cata(crossinline default: () -> B, crossinline f: (A) -> B): HK<F, B> = fold(default, f)
 
     inline fun <B> flatMap(crossinline f: (A) -> OptionT<F, B>): OptionT<F, B> = flatMapF({ it -> f(it).value })
 
-    inline fun <B> flatMapF(crossinline f: (A) -> HK<F, Option<B>>): OptionT<F, B> =
-            OptionT(MF, MF.flatMap(value, { option -> option.fold({ MF.pure(Option.None) }, f) }))
+    inline fun <B> flatMapF(crossinline f: (A) -> HK<F, Option<B>>): OptionT<F, B> = OptionT(MF, MF.flatMap(value, { option -> option.fold({ MF.pure(Option.None) }, f) }))
 
     fun <B> liftF(fa: HK<F, B>): OptionT<F, B> = OptionT(MF, MF.map(fa, { Option.Some(it) }))
 
-    inline fun <B> semiflatMap(crossinline f: (A) -> HK<F, B>): OptionT<F, B> =
-            flatMap({ option -> liftF(f(option)) })
+    inline fun <B> semiflatMap(crossinline f: (A) -> HK<F, B>): OptionT<F, B> = flatMap({ option -> liftF(f(option)) })
 
-    inline fun <B> map(crossinline f: (A) -> B): OptionT<F, B> =
-            OptionT(MF, MF.map(value, { it.map(f) }))
+    inline fun <B> map(crossinline f: (A) -> B): OptionT<F, B> = OptionT(MF, MF.map(value, { it.map(f) }))
 
-    fun getOrElse(default: () -> A): HK<F, A> =
-            MF.map(value, { it.getOrElse(default) })
+    fun getOrElse(default: () -> A): HK<F, A> = MF.map(value, { it.getOrElse(default) })
 
-    inline fun getOrElseF(crossinline default: () -> HK<F, A>): HK<F, A> =
-            MF.flatMap(value, { it.fold(default, { MF.pure(it) }) })
+    inline fun getOrElseF(crossinline default: () -> HK<F, A>): HK<F, A> = MF.flatMap(value, { it.fold(default, { MF.pure(it) }) })
 
-    inline fun filter(crossinline p: (A) -> Boolean): OptionT<F, A> =
-            OptionT(MF, MF.map(value, { it.filter(p) }))
+    inline fun filter(crossinline p: (A) -> Boolean): OptionT<F, A> = OptionT(MF, MF.map(value, { it.filter(p) }))
 
-    inline fun forall(crossinline p: (A) -> Boolean): HK<F, Boolean> =
-            MF.map(value, { it.forall(p) })
+    inline fun forall(crossinline p: (A) -> Boolean): HK<F, Boolean> = MF.map(value, { it.forall(p) })
 
-    fun isDefined(): HK<F, Boolean> =
-            MF.map(value, { it.isDefined })
+    fun isDefined(): HK<F, Boolean> = MF.map(value, { it.isDefined })
 
-    fun isEmpty(): HK<F, Boolean> =
-            MF.map(value, { it.isEmpty })
+    fun isEmpty(): HK<F, Boolean> = MF.map(value, { it.isEmpty })
 
-    inline fun orElse(crossinline default: () -> OptionT<F, A>): OptionT<F, A> =
-            orElseF({ default().value })
+    inline fun orElse(crossinline default: () -> OptionT<F, A>): OptionT<F, A> = orElseF({ default().value })
 
     inline fun orElseF(crossinline default: () -> HK<F, Option<A>>): OptionT<F, A> =
             OptionT(MF, MF.flatMap(value) {
@@ -105,17 +88,13 @@ data class OptionT<F, A>(val MF: Monad<F>, val value: HK<F, Option<A>>) : Option
                 }
             })
 
-    inline fun <B> transform(crossinline f: (Option<A>) -> Option<B>): OptionT<F, B> =
-            OptionT(MF, MF.map(value, { f(it) }))
+    inline fun <B> transform(crossinline f: (Option<A>) -> Option<B>): OptionT<F, B> = OptionT(MF, MF.map(value, { f(it) }))
 
-    inline fun <B> subflatMap(crossinline f: (A) -> Option<B>): OptionT<F, B> =
-            transform({ it.flatMap(f) })
+    inline fun <B> subflatMap(crossinline f: (A) -> Option<B>): OptionT<F, B> = transform({ it.flatMap(f) })
 
-    fun <B> foldL(b: B, f: (B, A) -> B, FF: Foldable<F>): B =
-            FF.compose(Option).foldLC(value, b, f)
+    fun <B> foldL(b: B, f: (B, A) -> B, FF: Foldable<F>): B = FF.compose(Option).foldLC(value, b, f)
 
-    fun <B> foldR(lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>, FF: Foldable<F>): Eval<B> =
-            FF.compose(Option).foldRC(value, lb, f)
+    fun <B> foldR(lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>, FF: Foldable<F>): Eval<B> = FF.compose(Option).foldRC(value, lb, f)
 
     fun <G, B> traverse(f: (A) -> HK<G, B>, GA: Applicative<G>, FF: Traverse<F>, MF: Monad<F>): HK<G, HK<OptionTF<F>, B>> {
         val fa = ComposedTraverse(FF, Option, Option).traverseC(value, f, GA)

--- a/kategory/src/main/kotlin/kategory/data/Reader.kt
+++ b/kategory/src/main/kotlin/kategory/data/Reader.kt
@@ -1,26 +1,19 @@
 package kategory
 
-infix fun <A, B, C> ((B) -> C).compose(f: (A) -> B): (A) -> C =
-        { a: A -> this(f(a)) }
+infix fun <A, B, C> ((B) -> C).compose(f: (A) -> B): (A) -> C = { a: A -> this(f(a)) }
 
-infix fun <A, B, C> ((A) -> B).andThen(g: (B) -> C): (A) -> C =
-        { a: A -> g(this(a)) }
+infix fun <A, B, C> ((A) -> B).andThen(g: (B) -> C): (A) -> C = { a: A -> g(this(a)) }
 
-fun <D, A> ((D) -> A).reader(): ReaderT<Id.F, D, A> =
-        Reader(this, Id)
+fun <D, A> ((D) -> A).reader(): ReaderT<Id.F, D, A> = Reader(this, Id)
 
-fun <D, A> ReaderT<Id.F, D, A>.runId(d: D): A =
-        this.run(d).value()
+fun <D, A> ReaderT<Id.F, D, A>.runId(d: D): A = this.run(d).value()
 
 object Reader {
 
-    operator fun <D, A> invoke(run: (D) -> A, MF: Monad<Id.F> = Id): ReaderT<Id.F, D, A> =
-            Kleisli(run.andThen { Id(it) }, MF)
+    operator fun <D, A> invoke(run: (D) -> A, MF: Monad<Id.F> = Id): ReaderT<Id.F, D, A> = Kleisli(run.andThen { Id(it) }, MF)
 
-    fun <D, A> pure(x: A, MF: Monad<Id.F> = Id): ReaderT<Id.F, D, A> =
-            Kleisli.pure<Id.F, D, A>(x, Id)
+    fun <D, A> pure(x: A, MF: Monad<Id.F> = Id): ReaderT<Id.F, D, A> = Kleisli.pure<Id.F, D, A>(x, Id)
 
-    fun <D> ask(MF: Monad<Id.F> = Id): ReaderT<Id.F, D, D> =
-            Kleisli.ask<Id.F, D>(Id)
+    fun <D> ask(MF: Monad<Id.F> = Id): ReaderT<Id.F, D, D> = Kleisli.ask<Id.F, D>(Id)
 
 }

--- a/kategory/src/main/kotlin/kategory/data/State.kt
+++ b/kategory/src/main/kotlin/kategory/data/State.kt
@@ -1,9 +1,7 @@
 package kategory
 
 object State {
-    operator fun <S, A> invoke(run: (S) -> Tuple2<S, A>, MF: Monad<Id.F> = Id): StateT<Id.F, S, A> =
-            StateT(MF, Id(run.andThen { Id(it) }))
+    operator fun <S, A> invoke(run: (S) -> Tuple2<S, A>, MF: Monad<Id.F> = Id): StateT<Id.F, S, A> = StateT(MF, Id(run.andThen { Id(it) }))
 }
 
-fun <S, A> ((S) -> Tuple2<S, A>).state() : StateT<Id.F, S, A> =
-        State(this, Id)
+fun <S, A> ((S) -> Tuple2<S, A>).state() : StateT<Id.F, S, A> = State(this, Id)

--- a/kategory/src/main/kotlin/kategory/data/StateT.kt
+++ b/kategory/src/main/kotlin/kategory/data/StateT.kt
@@ -6,11 +6,9 @@ typealias StateTF<F, S> = HK2<StateT.F, F, S>
 typealias StateTFun<F, S, A> = (S) -> HK<F, Tuple2<S, A>>
 typealias StateTFunKind<F, S, A> = HK<F, StateTFun<F, S, A>>
 
-fun <F, S, A> StateTKind<F, S, A>.ev(): StateT<F, S, A> =
-        this as StateT<F, S, A>
+fun <F, S, A> StateTKind<F, S, A>.ev(): StateT<F, S, A> = this as StateT<F, S, A>
 
-fun <F, S, A> StateTKind<F, S, A>.runM(initial: S): HK<F, Tuple2<S, A>> =
-        (this as StateT<F, S, A>).run(initial)
+fun <F, S, A> StateTKind<F, S, A>.runM(initial: S): HK<F, Tuple2<S, A>> = (this as StateT<F, S, A>).run(initial)
 
 class StateT<F, S, A>(
         val MF: Monad<F>,
@@ -19,11 +17,9 @@ class StateT<F, S, A>(
     class F private constructor()
 
     companion object {
-        inline operator fun <reified F, S, A> invoke(noinline run: StateTFun<F, S, A>, MF: Monad<F> = monad<F>()): StateT<F, S, A> =
-                StateT(MF, MF.pure(run))
+        inline operator fun <reified F, S, A> invoke(noinline run: StateTFun<F, S, A>, MF: Monad<F> = monad<F>()): StateT<F, S, A> = StateT(MF, MF.pure(run))
 
-        fun <F, S, A> invokeF(runF: StateTFunKind<F, S, A>, MF: Monad<F>): StateT<F, S, A> =
-                StateT(MF, runF)
+        fun <F, S, A> invokeF(runF: StateTFunKind<F, S, A>, MF: Monad<F>): StateT<F, S, A> = StateT(MF, runF)
 
         inline fun <reified F, S> instances(MF: Monad<F> = monad<F>()): StateTInstances<F, S> = object : StateTInstances<F, S> {
             override fun MF(): Monad<F> = MF
@@ -44,8 +40,7 @@ class StateT<F, S, A>(
                 }
     }
 
-    fun <B> map(f: (A) -> B): StateT<F, S, B> =
-            transform { (s, a) -> Tuple2(s, f(a)) }
+    fun <B> map(f: (A) -> B): StateT<F, S, B> = transform { (s, a) -> Tuple2(s, f(a)) }
 
     fun <B, Z> map2(sb: StateT<F, S, B>, fn: (A, B) -> Z): StateT<F, S, Z> =
             invokeF(MF.map2(runF, sb.runF) { (ssa, ssb) ->
@@ -65,8 +60,7 @@ class StateT<F, S, A>(
                 }
             }.map { invokeF(it, MF) }
 
-    fun <B> product(sb: StateT<F, S, B>): StateT<F, S, Tuple2<A, B>> =
-            map2(sb) { a, b -> Tuple2(a, b) }
+    fun <B> product(sb: StateT<F, S, B>): StateT<F, S, Tuple2<A, B>> = map2(sb) { a, b -> Tuple2(a, b) }
 
     fun <B> flatMap(fas: (A) -> StateTKind<F, S, B>): StateT<F, S, B> =
             invokeF(
@@ -98,15 +92,11 @@ class StateT<F, S, A>(
                         }
                     }, MF)
 
-    fun run(initial: S): HK<F, Tuple2<S, A>> =
-            MF.flatMap(runF) { f -> f(initial) }
+    fun run(initial: S): HK<F, Tuple2<S, A>> = MF.flatMap(runF) { f -> f(initial) }
 
-    fun runA(s: S): HK<F, A> =
-            MF.map(run(s)) { it.b }
+    fun runA(s: S): HK<F, A> = MF.map(run(s)) { it.b }
 
-    fun runS(s: S): HK<F, S> =
-            MF.map(run(s)) { it.a }
+    fun runS(s: S): HK<F, S> = MF.map(run(s)) { it.a }
 }
 
-inline fun <reified F, S, A> StateTFunKind<F, S, A>.stateT(FT: Monad<F> = monad()): StateT<F, S, A> =
-        StateT(FT, this)
+inline fun <reified F, S, A> StateTFunKind<F, S, A>.stateT(FT: Monad<F> = monad()): StateT<F, S, A> = StateT(FT, this)

--- a/kategory/src/main/kotlin/kategory/data/Try.kt
+++ b/kategory/src/main/kotlin/kategory/data/Try.kt
@@ -2,8 +2,7 @@ package kategory
 
 typealias TryKind<A> = HK<Try.F, A>
 
-fun <A> TryKind<A>.ev(): Try<A> =
-        this as Try<A>
+fun <A> TryKind<A>.ev(): Try<A> = this as Try<A>
 
 /**
  * The `Try` type represents a computation that may either result in an exception, or return a
@@ -24,8 +23,7 @@ sealed class Try<out A> : TryKind<A> {
                     Failure(e)
                 }
 
-        fun <A> raise(e: Exception): Try<A> =
-                Failure(e)
+        fun <A> raise(e: Exception): Try<A> = Failure(e)
 
         fun functor(): Functor<Try.F> = this
 
@@ -44,14 +42,12 @@ sealed class Try<out A> : TryKind<A> {
     /**
      * Returns the given function applied to the value from this `Success` or returns this if this is a `Failure`.
      */
-    inline fun <B> flatMap(crossinline f: (A) -> Try<B>): Try<B> =
-            fold({ Failure(it) }, { f(it) })
+    inline fun <B> flatMap(crossinline f: (A) -> Try<B>): Try<B> = fold({ Failure(it) }, { f(it) })
 
     /**
      * Maps the given function to the value from this `Success` or returns this if this is a `Failure`.
      */
-    inline fun <B> map(crossinline f: (A) -> B): Try<B> =
-            fold({ Failure(it) }, { Success(f(it)) })
+    inline fun <B> map(crossinline f: (A) -> B): Try<B> = fold({ Failure(it) }, { Success(f(it)) })
 
     /**
      * Converts this to a `Failure` if the predicate is not satisfied.
@@ -108,29 +104,24 @@ sealed class TryException(override val message: String) : kotlin.Exception(messa
  *
  * ''Note:'': This will throw an exception if it is not a success and default throws an exception.
  */
-fun <B> Try<B>.getOrElse(default: () -> B): B =
-        fold({ default() }, { it })
+fun <B> Try<B>.getOrElse(default: () -> B): B = fold({ default() }, { it })
 
 /**
  * Applies the given function `f` if this is a `Failure`, otherwise returns this if this is a `Success`.
  * This is like `flatMap` for the exception.
  */
-fun <B> Try<B>.recoverWith(f: (Throwable) -> Try<B>): Try<B> =
-        fold({ f(it) }, { Try.Success(it) })
+fun <B> Try<B>.recoverWith(f: (Throwable) -> Try<B>): Try<B> = fold({ f(it) }, { Try.Success(it) })
 
 /**
  * Applies the given function `f` if this is a `Failure`, otherwise returns this if this is a `Success`.
  * This is like map for the exception.
  */
-fun <B> Try<B>.recover(f: (Throwable) -> B): Try<B> =
-        fold({ Try.Success(f(it)) }, { Try.Success(it) })
+fun <B> Try<B>.recover(f: (Throwable) -> B): Try<B> = fold({ Try.Success(f(it)) }, { Try.Success(it) })
 
 /**
  * Completes this `Try` by applying the function `f` to this if this is of type `Failure`,
  * or conversely, by applying `s` if this is a `Success`.
  */
-fun <B> Try<B>.transform(s: (B) -> Try<B>, f: (Throwable) -> Try<B>): Try<B> =
-        fold({ f(it) }, { flatMap(s) })
+fun <B> Try<B>.transform(s: (B) -> Try<B>, f: (Throwable) -> Try<B>): Try<B> = fold({ f(it) }, { flatMap(s) })
 
-fun <A> (() -> A).try_(): Try<A> =
-        Try(this)
+fun <A> (() -> A).try_(): Try<A> = Try(this)

--- a/kategory/src/main/kotlin/kategory/data/Validated.kt
+++ b/kategory/src/main/kotlin/kategory/data/Validated.kt
@@ -15,23 +15,19 @@ sealed class Validated<out E, out A> : ValidatedKind<E, A> {
 
     companion object {
 
-        @JvmStatic fun <E, A> invalidNel(e: E): ValidatedNel<E, A> =
-                Validated.Invalid(NonEmptyList(e, listOf()))
+        @JvmStatic fun <E, A> invalidNel(e: E): ValidatedNel<E, A> = Validated.Invalid(NonEmptyList(e, listOf()))
 
-        @JvmStatic fun <E, A> validNel(a: A): ValidatedNel<E, A> =
-                Validated.Valid(a)
+        @JvmStatic fun <E, A> validNel(a: A): ValidatedNel<E, A> = Validated.Valid(a)
 
         /**
          * Converts a `Try<A>` to a `Validated<Throwable, A>`.
          */
-        @JvmStatic fun <A> fromTry(t: Try<A>): Validated<Throwable, A> =
-                t.fold({ Invalid(it) }, { Valid(it) })
+        @JvmStatic fun <A> fromTry(t: Try<A>): Validated<Throwable, A> = t.fold({ Invalid(it) }, { Valid(it) })
 
         /**
          * Converts an `Either<A, B>` to an `Validated<A, B>`.
          */
-        @JvmStatic fun <E, A> fromEither(e: Either<E, A>): Validated<E, A> =
-                e.fold({ Invalid(it) }, { Valid(it) })
+        @JvmStatic fun <E, A> fromEither(e: Either<E, A>): Validated<E, A> = e.fold({ Invalid(it) }, { Valid(it) })
 
         /**
          * Converts an `Option<B>` to an `Validated<A, B>`, where the provided `ifNone` values is returned on
@@ -79,27 +75,23 @@ sealed class Validated<out E, out A> : ValidatedKind<E, A> {
     /**
      * Is this Valid and matching the given predicate
      */
-    fun exist(predicate: (A) -> Boolean): Boolean =
-            fold({ false }, { predicate(it) })
+    fun exist(predicate: (A) -> Boolean): Boolean = fold({ false }, { predicate(it) })
 
     /**
      * Converts the value to an Either<E, A>
      */
-    fun toEither(): Either<E, A> =
-            fold({ Either.Left(it) }, { Either.Right(it) })
+    fun toEither(): Either<E, A> = fold({ Either.Left(it) }, { Either.Right(it) })
 
     /**
      * Returns Valid values wrapped in Some, and None for Invalid values
      */
-    fun toOption(): Option<A> =
-            fold({ Option.None }, { Option.Some(it) })
+    fun toOption(): Option<A> = fold({ Option.None }, { Option.Some(it) })
 
     /**
      * Convert this value to a single element List if it is Valid,
      * otherwise return an empty List
      */
-    fun toList(): List<A> =
-            fold({ listOf() }, { listOf(it) })
+    fun toList(): List<A> = fold({ listOf() }, { listOf(it) })
 
     /** Lift the Invalid value into a NonEmptyList. */
     fun toValidatedNel(): ValidatedNel<E, A> =
@@ -112,51 +104,43 @@ sealed class Validated<out E, out A> : ValidatedKind<E, A> {
      * Convert to an Either, apply a function, convert back. This is handy
      * when you want to use the Monadic properties of the Either type.
      */
-    fun <EE, B> withEither(f: (Either<E, A>) -> Either<EE, B>): Validated<EE, B> =
-            Validated.fromEither(f(toEither()))
+    fun <EE, B> withEither(f: (Either<E, A>) -> Either<EE, B>): Validated<EE, B> = Validated.fromEither(f(toEither()))
 
     /**
      * Validated is a [[functor.Bifunctor]], this method applies one of the
      * given functions.
      */
-    fun <EE, AA> bimap(fe: (E) -> EE, fa: (A) -> AA): Validated<EE, AA> =
-            fold({ Invalid(fe(it)) }, { Valid(fa(it)) })
+    fun <EE, AA> bimap(fe: (E) -> EE, fa: (A) -> AA): Validated<EE, AA> = fold({ Invalid(fe(it)) }, { Valid(fa(it)) })
 
     /**
      * Apply a function to a Valid value, returning a new Valid value
      */
-    fun <B> map(f: (A) -> B): Validated<E, B> =
-            bimap({ it }, { f(it) })
+    fun <B> map(f: (A) -> B): Validated<E, B> = bimap({ it }, { f(it) })
 
     /**
      * Apply a function to an Invalid value, returning a new Invalid value.
      * Or, if the original valid was Valid, return it.
      */
-    fun <EE> leftMap(f: (E) -> EE): Validated<EE, A> =
-            bimap({ f(it) }, { it })
+    fun <EE> leftMap(f: (E) -> EE): Validated<EE, A> = bimap({ f(it) }, { it })
 
     /**
      * apply the given function to the value with the given B when
      * valid, otherwise return the given B
      */
-    fun <B> foldLeft(b: B, f: (B, A) -> B): B =
-            fold({ b }, { f(b, it) })
+    fun <B> foldLeft(b: B, f: (B, A) -> B): B = fold({ b }, { f(b, it) })
 
-    fun swap(): Validated<A, E> =
-            fold({ Valid(it) }, { Invalid(it) })
+    fun swap(): Validated<A, E> = fold({ Valid(it) }, { Invalid(it) })
 }
 
 /**
  * Return the Valid value, or the default if Invalid
  */
-fun <E, B> Validated<E, B>.getOrElse(default: () -> B): B =
-        fold({ default() }, { it })
+fun <E, B> Validated<E, B>.getOrElse(default: () -> B): B = fold({ default() }, { it })
 
 /**
  * Return the Valid value, or the result of f if Invalid
  */
-fun <E, B> Validated<E, B>.valueOr(f: (E) -> B): B =
-        fold({ f(it) }, { it })
+fun <E, B> Validated<E, B>.valueOr(f: (E) -> B): B = fold({ f(it) }, { it })
 
 /**
  * If `this` is valid return `this`, otherwise if `that` is valid return `that`, otherwise combine the failures.
@@ -199,14 +183,10 @@ fun <E, A, B> Validated<E, A>.ap(f: Validated<E, (A) -> B>, SE: Semigroup<E>): V
             }
         }
 
-fun <E, A> A.valid(): Validated<E, A> =
-        Validated.Valid(this)
+fun <E, A> A.valid(): Validated<E, A> = Validated.Valid(this)
 
-fun <E, A> E.invalid(): Validated<E, A> =
-        Validated.Invalid(this)
+fun <E, A> E.invalid(): Validated<E, A> = Validated.Invalid(this)
 
-fun <E, A> A.validNel(): ValidatedNel<E, A> =
-        Validated.validNel(this)
+fun <E, A> A.validNel(): ValidatedNel<E, A> = Validated.validNel(this)
 
-fun <E, A> E.invalidNel(): ValidatedNel<E, A> =
-        Validated.invalidNel(this)
+fun <E, A> E.invalidNel(): ValidatedNel<E, A> = Validated.invalidNel(this)

--- a/kategory/src/main/kotlin/kategory/data/WriterT.kt
+++ b/kategory/src/main/kotlin/kategory/data/WriterT.kt
@@ -3,24 +3,19 @@ package kategory
 typealias WriterTKind<F, W, A> = HK3<WriterT.F, F, W, A>
 typealias WriterF<F, W> = HK2<WriterT.F, F, W>
 
-fun <F, A, B> WriterTKind<F, A, B>.ev(): WriterT<F, A, B> =
-        this as WriterT<F, A, B>
+fun <F, A, B> WriterTKind<F, A, B>.ev(): WriterT<F, A, B> = this as WriterT<F, A, B>
 
 data class WriterT<F, W, A>(val MF: Monad<F>, val value: HK<F, Tuple2<W, A>>) : WriterTKind<F, W, A> {
     class F private constructor()
 
     companion object {
-        inline fun <reified F, reified W, A> pure(a: A, MM: Monoid<W> = monoid(), MF: Monad<F> = kategory.monad()) =
-                WriterT(MF.pure(MM.empty() toT a), MF)
+        inline fun <reified F, reified W, A> pure(a: A, MM: Monoid<W> = monoid(), MF: Monad<F> = kategory.monad()) = WriterT(MF.pure(MM.empty() toT a), MF)
 
-        inline fun <reified F, W, A> both(w: W, a: A, MF: Monad<F> = kategory.monad()) =
-                WriterT(MF.pure(w toT a), MF)
+        inline fun <reified F, W, A> both(w: W, a: A, MF: Monad<F> = kategory.monad()) = WriterT(MF.pure(w toT a), MF)
 
-        inline fun <reified F, W, A> fromTuple(z: Tuple2<W, A>, MF: Monad<F> = kategory.monad()) =
-                WriterT(MF.pure(z), MF)
+        inline fun <reified F, W, A> fromTuple(z: Tuple2<W, A>, MF: Monad<F> = kategory.monad()) = WriterT(MF.pure(z), MF)
 
-        inline operator fun <reified F, W, A> invoke(value: HK<F, Tuple2<W, A>>, MF: Monad<F> = kategory.monad()) =
-                WriterT(MF, value)
+        inline operator fun <reified F, W, A> invoke(value: HK<F, Tuple2<W, A>>, MF: Monad<F> = kategory.monad()) = WriterT(MF, value)
 
         inline fun <reified F, reified W> instances(MM: Monad<F> = kategory.monad<F>(), SG: Monoid<W> = kategory.monoid<W>()): WriterTInstances<F, W> = object : WriterTInstances<F, W> {
             override fun MM(): Monad<F> = MM
@@ -47,42 +42,29 @@ data class WriterT<F, W, A>(val MF: Monad<F>, val value: HK<F, Tuple2<W, A>>) : 
         }
     }
 
-    fun tell(w: W, SG: Semigroup<W>): WriterT<F, W, A> =
-            mapAcc { SG.combine(it, w) }
+    fun tell(w: W, SG: Semigroup<W>): WriterT<F, W, A> = mapAcc { SG.combine(it, w) }
 
-    fun content(): HK<F, A> =
-            MF.map(value, { it.b })
+    fun content(): HK<F, A> = MF.map(value, { it.b })
 
-    fun write(): HK<F, W> =
-            MF.map(value, { it.a })
+    fun write(): HK<F, W> = MF.map(value, { it.a })
 
-    fun reset(MM: Monoid<W>): WriterT<F, W, A> =
-            mapAcc { MM.empty() }
+    fun reset(MM: Monoid<W>): WriterT<F, W, A> = mapAcc { MM.empty() }
 
-    inline fun <B> map(crossinline f: (A) -> B): WriterT<F, W, B> =
-            WriterT(MF, MF.map(value, { it.a toT f(it.b) }))
+    inline fun <B> map(crossinline f: (A) -> B): WriterT<F, W, B> = WriterT(MF, MF.map(value, { it.a toT f(it.b) }))
 
-    inline fun <U> mapAcc(crossinline f: (W) -> U): WriterT<F, U, A> =
-            transform { f(it.a) toT it.b }
+    inline fun <U> mapAcc(crossinline f: (W) -> U): WriterT<F, U, A> = transform { f(it.a) toT it.b }
 
-    inline fun <C, U> bimap(crossinline g: (W) -> U, crossinline f: (A) -> C): WriterT<F, U, C> =
-            transform { g(it.a) toT f(it.b) }
+    inline fun <C, U> bimap(crossinline g: (W) -> U, crossinline f: (A) -> C): WriterT<F, U, C> = transform { g(it.a) toT f(it.b) }
 
-    fun swap(): WriterT<F, A, W> =
-            transform { it.b toT it.a }
+    fun swap(): WriterT<F, A, W> = transform { it.b toT it.a }
 
-    inline fun <B> flatMap(crossinline f: (A) -> WriterT<F, W, B>, SG: Semigroup<W>): WriterT<F, W, B> =
-            WriterT(MF, MF.flatMap(value, { value -> MF.map(f(value.b).value, { SG.combine(it.a, value.a) toT it.b }) }))
+    inline fun <B> flatMap(crossinline f: (A) -> WriterT<F, W, B>, SG: Semigroup<W>): WriterT<F, W, B> = WriterT(MF, MF.flatMap(value, { value -> MF.map(f(value.b).value, { SG.combine(it.a, value.a) toT it.b }) }))
 
-    inline fun <B, U> transform(crossinline f: (Tuple2<W, A>) -> Tuple2<U, B>): WriterT<F, U, B> =
-            WriterT(MF, MF.flatMap(value, { MF.pure(f(it)) }))
+    inline fun <B, U> transform(crossinline f: (Tuple2<W, A>) -> Tuple2<U, B>): WriterT<F, U, B> = WriterT(MF, MF.flatMap(value, { MF.pure(f(it)) }))
 
-    fun <B> liftF(fa: HK<F, B>): WriterT<F, W, B> =
-            WriterT(MF, MF.map2(fa, value, { it.b.a toT it.a }))
+    fun <B> liftF(fa: HK<F, B>): WriterT<F, W, B> = WriterT(MF, MF.map2(fa, value, { it.b.a toT it.a }))
 
-    inline fun <C> semiflatMap(crossinline f: (A) -> HK<F, C>, SG: Semigroup<W>): WriterT<F, W, C> =
-            flatMap({ liftF(f(it)) }, SG)
+    inline fun <C> semiflatMap(crossinline f: (A) -> HK<F, C>, SG: Semigroup<W>): WriterT<F, W, C> = flatMap({ liftF(f(it)) }, SG)
 
-    inline fun <B> subflatMap(crossinline f: (A) -> Tuple2<W, B>): WriterT<F, W, B> =
-            transform({ f(it.b) })
+    inline fun <B> subflatMap(crossinline f: (A) -> Tuple2<W, B>): WriterT<F, W, B> = transform({ f(it.b) })
 }

--- a/kategory/src/main/kotlin/kategory/effects/internal/AndThen.kt
+++ b/kategory/src/main/kotlin/kategory/effects/internal/AndThen.kt
@@ -12,14 +12,11 @@ internal sealed class AndThen<in A, out B> : (A) -> B {
     internal data class ErrorHandler<in A, out B>(val fa: (A) -> B, val fe: (Throwable) -> B) : AndThen<A, B>()
     internal data class Concat<in A, E, out B>(val left: AndThen<A, E>, val right: AndThen<E, B>) : AndThen<A, B>()
 
-    fun <C> andThen(g: AndThen<B, C>): AndThen<A, C> =
-            Concat(this, g)
+    fun <C> andThen(g: AndThen<B, C>): AndThen<A, C> = Concat(this, g)
 
-    fun <C> compose(g: AndThen<C, A>): AndThen<C, B> =
-            Concat(g, this)
+    fun <C> compose(g: AndThen<C, A>): AndThen<C, B> = Concat(g, this)
 
-    override operator fun invoke(a: A): B =
-            runLoop(a, null, true)
+    override operator fun invoke(a: A): B = runLoop(a, null, true)
 
     /**
      * Abandon all hope
@@ -121,11 +118,9 @@ internal sealed class AndThen<in A, out B> : (A) -> B {
     }
 
     companion object {
-        operator fun <A, B> invoke(f: (A) -> B): AndThen<A, B> =
-                Single(f)
+        operator fun <A, B> invoke(f: (A) -> B): AndThen<A, B> = Single(f)
 
-        operator fun <A, B> invoke(fa: (A) -> B, fb: (Throwable) -> B): AndThen<A, B> =
-                ErrorHandler(fa, fb)
+        operator fun <A, B> invoke(fa: (A) -> B, fb: (Throwable) -> B): AndThen<A, B> = ErrorHandler(fa, fb)
     }
 }
 

--- a/kategory/src/main/kotlin/kategory/free/CoYoneda.kt
+++ b/kategory/src/main/kotlin/kategory/free/CoYoneda.kt
@@ -4,8 +4,7 @@ typealias CoYonedaKind<U, P, A> = HK3<CoYoneda.F, U, P, A>
 
 typealias CoYonedaF<U, P> = HK2<CoYoneda.F, U, P>
 
-fun <U, A, B> CoYonedaKind<U, A, B>.ev(): CoYoneda<U, A, B> =
-        this as CoYoneda<U, A, B>
+fun <U, A, B> CoYonedaKind<U, A, B>.ev(): CoYoneda<U, A, B> = this as CoYoneda<U, A, B>
 
 private typealias AnyFunc = (Any?) -> Any?
 
@@ -18,12 +17,10 @@ data class CoYoneda<F, P, A>(val pivot: HK<F, P>, internal val ks: List<AnyFunc>
         curr as A
     }
 
-    fun lower(FF: Functor<F>): HK<F, A> =
-            FF.map(pivot, transform)
+    fun lower(FF: Functor<F>): HK<F, A> = FF.map(pivot, transform)
 
     @Suppress("UNCHECKED_CAST")
-    fun <B> map(f: (A) -> B): CoYoneda<F, P, B> =
-            CoYoneda(pivot, ks + f as AnyFunc)
+    fun <B> map(f: (A) -> B): CoYoneda<F, P, B> = CoYoneda(pivot, ks + f as AnyFunc)
 
     fun toYoneda(FF: Functor<F>): Yoneda<F, A> =
             object : Yoneda<F, A> {
@@ -32,11 +29,9 @@ data class CoYoneda<F, P, A>(val pivot: HK<F, P>, internal val ks: List<AnyFunc>
 
     companion object {
         @Suppress("UNCHECKED_CAST")
-        inline fun <reified U, A, B> apply(fa: HK<U, A>, noinline f: (A) -> B): CoYoneda<U, A, B> =
-                unsafeApply(fa, listOf(f as AnyFunc))
+        inline fun <reified U, A, B> apply(fa: HK<U, A>, noinline f: (A) -> B): CoYoneda<U, A, B> = unsafeApply(fa, listOf(f as AnyFunc))
 
-        inline fun <reified U, A, B> unsafeApply(fa: HK<U, A>, f: List<AnyFunc>): CoYoneda<U, A, B> =
-                CoYoneda(fa, f)
+        inline fun <reified U, A, B> unsafeApply(fa: HK<U, A>, f: List<AnyFunc>): CoYoneda<U, A, B> = CoYoneda(fa, f)
 
         fun <U, P> functor(): Functor<CoYonedaF<U, P>> = object : CoYonedaInstances<U, P> {}
 

--- a/kategory/src/main/kotlin/kategory/free/Cofree.kt
+++ b/kategory/src/main/kotlin/kategory/free/Cofree.kt
@@ -5,54 +5,40 @@ typealias CofreeF<S> = HK<Cofree.F, S>
 
 typealias CofreeEval<S, A> = HK<S, Cofree<S, A>>
 
-fun <S, A> CofreeKind<S, A>.ev(): Cofree<S, A> =
-        this as Cofree<S, A>
+fun <S, A> CofreeKind<S, A>.ev(): Cofree<S, A> = this as Cofree<S, A>
 
 data class Cofree<S, A>(val FS: Functor<S>, val head: A, val tail: Eval<CofreeEval<S, A>>) : CofreeKind<S, A> {
 
     class F private constructor()
 
-    fun tailForced(): CofreeEval<S, A> =
-            tail.value()
+    fun tailForced(): CofreeEval<S, A> = tail.value()
 
-    inline fun <B> transform(f: (A) -> B, noinline g: (Cofree<S, A>) -> Cofree<S, B>): Cofree<S, B> =
-            Cofree(FS, f(head), tail.map { FS.map(it, g) })
+    inline fun <B> transform(f: (A) -> B, noinline g: (Cofree<S, A>) -> Cofree<S, B>): Cofree<S, B> = Cofree(FS, f(head), tail.map { FS.map(it, g) })
 
-    fun <B> map(f: (A) -> B): Cofree<S, B> =
-            transform(f, { it.map(f) })
+    fun <B> map(f: (A) -> B): Cofree<S, B> = transform(f, { it.map(f) })
 
-    fun mapBranchingRoot(fk: FunctionK<S, S>): Cofree<S, A> =
-            Cofree(FS, head, tail.map { fk(it) })
+    fun mapBranchingRoot(fk: FunctionK<S, S>): Cofree<S, A> = Cofree(FS, head, tail.map { fk(it) })
 
     // Due to the recursive nature of this function, it cannot be reified for FT to use functor<T>()
-    fun <T> mapBranchingS(fk: FunctionK<S, T>, FT: Functor<T>): Cofree<T, A> =
-            Cofree(FT, head, tail.map { ce -> fk(FS.map(ce, { it.mapBranchingS(fk, FT) })) })
+    fun <T> mapBranchingS(fk: FunctionK<S, T>, FT: Functor<T>): Cofree<T, A> = Cofree(FT, head, tail.map { ce -> fk(FS.map(ce, { it.mapBranchingS(fk, FT) })) })
 
     // Due to the recursive nature of this function, it cannot be reified for FT to use functor<T>()
-    fun <T> mapBranchingT(fk: FunctionK<S, T>, FT: Functor<T>): Cofree<T, A> =
-            Cofree(FT, head, tail.map { ce -> FT.map(fk(ce), { it.mapBranchingT(fk, FT) }) })
+    fun <T> mapBranchingT(fk: FunctionK<S, T>, FT: Functor<T>): Cofree<T, A> = Cofree(FT, head, tail.map { ce -> FT.map(fk(ce), { it.mapBranchingT(fk, FT) }) })
 
-    fun <B> coflatMap(f: (Cofree<S, A>) -> B): Cofree<S, B> =
-            Cofree(FS, f(this), tail.map { FS.map(it, { coflatMap(f) }) })
+    fun <B> coflatMap(f: (Cofree<S, A>) -> B): Cofree<S, B> = Cofree(FS, f(this), tail.map { FS.map(it, { coflatMap(f) }) })
 
-    fun duplicate(): Cofree<S, Cofree<S, A>> =
-            Cofree(FS, this, tail.map { FS.map(it, { duplicate() }) })
+    fun duplicate(): Cofree<S, Cofree<S, A>> = Cofree(FS, this, tail.map { FS.map(it, { duplicate() }) })
 
-    fun runTail(): Cofree<S, A> =
-            Cofree(FS, head, Eval.now(tail.value()))
+    fun runTail(): Cofree<S, A> = Cofree(FS, head, Eval.now(tail.value()))
 
-    fun run(): Cofree<S, A> =
-            Cofree(FS, head, Eval.now(tail.map { FS.map(it, { it.run() }) }.value()))
+    fun run(): Cofree<S, A> = Cofree(FS, head, Eval.now(tail.map { FS.map(it, { it.run() }) }.value()))
 
-    fun extract(): A =
-            head
+    fun extract(): A = head
 
     companion object {
-        inline fun <reified S, A> unfold(a: A, noinline f: (A) -> HK<S, A>, FS: Functor<S> = functor<S>()): Cofree<S, A> =
-                create(a, f, FS)
+        inline fun <reified S, A> unfold(a: A, noinline f: (A) -> HK<S, A>, FS: Functor<S> = functor<S>()): Cofree<S, A> = create(a, f, FS)
 
-        fun <S, A> create(a: A, f: (A) -> HK<S, A>, FS: Functor<S>): Cofree<S, A> =
-                Cofree(FS, a, Eval.later { FS.map(f(a), { create(it, f, FS) }) })
+        fun <S, A> create(a: A, f: (A) -> HK<S, A>, FS: Functor<S>): Cofree<S, A> = Cofree(FS, a, Eval.later { FS.map(f(a), { create(it, f, FS) }) })
 
         fun <S> comonad() : CofreeInstances<S> = object : CofreeInstances<S> {}
     }

--- a/kategory/src/main/kotlin/kategory/free/Free.kt
+++ b/kategory/src/main/kotlin/kategory/free/Free.kt
@@ -3,25 +3,20 @@ package kategory
 typealias FreeKind<S, A> = HK2<Free.F, S, A>
 typealias FreeF<S> = HK<Free.F, S>
 
-fun <S, A> FreeKind<S, A>.ev(): Free<S, A> =
-        this as Free<S, A>
+fun <S, A> FreeKind<S, A>.ev(): Free<S, A> = this as Free<S, A>
 
-inline fun <reified M, S, A> FreeKind<S, A>.foldMapK(f: FunctionK<S, M>, MM: Monad<M> = monad()): HK<M, A> =
-        (this as Free<S, A>).foldMap(f, MM)
+inline fun <reified M, S, A> FreeKind<S, A>.foldMapK(f: FunctionK<S, M>, MM: Monad<M> = monad()): HK<M, A> = (this as Free<S, A>).foldMap(f, MM)
 
 sealed class Free<out S, out A> : FreeKind<S, A> {
 
     class F private constructor()
 
     companion object {
-        fun <S, A> pure(a: A): Free<S, A> =
-                Pure(a)
+        fun <S, A> pure(a: A): Free<S, A> = Pure(a)
 
-        fun <S, A> liftF(fa: HK<S, A>): Free<S, A> =
-                Suspend(fa)
+        fun <S, A> liftF(fa: HK<S, A>): Free<S, A> = Suspend(fa)
 
-        fun <S, A> defer(value: () -> Free<S, A>): Free<S, A> =
-                pure<S, Unit>(Unit).flatMap { _ -> value() }
+        fun <S, A> defer(value: () -> Free<S, A>): Free<S, A> = pure<S, Unit>(Unit).flatMap { _ -> value() }
 
         fun <S> functor(): FreeInstances<S> = object : FreeInstances<S> {}
 
@@ -52,28 +47,23 @@ sealed class Free<out S, out A> : FreeKind<S, A> {
     abstract fun <O, B> transform(f: (A) -> B, fs: FunctionK<S, O>): Free<O, B>
 
     data class Pure<out S, out A>(val a: A) : Free<S, A>() {
-        override fun <O, B> transform(f: (A) -> B, fs: FunctionK<S, O>): Free<O, B> =
-                Free.pure(f(a))
+        override fun <O, B> transform(f: (A) -> B, fs: FunctionK<S, O>): Free<O, B> = Free.pure(f(a))
     }
 
     data class Suspend<out S, out A>(val a: HK<S, A>) : Free<S, A>() {
-        override fun <O, B> transform(f: (A) -> B, fs: FunctionK<S, O>): Free<O, B> =
-                Free.liftF(fs(a)).map(f)
+        override fun <O, B> transform(f: (A) -> B, fs: FunctionK<S, O>): Free<O, B> = Free.liftF(fs(a)).map(f)
     }
 
     data class FlatMapped<out S, out A, C>(val c: Free<S, C>, val f: (C) -> Free<S, A>) : Free<S, A>() {
-        override fun <O, B> transform(fm: (A) -> B, fs: FunctionK<S, O>): Free<O, B> =
-                Free.FlatMapped(c.transform({ it }, fs), { c.flatMap { f(it) }.transform(fm, fs) })
+        override fun <O, B> transform(fm: (A) -> B, fs: FunctionK<S, O>): Free<O, B> = Free.FlatMapped(c.transform({ it }, fs), { c.flatMap { f(it) }.transform(fm, fs) })
     }
 
     override fun toString(): String = "Free(...) : toString is not stack-safe"
 }
 
-fun <S, A, B> Free<S, A>.map(f: (A) -> B): Free<S, B> =
-        flatMap { Free.Pure<S, B>(f(it)) }
+fun <S, A, B> Free<S, A>.map(f: (A) -> B): Free<S, B> = flatMap { Free.Pure<S, B>(f(it)) }
 
-fun <S, A, B> Free<S, A>.flatMap(f: (A) -> Free<S, B>): Free<S, B> =
-        Free.FlatMapped(this, f)
+fun <S, A, B> Free<S, A>.flatMap(f: (A) -> Free<S, B>): Free<S, B> = Free.FlatMapped(this, f)
 
 @Suppress("UNCHECKED_CAST")
 tailrec fun <S, A> Free<S, A>.step(): Free<S, A> =
@@ -105,8 +95,7 @@ fun <M, S, A> Free<S, A>.foldMap(f: FunctionK<S, M>, MM: Monad<M>): HK<M, A> =
             }
         }
 
-fun <S, A> A.free(): Free<S, A> =
-        Free.pure<S, A>(this)
+fun <S, A> A.free(): Free<S, A> = Free.pure<S, A>(this)
 
 fun <F, A> Free<F, A>.run(M: Monad<F>): HK<F, A> = this.foldMap(FunctionK.id(), M)
 

--- a/kategory/src/main/kotlin/kategory/free/FreeApplicative.kt
+++ b/kategory/src/main/kotlin/kategory/free/FreeApplicative.kt
@@ -3,14 +3,11 @@ package kategory
 typealias FreeApplicativeKind<S, A> = HK2<FreeApplicative.F, S, A>
 typealias FreeApplicativeF<S> = HK<FreeApplicative.F, S>
 
-fun <F, A> FreeApplicativeKind<F, A>.ev(): FreeApplicative<F, A> =
-        this as FreeApplicative<F, A>
+fun <F, A> FreeApplicativeKind<F, A>.ev(): FreeApplicative<F, A> = this as FreeApplicative<F, A>
 
-inline fun <F, reified G, A> FreeApplicativeKind<F, A>.foldMapK(f: FunctionK<F, G>, GA: Applicative<G> = applicative<G>()): HK<G, A> =
-        (this as FreeApplicative<F, A>).foldMap(f, GA)
+inline fun <F, reified G, A> FreeApplicativeKind<F, A>.foldMapK(f: FunctionK<F, G>, GA: Applicative<G> = applicative<G>()): HK<G, A> = (this as FreeApplicative<F, A>).foldMap(f, GA)
 
-inline fun <reified F, A> FreeApplicativeKind<F, A>.foldK(FA: Applicative<F> = applicative<F>()): HK<F, A> =
-        (this as FreeApplicative<F, A>).fold(FA)
+inline fun <reified F, A> FreeApplicativeKind<F, A>.foldK(FA: Applicative<F> = applicative<F>()): HK<F, A> = (this as FreeApplicative<F, A>).fold(FA)
 
 /**
  * See [https://github.com/edmundnoble/cats/blob/6454b4f8b7c5cefd15d8198fa7d52e46e2f45fea/docs/src/main/tut/datatypes/freeapplicative.md]
@@ -20,14 +17,11 @@ sealed class FreeApplicative<F, out A> : FreeApplicativeKind<F, A> {
     class F private constructor()
 
     companion object {
-        fun <F, A> pure(a: A): FreeApplicative<F, A> =
-                Pure(a)
+        fun <F, A> pure(a: A): FreeApplicative<F, A> = Pure(a)
 
-        fun <F, P, A> ap(fp: FreeApplicative<F, P>, fn: FreeApplicative<F, (P) -> A>): FreeApplicative<F, A> =
-                Ap(fn, fp)
+        fun <F, P, A> ap(fp: FreeApplicative<F, P>, fn: FreeApplicative<F, (P) -> A>): FreeApplicative<F, A> = Ap(fn, fp)
 
-        fun <F, A> liftF(fa: HK<F, A>): FreeApplicative<F, A> =
-                Lift(fa)
+        fun <F, A> liftF(fa: HK<F, A>): FreeApplicative<F, A> = Lift(fa)
 
         fun <S> functor(): FreeApplicativeInstances<S> = object : FreeApplicativeInstances<S> {}
 
@@ -61,20 +55,16 @@ sealed class FreeApplicative<F, out A> : FreeApplicativeKind<F, A> {
                 else -> Ap(Pure(f), this)
             }
 
-    fun fold(FA: Applicative<F>): HK<F, A> =
-            foldMap(FunctionK.id(), FA)
+    fun fold(FA: Applicative<F>): HK<F, A> = foldMap(FunctionK.id(), FA)
 
-    fun <G> compile(f: FunctionK<F, G>): FreeApplicative<G, A> =
-            foldMap(functionKF(f), applicativeF()).ev()
+    fun <G> compile(f: FunctionK<F, G>): FreeApplicative<G, A> = foldMap(functionKF(f), applicativeF()).ev()
 
-    fun <G> flatCompile(f: FunctionK<F, FreeApplicativeF<G>>, GFA: Applicative<FreeApplicativeF<G>>): FreeApplicative<G, A> =
-            foldMap(f, GFA).ev()
+    fun <G> flatCompile(f: FunctionK<F, FreeApplicativeF<G>>, GFA: Applicative<FreeApplicativeF<G>>): FreeApplicative<G, A> = foldMap(f, GFA).ev()
 
     // TODO(paco): requires Const
     // final def analyze[M: Monoid](f: FunctionK[F, λ[α => M]]): M
 
-    fun monad(): Free<F, A> =
-            foldMap(Free.functionKF(), Free.applicativeF()).ev()
+    fun monad(): Free<F, A> = foldMap(Free.functionKF(), Free.applicativeF()).ev()
 
     // Beware: smart code
     @Suppress("UNCHECKED_CAST")
@@ -166,8 +156,7 @@ sealed class FreeApplicative<F, out A> : FreeApplicativeKind<F, A> {
 
     internal data class Ap<S, P, out A>(val fn: FreeApplicative<S, (P) -> A>, val fp: FreeApplicative<S, P>) : FreeApplicative<S, A>()
 
-    override fun toString(): String =
-            "FreeApplicative(...)"
+    override fun toString(): String = "FreeApplicative(...)"
 }
 
 private fun <F, G, A> foldArg(node: FreeApplicative<F, A>, f: FunctionK<F, G>, GA: Applicative<G>): HK<G, A> =
@@ -179,5 +168,4 @@ private fun <F, G, A> foldArg(node: FreeApplicative<F, A>, f: FunctionK<F, G>, G
             }
         }
 
-fun <S, A> A.freeAp(): FreeApplicative<S, A> =
-        FreeApplicative.pure(this)
+fun <S, A> A.freeAp(): FreeApplicative<S, A> = FreeApplicative.pure(this)

--- a/kategory/src/main/kotlin/kategory/free/Yoneda.kt
+++ b/kategory/src/main/kotlin/kategory/free/Yoneda.kt
@@ -4,8 +4,7 @@ typealias YonedaKind<F, A> = HK2<Yoneda.F, F, A>
 
 typealias YonedaF<F> = HK<Yoneda.F, F>
 
-fun <F, A> YonedaKind<F, A>.ev(): Yoneda<F, A> =
-        this as Yoneda<F, A>
+fun <F, A> YonedaKind<F, A>.ev(): Yoneda<F, A> = this as Yoneda<F, A>
 
 // FIXME using YonedaKind throws a compiler error, but not the expanded form
 interface Yoneda<F, A> : HK<HK<Yoneda.F, F>, A> {
@@ -14,16 +13,14 @@ interface Yoneda<F, A> : HK<HK<Yoneda.F, F>, A> {
 
     fun <B> apply(f: (A) -> B): HK<F, B>
 
-    fun lower(): HK<F, A> =
-            apply { a -> a }
+    fun lower(): HK<F, A> = apply { a -> a }
 
     fun <B> map(ff: (A) -> B, FF: Functor<F>): Yoneda<F, B> =
             object : Yoneda<F, B> {
                 override fun <C> apply(f: (B) -> C): HK<F, C> = this@Yoneda.apply({ f(ff(it)) })
             }
 
-    fun toCoYoneda(): CoYoneda<F, A, A> =
-            CoYoneda(lower(), listOf({ a: Any? -> a }))
+    fun toCoYoneda(): CoYoneda<F, A, A> = CoYoneda(lower(), listOf({ a: Any? -> a }))
 
     companion object {
         inline fun <reified U, A> apply(fa: HK<U, A>, FF: Functor<U> = functor()): Yoneda<U, A> =

--- a/kategory/src/main/kotlin/kategory/instances/CoYonedaInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/CoYonedaInstances.kt
@@ -1,6 +1,5 @@
 package kategory
 
 interface CoYonedaInstances<U, P> : Functor<CoYonedaF<U, P>> {
-    override fun <A, B> map(fa: HK<CoYonedaF<U, P>, A>, f: (A) -> B): HK<CoYonedaF<U, P>, B> =
-            fa.ev().map(f)
+    override fun <A, B> map(fa: HK<CoYonedaF<U, P>, A>, f: (A) -> B): HK<CoYonedaF<U, P>, B> = fa.ev().map(f)
 }

--- a/kategory/src/main/kotlin/kategory/instances/CofreeInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/CofreeInstances.kt
@@ -1,15 +1,11 @@
 package kategory
 
 interface CofreeInstances<S> : Comonad<CofreeF<S>>, Typeclass {
-    override fun <A, B> coflatMap(fa: CofreeKind<S, A>, f: (CofreeKind<S, A>) -> B): Cofree<S, B> =
-            fa.ev().coflatMap(f)
+    override fun <A, B> coflatMap(fa: CofreeKind<S, A>, f: (CofreeKind<S, A>) -> B): Cofree<S, B> = fa.ev().coflatMap(f)
 
-    override fun <A> extract(fa: CofreeKind<S, A>): A =
-            fa.ev().extract()
+    override fun <A> extract(fa: CofreeKind<S, A>): A = fa.ev().extract()
 
-    override fun <A, B> map(fa: CofreeKind<S, A>, f: (A) -> B): Cofree<S, B> =
-            fa.ev().map(f)
+    override fun <A, B> map(fa: CofreeKind<S, A>, f: (A) -> B): Cofree<S, B> = fa.ev().map(f)
 
-    override fun <A> duplicate(fa: CofreeKind<S, A>): HK<CofreeF<S>, Cofree<S, A>> =
-            fa.ev().duplicate()
+    override fun <A> duplicate(fa: CofreeKind<S, A>): HK<CofreeF<S>, Cofree<S, A>> = fa.ev().duplicate()
 }

--- a/kategory/src/main/kotlin/kategory/instances/CoproductInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/CoproductInstances.kt
@@ -2,20 +2,16 @@ package kategory
 
 interface CoproductComonad<F, G> : Comonad<CoproductFG<F, G>> {
 
-    override fun <A, B> coflatMap(fa: CoproductKind<F, G, A>, f: (CoproductKind<F, G, A>) -> B): Coproduct<F, G, B> =
-            fa.ev().coflatMap(f)
+    override fun <A, B> coflatMap(fa: CoproductKind<F, G, A>, f: (CoproductKind<F, G, A>) -> B): Coproduct<F, G, B> = fa.ev().coflatMap(f)
 
-    override fun <A> extract(fa: CoproductKind<F, G, A>): A =
-            fa.ev().extract()
+    override fun <A> extract(fa: CoproductKind<F, G, A>): A = fa.ev().extract()
 
-    override fun <A, B> map(fa: HK<CoproductFG<F, G>, A>, f: (A) -> B): CoproductKind<F, G, B> =
-            fa.ev().map(f)
+    override fun <A, B> map(fa: HK<CoproductFG<F, G>, A>, f: (A) -> B): CoproductKind<F, G, B> = fa.ev().map(f)
 
     companion object {
         // Cobinding for HK2 requires an instance to infer the types.
         // As cobinding cannot be delegated you have to create an <Any, Any> so any internal type can be used
-        fun any(): CoproductComonad<Any, Any> =
-                object : CoproductComonad<Any, Any> {}
+        fun any(): CoproductComonad<Any, Any> = object : CoproductComonad<Any, Any> {}
     }
 }
 
@@ -25,13 +21,10 @@ interface CoproductTraverse<F, G> : Traverse<CoproductFG<F, G>> {
 
     fun FG(): Traverse<G>
 
-    override fun <H, A, B> traverse(fa: HK<CoproductFG<F, G>, A>, f: (A) -> HK<H, B>, GA: Applicative<H>): HK<H, HK<CoproductFG<F, G>, B>> =
-            fa.ev().traverse(f, GA, FF(), FG())
+    override fun <H, A, B> traverse(fa: HK<CoproductFG<F, G>, A>, f: (A) -> HK<H, B>, GA: Applicative<H>): HK<H, HK<CoproductFG<F, G>, B>> = fa.ev().traverse(f, GA, FF(), FG())
 
-    override fun <A, B> foldL(fa: HK<CoproductFG<F, G>, A>, b: B, f: (B, A) -> B): B =
-            fa.ev().foldL(b, f, FF(), FG())
+    override fun <A, B> foldL(fa: HK<CoproductFG<F, G>, A>, b: B, f: (B, A) -> B): B = fa.ev().foldL(b, f, FF(), FG())
 
-    override fun <A, B> foldR(fa: HK<CoproductFG<F, G>, A>, lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> =
-            fa.ev().foldR(lb, f, FF(), FG())
+    override fun <A, B> foldR(fa: HK<CoproductFG<F, G>, A>, lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> = fa.ev().foldR(lb, f, FF(), FG())
 
 }

--- a/kategory/src/main/kotlin/kategory/instances/EitherInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/EitherInstances.kt
@@ -10,11 +10,9 @@ interface EitherInstances<L> :
 
     override fun <A> pure(a: A): Either<L, A> = Either.Right(a)
 
-    override fun <A, B> flatMap(fa: EitherKind<L, A>, f: (A) -> EitherKind<L, B>): Either<L, B> =
-            fa.ev().flatMap { f(it).ev() }
+    override fun <A, B> flatMap(fa: EitherKind<L, A>, f: (A) -> EitherKind<L, B>): Either<L, B> = fa.ev().flatMap { f(it).ev() }
 
-    override fun <A, B> map(fa: HK<EitherF<L>, A>, f: (A) -> B): Either<L, B> =
-            fa.ev().map(f)
+    override fun <A, B> map(fa: HK<EitherF<L>, A>, f: (A) -> B): Either<L, B> = fa.ev().map(f)
 
     tailrec override fun <A, B> tailRecM(a: A, f: (A) -> HK<EitherF<L>, Either<A, B>>): Either<L, B> {
         val ev: Either<L, Either<A, B>> = f(a).ev()
@@ -40,8 +38,7 @@ interface EitherInstances<L> :
         }
     }
 
-    override fun <G, A, B> traverse(fa: HK<EitherF<L>, A>, f: (A) -> HK<G, B>, GA: Applicative<G>): HK<G, HK<EitherF<L>, B>> =
-            fa.ev().fold({ GA.pure(it.left()) }, { GA.map(f(it), { Either.Right(it) }) })
+    override fun <G, A, B> traverse(fa: HK<EitherF<L>, A>, f: (A) -> HK<G, B>, GA: Applicative<G>): HK<G, HK<EitherF<L>, B>> = fa.ev().fold({ GA.pure(it.left()) }, { GA.map(f(it), { Either.Right(it) }) })
 
     override fun <A, B> foldL(fa: HK<EitherF<L>, A>, b: B, f: (B, A) -> B): B =
             fa.ev().let { either ->

--- a/kategory/src/main/kotlin/kategory/instances/EitherTInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/EitherTInstances.kt
@@ -8,14 +8,11 @@ interface EitherTInstances<F, L> :
 
     fun MF(): Monad<F>
 
-    override fun <A> pure(a: A): EitherT<F, L, A> =
-            EitherT(MF(), MF().pure(Either.Right(a)))
+    override fun <A> pure(a: A): EitherT<F, L, A> = EitherT(MF(), MF().pure(Either.Right(a)))
 
-    override fun <A, B> map(fa: EitherTKind<F, L, A>, f: (A) -> B): EitherT<F, L, B> =
-            fa.ev().map { f(it) }
+    override fun <A, B> map(fa: EitherTKind<F, L, A>, f: (A) -> B): EitherT<F, L, B> = fa.ev().map { f(it) }
 
-    override fun <A, B> flatMap(fa: EitherTKind<F, L, A>, f: (A) -> EitherTKind<F, L, B>): EitherT<F, L, B> =
-            fa.ev().flatMap { f(it).ev() }
+    override fun <A, B> flatMap(fa: EitherTKind<F, L, A>, f: (A) -> EitherTKind<F, L, B>): EitherT<F, L, B> = fa.ev().flatMap { f(it).ev() }
 
     override fun <A, B> tailRecM(a: A, f: (A) -> HK<EitherTF<F, L>, Either<A, B>>): EitherT<F, L, B> =
             EitherT(MF(), MF().tailRecM(a, {
@@ -41,8 +38,7 @@ interface EitherTInstances<F, L> :
                 }
             }))
 
-    override fun <A> raiseError(e: L): EitherT<F, L, A> =
-            EitherT(MF(), MF().pure(Either.Left(e)))
+    override fun <A> raiseError(e: L): EitherT<F, L, A> = EitherT(MF(), MF().pure(Either.Left(e)))
 
 }
 
@@ -54,14 +50,11 @@ interface EitherTTraverse<F, A> :
 
     fun MF(): Monad<F>
 
-    override fun <G, B, C> traverse(fa: HK<EitherTF<F, A>, B>, f: (B) -> HK<G, C>, GA: Applicative<G>): HK<G, HK<EitherTF<F, A>, C>> =
-            fa.ev().traverse(f, GA, FF(), MF())
+    override fun <G, B, C> traverse(fa: HK<EitherTF<F, A>, B>, f: (B) -> HK<G, C>, GA: Applicative<G>): HK<G, HK<EitherTF<F, A>, C>> = fa.ev().traverse(f, GA, FF(), MF())
 
-    override fun <B, C> foldL(fa: HK<EitherTF<F, A>, B>, b: C, f: (C, B) -> C): C =
-            fa.ev().foldL(b, f, FF())
+    override fun <B, C> foldL(fa: HK<EitherTF<F, A>, B>, b: C, f: (C, B) -> C): C = fa.ev().foldL(b, f, FF())
 
-    override fun <B, C> foldR(fa: HK<EitherTF<F, A>, B>, lb: Eval<C>, f: (B, Eval<C>) -> Eval<C>): Eval<C> =
-            fa.ev().foldR(lb, f, FF())
+    override fun <B, C> foldR(fa: HK<EitherTF<F, A>, B>, lb: Eval<C>, f: (B, Eval<C>) -> Eval<C>): Eval<C> = fa.ev().foldR(lb, f, FF())
 
 }
 

--- a/kategory/src/main/kotlin/kategory/instances/EvalInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/EvalInstances.kt
@@ -5,14 +5,11 @@ interface EvalInstances :
         Applicative<Eval.F>,
         Monad<Eval.F> {
 
-    override fun <A> pure(a: A): Eval<A> =
-            Eval.now(a)
+    override fun <A> pure(a: A): Eval<A> = Eval.now(a)
 
-    override fun <A, B> map(fa: HK<Eval.F, A>, f: (A) -> B): Eval<B> =
-            fa.ev().map(f)
+    override fun <A, B> map(fa: HK<Eval.F, A>, f: (A) -> B): Eval<B> = fa.ev().map(f)
 
-    override fun <A, B> flatMap(fa: HK<Eval.F, A>, f: (A) -> HK<Eval.F, B>): Eval<B> =
-            fa.ev().flatMap { f(it).ev() }
+    override fun <A, B> flatMap(fa: HK<Eval.F, A>, f: (A) -> HK<Eval.F, B>): Eval<B> = fa.ev().flatMap { f(it).ev() }
 
     override fun <A, B> tailRecM(a: A, f: (A) -> HK<Eval.F, Either<A, B>>): Eval<B> =
             f(a).ev().flatMap { eval: Either<A, B> ->

--- a/kategory/src/main/kotlin/kategory/instances/FreeApplicativeInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/FreeApplicativeInstances.kt
@@ -4,22 +4,17 @@ interface FreeApplicativeInstances<S> :
         Functor<FreeApplicativeF<S>>,
         Applicative<FreeApplicativeF<S>> {
 
-    override fun <A> pure(a: A): FreeApplicative<S, A> =
-            FreeApplicative.pure(a)
+    override fun <A> pure(a: A): FreeApplicative<S, A> = FreeApplicative.pure(a)
 
-    override fun <A, B> map(fa: FreeApplicativeKind<S, A>, f: (A) -> B): FreeApplicative<S, B> =
-            fa.ev().map(f)
+    override fun <A, B> map(fa: FreeApplicativeKind<S, A>, f: (A) -> B): FreeApplicative<S, B> = fa.ev().map(f)
 
-    override fun <A, B> ap(fa: HK<FreeApplicativeF<S>, A>, ff: HK<FreeApplicativeF<S>, (A) -> B>): FreeApplicative<S, B> =
-            fa.ev().ap(ff.ev())
+    override fun <A, B> ap(fa: HK<FreeApplicativeF<S>, A>, ff: HK<FreeApplicativeF<S>, (A) -> B>): FreeApplicative<S, B> = fa.ev().ap(ff.ev())
 }
 
 data class FreeApplicativeEq<in F, in G, in A>(private val interpreter: FunctionK<F, G>, private val MG: Monad<G>) : Eq<HK<FreeApplicativeF<F>, A>> {
-    override fun eqv(a: HK<FreeApplicativeF<F>, A>, b: HK<FreeApplicativeF<F>, A>): Boolean =
-            a.ev().foldMap(interpreter, MG) == b.ev().foldMap(interpreter, MG)
+    override fun eqv(a: HK<FreeApplicativeF<F>, A>, b: HK<FreeApplicativeF<F>, A>): Boolean = a.ev().foldMap(interpreter, MG) == b.ev().foldMap(interpreter, MG)
 
     companion object {
-        inline operator fun <F, reified G, A> invoke(interpreter: FunctionK<F, G>, MG: Monad<G> = monad(), dummy: Unit = Unit): FreeApplicativeEq<F, G, A> =
-                FreeApplicativeEq(interpreter, MG)
+        inline operator fun <F, reified G, A> invoke(interpreter: FunctionK<F, G>, MG: Monad<G> = monad(), dummy: Unit = Unit): FreeApplicativeEq<F, G, A> = FreeApplicativeEq(interpreter, MG)
     }
 }

--- a/kategory/src/main/kotlin/kategory/instances/FreeInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/FreeInstances.kt
@@ -5,14 +5,11 @@ interface FreeInstances<S> :
         Applicative<FreeF<S>>,
         Monad<FreeF<S>> {
 
-    override fun <A> pure(a: A): Free<S, A> =
-            Free.pure(a)
+    override fun <A> pure(a: A): Free<S, A> = Free.pure(a)
 
-    override fun <A, B> map(fa: FreeKind<S, A>, f: (A) -> B): Free<S, B> =
-            fa.ev().map(f)
+    override fun <A, B> map(fa: FreeKind<S, A>, f: (A) -> B): Free<S, B> = fa.ev().map(f)
 
-    override fun <A, B> flatMap(fa: FreeKind<S, A>, f: (A) -> FreeKind<S, B>): Free<S, B> =
-            fa.ev().flatMap { f(it).ev() }
+    override fun <A, B> flatMap(fa: FreeKind<S, A>, f: (A) -> FreeKind<S, B>): Free<S, B> = fa.ev().flatMap { f(it).ev() }
 
     override fun <A, B> tailRecM(a: A, f: (A) -> FreeKind<S, Either<A, B>>): Free<S, B> = f(a).ev().flatMap {
             when (it) {
@@ -23,11 +20,9 @@ interface FreeInstances<S> :
 }
 
 data class FreeEq<in F, in G, in A>(private val interpreter: FunctionK<F, G>, private val MG: Monad<G>) : Eq<HK<FreeF<F>, A>> {
-    override fun eqv(a: HK<FreeF<F>, A>, b: HK<FreeF<F>, A>): Boolean =
-            a.ev().foldMap(interpreter, MG) == b.ev().foldMap(interpreter, MG)
+    override fun eqv(a: HK<FreeF<F>, A>, b: HK<FreeF<F>, A>): Boolean = a.ev().foldMap(interpreter, MG) == b.ev().foldMap(interpreter, MG)
 
     companion object {
-        inline operator fun <F, reified G, A> invoke(interpreter: FunctionK<F, G>, MG: Monad<G> = monad(), dummy: Unit = Unit): FreeEq<F, G, A> =
-                FreeEq(interpreter, MG)
+        inline operator fun <F, reified G, A> invoke(interpreter: FunctionK<F, G>, MG: Monad<G> = monad(), dummy: Unit = Unit): FreeEq<F, G, A> = FreeEq(interpreter, MG)
     }
 }

--- a/kategory/src/main/kotlin/kategory/instances/FreeInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/FreeInstances.kt
@@ -14,14 +14,12 @@ interface FreeInstances<S> :
     override fun <A, B> flatMap(fa: FreeKind<S, A>, f: (A) -> FreeKind<S, B>): Free<S, B> =
             fa.ev().flatMap { f(it).ev() }
 
-    override fun <A, B> tailRecM(a: A, f: (A) -> FreeKind<S, Either<A, B>>): Free<S, B> {
-        return f(a).ev().flatMap {
+    override fun <A, B> tailRecM(a: A, f: (A) -> FreeKind<S, Either<A, B>>): Free<S, B> = f(a).ev().flatMap {
             when (it) {
                 is Either.Left -> tailRecM(it.a, f)
                 is Either.Right -> pure(it.b)
             }
         }
-    }
 }
 
 data class FreeEq<in F, in G, in A>(private val interpreter: FunctionK<F, G>, private val MG: Monad<G>) : Eq<HK<FreeF<F>, A>> {

--- a/kategory/src/main/kotlin/kategory/instances/Function1Instances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/Function1Instances.kt
@@ -6,20 +6,15 @@ interface Function1Instances<I> :
         Monad<Function1F<I>>,
         MonadReader<Function1F<I>, I> {
 
-    override fun ask(): Function1<I, I> =
-            { a: I -> a }.k()
+    override fun ask(): Function1<I, I> = { a: I -> a }.k()
 
-    override fun <A> local(f: (I) -> I, fa: Function1Kind<I, A>): Function1<I, A> =
-            f.andThen { fa(it) }.k()
+    override fun <A> local(f: (I) -> I, fa: Function1Kind<I, A>): Function1<I, A> = f.andThen { fa(it) }.k()
 
-    override fun <A> pure(a: A): Function1<I, A> =
-            { _: I -> a }.k()
+    override fun <A> pure(a: A): Function1<I, A> = { _: I -> a }.k()
 
-    override fun <A, B> map(fa: Function1Kind<I, A>, f: (A) -> B): Function1<I, B> =
-            f.compose { a: I -> fa(a) }.k()
+    override fun <A, B> map(fa: Function1Kind<I, A>, f: (A) -> B): Function1<I, B> = f.compose { a: I -> fa(a) }.k()
 
-    override fun <A, B> flatMap(fa: Function1Kind<I, A>, f: (A) -> Function1Kind<I, B>): Function1<I, B> =
-            { p: I -> f(fa(p))(p) }.k()
+    override fun <A, B> flatMap(fa: Function1Kind<I, A>, f: (A) -> Function1Kind<I, B>): Function1<I, B> = { p: I -> f(fa(p))(p) }.k()
 
     tailrec private fun <A, B> step(a: A, t: I, fn: (A) -> Function1Kind<I, Either<A, B>>): B {
         val af = fn(a)(t)
@@ -29,7 +24,6 @@ interface Function1Instances<I> :
         }
     }
 
-    override fun <A, B> tailRecM(a: A, f: (A) -> Function1Kind<I, Either<A, B>>): Function1<I, B> =
-            { t: I -> step(a, t, f) }.k()
+    override fun <A, B> tailRecM(a: A, f: (A) -> Function1Kind<I, Either<A, B>>): Function1<I, B> = { t: I -> step(a, t, f) }.k()
 }
 

--- a/kategory/src/main/kotlin/kategory/instances/IOInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/IOInstances.kt
@@ -5,14 +5,11 @@ interface IOInstances :
         Applicative<IO.F>,
         Monad<IO.F> {
 
-    override fun <A, B> map(fa: HK<IO.F, A>, f: (A) -> B): IO<B> =
-            fa.ev().map(f)
+    override fun <A, B> map(fa: HK<IO.F, A>, f: (A) -> B): IO<B> = fa.ev().map(f)
 
-    override fun <A> pure(a: A): IO<A> =
-            IO.pure(a)
+    override fun <A> pure(a: A): IO<A> = IO.pure(a)
 
-    override fun <A, B> flatMap(fa: IOKind<A>, f: (A) -> IOKind<B>): IO<B> =
-            fa.ev().flatMap { f(it).ev() }
+    override fun <A, B> flatMap(fa: IOKind<A>, f: (A) -> IOKind<B>): IO<B> = fa.ev().flatMap { f(it).ev() }
 
     tailrec override fun <A, B> tailRecM(a: A, f: (A) -> IOKind<Either<A, B>>): IO<B> =
             f(a).ev().flatMap {
@@ -27,11 +24,9 @@ interface IOMonoid<A> : Monoid<HK<IO.F, A>>, Semigroup<HK<IO.F, A>> {
 
     fun SM(): Monoid<A>
 
-    override fun combine(ioa: HK<IO.F, A>, iob: HK<IO.F, A>): IO<A> =
-            ioa.ev().flatMap { a1 -> iob.ev().map { a2 -> SM().combine(a1, a2) } }
+    override fun combine(ioa: HK<IO.F, A>, iob: HK<IO.F, A>): IO<A> = ioa.ev().flatMap { a1 -> iob.ev().map { a2 -> SM().combine(a1, a2) } }
 
-    override fun empty(): IO<A> =
-            IO.pure(SM().empty())
+    override fun empty(): IO<A> = IO.pure(SM().empty())
 
 }
 
@@ -39,6 +34,5 @@ interface IOSemigroup<A> : Semigroup<HK<IO.F, A>> {
 
     fun SG(): Semigroup<A>
 
-    override fun combine(ioa: HK<IO.F, A>, iob: HK<IO.F, A>): IO<A> =
-            ioa.ev().flatMap { a1 -> iob.ev().map { a2 -> SG().combine(a1, a2) } }
+    override fun combine(ioa: HK<IO.F, A>, iob: HK<IO.F, A>): IO<A> = ioa.ev().flatMap { a1 -> iob.ev().map { a2 -> SG().combine(a1, a2) } }
 }

--- a/kategory/src/main/kotlin/kategory/instances/IdInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/IdInstances.kt
@@ -11,11 +11,9 @@ interface IdInstances :
 
     override fun <A> pure(a: A): Id<A> = Id(a)
 
-    override fun <A, B> flatMap(fa: IdKind<A>, f: (A) -> IdKind<B>): Id<B> =
-            fa.ev().flatMap { f(it).ev() }
+    override fun <A, B> flatMap(fa: IdKind<A>, f: (A) -> IdKind<B>): Id<B> = fa.ev().flatMap { f(it).ev() }
 
-    override fun <A, B> map(fa: IdKind<A>, f: (A) -> B): Id<B> =
-            fa.ev().map(f)
+    override fun <A, B> map(fa: IdKind<A>, f: (A) -> B): Id<B> = fa.ev().map(f)
 
     tailrec override fun <A, B> tailRecM(a: A, f: (A) -> IdKind<Either<A, B>>): Id<B> {
         val x: Either<A, B> = f(a).ev().value
@@ -25,19 +23,14 @@ interface IdInstances :
         }
     }
 
-    override fun <A, B> foldL(fa: IdKind<A>, b: B, f: (B, A) -> B): B =
-            f(b, fa.ev().value)
+    override fun <A, B> foldL(fa: IdKind<A>, b: B, f: (B, A) -> B): B = f(b, fa.ev().value)
 
-    override fun <A, B> foldR(fa: IdKind<A>, lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> =
-            f(fa.ev().value, lb)
+    override fun <A, B> foldR(fa: IdKind<A>, lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> = f(fa.ev().value, lb)
 
-    override fun <G, A, B> traverse(fa: IdKind<A>, f: (A) -> HK<G, B>, GA: Applicative<G>): HK<G, Id<B>> =
-            GA.map(f(fa.ev().value), { Id(it) })
+    override fun <G, A, B> traverse(fa: IdKind<A>, f: (A) -> HK<G, B>, GA: Applicative<G>): HK<G, Id<B>> = GA.map(f(fa.ev().value), { Id(it) })
 
-    override fun <A, B> coflatMap(fa: IdKind<A>, f: (IdKind<A>) -> B): Id<B> =
-            fa.ev().map({ f(fa) })
+    override fun <A, B> coflatMap(fa: IdKind<A>, f: (IdKind<A>) -> B): Id<B> = fa.ev().map({ f(fa) })
 
-    override fun <A> extract(fa: IdKind<A>): A =
-            fa.ev().value
+    override fun <A> extract(fa: IdKind<A>): A = fa.ev().value
 
 }

--- a/kategory/src/main/kotlin/kategory/instances/IorInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/IorInstances.kt
@@ -7,13 +7,11 @@ interface IorInstances<L> :
 
     fun SL(): Semigroup<L>
 
-    override fun <A, B> flatMap(fa: IorKind<L, A>, f: (A) -> IorKind<L, B>): Ior<L, B> =
-            fa.ev().flatMap(SL(), { f(it).ev() })
+    override fun <A, B> flatMap(fa: IorKind<L, A>, f: (A) -> IorKind<L, B>): Ior<L, B> = fa.ev().flatMap(SL(), { f(it).ev() })
 
     override fun <A> pure(a: A): Ior<L, A> = Ior.Right(a)
 
-    override fun <A, B> map(fa: IorKind<L, A>, f: (A) -> B): Ior<L, B> =
-            fa.ev().map(f)
+    override fun <A, B> map(fa: IorKind<L, A>, f: (A) -> B): Ior<L, B> = fa.ev().map(f)
 
     private tailrec fun <A, B> loop(v: Ior<L, Either<A, B>>, f: (A) -> IorKind<L, Either<A, B>>): Ior<L, B> = when (v) {
             is Ior.Left -> Ior.Left(v.value)
@@ -40,12 +38,9 @@ interface IorInstances<L> :
 interface IorTraverse<A> :
         Foldable<HK<Ior.F, A>>,
         Traverse<HK<Ior.F, A>> {
-    override fun <G, B, C> traverse(fa: HK<HK<Ior.F, A>, B>, f: (B) -> HK<G, C>, GA: Applicative<G>): HK<G, HK<HK<Ior.F, A>, C>> =
-            fa.ev().fold({ GA.pure(Ior.Left(it)) }, { GA.map(f(it), { Ior.Right(it) }) }, { _, b -> GA.map(f(b), { Ior.Right(it) }) })
+    override fun <G, B, C> traverse(fa: HK<HK<Ior.F, A>, B>, f: (B) -> HK<G, C>, GA: Applicative<G>): HK<G, HK<HK<Ior.F, A>, C>> = fa.ev().fold({ GA.pure(Ior.Left(it)) }, { GA.map(f(it), { Ior.Right(it) }) }, { _, b -> GA.map(f(b), { Ior.Right(it) }) })
 
-    override fun <B, C> foldL(fa: HK<HK<Ior.F, A>, B>, c: C, f: (C, B) -> C): C =
-            fa.ev().fold({ c }, { f(c, it) }, { _, b -> f(c, b) })
+    override fun <B, C> foldL(fa: HK<HK<Ior.F, A>, B>, c: C, f: (C, B) -> C): C = fa.ev().fold({ c }, { f(c, it) }, { _, b -> f(c, b) })
 
-    override fun <B, C> foldR(fa: HK<HK<Ior.F, A>, B>, lc: Eval<C>, f: (B, Eval<C>) -> Eval<C>): Eval<C> =
-            fa.ev().fold({ lc }, { f(it, lc) }, { _, b -> f(b, lc) })
+    override fun <B, C> foldR(fa: HK<HK<Ior.F, A>, B>, lc: Eval<C>, f: (B, Eval<C>) -> Eval<C>): Eval<C> = fa.ev().fold({ lc }, { f(it, lc) }, { _, b -> f(b, lc) })
 }

--- a/kategory/src/main/kotlin/kategory/instances/IorInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/IorInstances.kt
@@ -15,8 +15,7 @@ interface IorInstances<L> :
     override fun <A, B> map(fa: IorKind<L, A>, f: (A) -> B): Ior<L, B> =
             fa.ev().map(f)
 
-    private tailrec fun <A, B> loop(v: Ior<L, Either<A, B>>, f: (A) -> IorKind<L, Either<A, B>>): Ior<L, B> {
-        return when (v) {
+    private tailrec fun <A, B> loop(v: Ior<L, Either<A, B>>, f: (A) -> IorKind<L, Either<A, B>>): Ior<L, B> = when (v) {
             is Ior.Left -> Ior.Left(v.value)
             is Ior.Right -> when (v.value) {
                 is Either.Right -> Ior.Right(v.value.b)
@@ -34,11 +33,8 @@ interface IorInstances<L> :
                 }
             }
         }
-    }
 
-    override fun <A, B> tailRecM(a: A, f: (A) -> IorKind<L, Either<A, B>>): Ior<L, B> {
-        return loop(f(a).ev(), f)
-    }
+    override fun <A, B> tailRecM(a: A, f: (A) -> IorKind<L, Either<A, B>>): Ior<L, B> = loop(f(a).ev(), f)
 }
 
 interface IorTraverse<A> :

--- a/kategory/src/main/kotlin/kategory/instances/KleisliInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/KleisliInstances.kt
@@ -8,26 +8,19 @@ interface KleisliInstances<F, D> :
 
     fun MF(): Monad<F>
 
-    override fun ask(): Kleisli<F, D, D> =
-            Kleisli(MF(), { MF().pure(it) })
+    override fun ask(): Kleisli<F, D, D> = Kleisli(MF(), { MF().pure(it) })
 
-    override fun <A> local(f: (D) -> D, fa: HK<KleisliFD<F, D>, A>): Kleisli<F, D, A> =
-            fa.ev().local(f)
+    override fun <A> local(f: (D) -> D, fa: HK<KleisliFD<F, D>, A>): Kleisli<F, D, A> = fa.ev().local(f)
 
-    override fun <A, B> flatMap(fa: HK<KleisliFD<F, D>, A>, f: (A) -> HK<KleisliFD<F, D>, B>): Kleisli<F, D, B> =
-            fa.ev().flatMap(f.andThen { it.ev() })
+    override fun <A, B> flatMap(fa: HK<KleisliFD<F, D>, A>, f: (A) -> HK<KleisliFD<F, D>, B>): Kleisli<F, D, B> = fa.ev().flatMap(f.andThen { it.ev() })
 
-    override fun <A, B> map(fa: HK<KleisliFD<F, D>, A>, f: (A) -> B): Kleisli<F, D, B> =
-            fa.ev().map(f)
+    override fun <A, B> map(fa: HK<KleisliFD<F, D>, A>, f: (A) -> B): Kleisli<F, D, B> = fa.ev().map(f)
 
-    override fun <A, B> product(fa: HK<KleisliFD<F, D>, A>, fb: HK<KleisliFD<F, D>, B>): Kleisli<F, D, Tuple2<A, B>> =
-            Kleisli(MF(), { MF().product(fa.ev().run(it), fb.ev().run(it)) })
+    override fun <A, B> product(fa: HK<KleisliFD<F, D>, A>, fb: HK<KleisliFD<F, D>, B>): Kleisli<F, D, Tuple2<A, B>> = Kleisli(MF(), { MF().product(fa.ev().run(it), fb.ev().run(it)) })
 
-    override fun <A, B> tailRecM(a: A, f: (A) -> HK<KleisliFD<F, D>, Either<A, B>>): Kleisli<F, D, B> =
-            Kleisli(MF(), { b -> MF().tailRecM(a, { f(it).ev().run(b) }) })
+    override fun <A, B> tailRecM(a: A, f: (A) -> HK<KleisliFD<F, D>, Either<A, B>>): Kleisli<F, D, B> = Kleisli(MF(), { b -> MF().tailRecM(a, { f(it).ev().run(b) }) })
 
-    override fun <A> pure(a: A): Kleisli<F, D, A> =
-            Kleisli(MF(), { MF().pure(a) })
+    override fun <A> pure(a: A): Kleisli<F, D, A> = Kleisli(MF(), { MF().pure(a) })
 }
 
 interface KleisliMonadError<F, D, E> : MonadError<KleisliFD<F, D>, E>, KleisliInstances<F, D> {
@@ -39,8 +32,7 @@ interface KleisliMonadError<F, D, E> : MonadError<KleisliFD<F, D>, E>, KleisliIn
                 MFE().handleErrorWith(fa.ev().run(it), { e: E -> f(e).ev().run(it) })
             })
 
-    override fun <A> raiseError(e: E): Kleisli<F, D, A> =
-            Kleisli(MFE(), { MFE().raiseError(e) })
+    override fun <A> raiseError(e: E): Kleisli<F, D, A> = Kleisli(MFE(), { MFE().raiseError(e) })
 
 }
 

--- a/kategory/src/main/kotlin/kategory/instances/NonEmptyListInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/NonEmptyListInstances.kt
@@ -9,11 +9,9 @@ interface NonEmptyListInstances :
 
     override fun <A> pure(a: A): NonEmptyList<A> = NonEmptyList.of(a)
 
-    override fun <A, B> flatMap(fa: NonEmptyListKind<A>, f: (A) -> NonEmptyListKind<B>): NonEmptyList<B> =
-            fa.ev().flatMap { f(it).ev() }
+    override fun <A, B> flatMap(fa: NonEmptyListKind<A>, f: (A) -> NonEmptyListKind<B>): NonEmptyList<B> = fa.ev().flatMap { f(it).ev() }
 
-    override fun <A, B> map(fa: NonEmptyListKind<A>, f: (A) -> B): NonEmptyList<B> =
-            fa.ev().map(f)
+    override fun <A, B> map(fa: NonEmptyListKind<A>, f: (A) -> B): NonEmptyList<B> = fa.ev().map(f)
 
     @Suppress("UNCHECKED_CAST")
     private tailrec fun <A, B> go(
@@ -53,8 +51,7 @@ interface NonEmptyListInstances :
         return NonEmptyList(f(fa), consume(fa.ev().tail))
     }
 
-    override fun <A> extract(fa: NonEmptyListKind<A>): A =
-            fa.ev().head
+    override fun <A> extract(fa: NonEmptyListKind<A>): A = fa.ev().head
 
 }
 

--- a/kategory/src/main/kotlin/kategory/instances/NumberInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/NumberInstances.kt
@@ -1,8 +1,7 @@
 package kategory
 
 class NumberSemigroup<A : Number>(val f: (A, A) -> A) : Semigroup<A> {
-    override fun combine(a: A, b: A): A =
-            f(a, b)
+    override fun combine(a: A, b: A): A = f(a, b)
 }
 
 object ByteMonoid : Monoid<Byte>, Semigroup<Byte> by SGByte, GlobalInstance<Monoid<Byte>>() {

--- a/kategory/src/main/kotlin/kategory/instances/OptionInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/OptionInstances.kt
@@ -4,8 +4,7 @@ interface OptionMonoid<A> : Monoid<Option<A>> {
 
     fun SG(): Semigroup<A>
 
-    override fun empty(): Option<A> =
-            Option.None
+    override fun empty(): Option<A> = Option.None
 
     override fun combine(a: Option<A>, b: Option<A>): Option<A> =
             when (a) {
@@ -26,16 +25,13 @@ interface OptionInstances :
         Traverse<Option.F>,
         MonadError<Option.F, Unit> {
 
-    override fun <A, B> map(fa: OptionKind<A>, f: (A) -> B): Option<B> =
-            fa.ev().map(f)
+    override fun <A, B> map(fa: OptionKind<A>, f: (A) -> B): Option<B> = fa.ev().map(f)
 
     override fun <A> pure(a: A): Option<A> = Option.Some(a)
 
-    override fun <A, B> ap(fa: OptionKind<A>, ff: OptionKind<(A) -> B>): Option<B> =
-            ff.ev().flatMap { fa.ev().map(it) }
+    override fun <A, B> ap(fa: OptionKind<A>, ff: OptionKind<(A) -> B>): Option<B> = ff.ev().flatMap { fa.ev().map(it) }
 
-    override fun <A, B> flatMap(fa: OptionKind<A>, f: (A) -> OptionKind<B>): Option<B> =
-            fa.ev().flatMap { f(it).ev() }
+    override fun <A, B> flatMap(fa: OptionKind<A>, f: (A) -> OptionKind<B>): Option<B> = fa.ev().flatMap { f(it).ev() }
 
     tailrec override fun <A, B> tailRecM(a: A, f: (A) -> HK<Option.F, Either<A, B>>): Option<B> {
         val option = f(a).ev()
@@ -74,11 +70,9 @@ interface OptionInstances :
                 }
             }
 
-    override fun <A> raiseError(e: Unit): Option<A> =
-            Option.None
+    override fun <A> raiseError(e: Unit): Option<A> = Option.None
 
-    override fun <A> handleErrorWith(fa: OptionKind<A>, f: (Unit) -> OptionKind<A>): Option<A> =
-            fa.ev().orElse({ f(Unit).ev() })
+    override fun <A> handleErrorWith(fa: OptionKind<A>, f: (Unit) -> OptionKind<A>): Option<A> = fa.ev().orElse({ f(Unit).ev() })
 
 }
 
@@ -86,16 +80,14 @@ interface OptionInstances :
  * Dummy SemigroupK instance to be able to test laws for SemigroupK.
  */
 class OptionSemigroupK : SemigroupK<Option.F> {
-    override fun <A> combineK(x: HK<Option.F, A>, y: HK<Option.F, A>): Option<A> =
-            x.ev().flatMap { y.ev() }
+    override fun <A> combineK(x: HK<Option.F, A>, y: HK<Option.F, A>): Option<A> = x.ev().flatMap { y.ev() }
 }
 
 /**
  * Dummy MonoidK instance to be able to test laws for MonoidK.
  */
 class OptionMonoidK : MonoidK<Option.F>, GlobalInstance<ApplicativeError<Option.F, Unit>>() {
-    override fun <A> combineK(x: HK<Option.F, A>, y: HK<Option.F, A>): Option<A> =
-            x.ev().flatMap { y.ev() }
+    override fun <A> combineK(x: HK<Option.F, A>, y: HK<Option.F, A>): Option<A> = x.ev().flatMap { y.ev() }
 
     override fun <A> empty(): HK<Option.F, A> = Option.None
 }

--- a/kategory/src/main/kotlin/kategory/instances/OptionTInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/OptionTInstances.kt
@@ -9,11 +9,9 @@ interface OptionTInstances<F> :
 
     override fun <A> pure(a: A): OptionT<F, A> = OptionT(MF(), MF().pure(Option(a)))
 
-    override fun <A, B> flatMap(fa: OptionTKind<F, A>, f: (A) -> OptionTKind<F, B>): OptionT<F, B> =
-            fa.ev().flatMap { f(it).ev() }
+    override fun <A, B> flatMap(fa: OptionTKind<F, A>, f: (A) -> OptionTKind<F, B>): OptionT<F, B> = fa.ev().flatMap { f(it).ev() }
 
-    override fun <A, B> map(fa: OptionTKind<F, A>, f: (A) -> B): OptionT<F, B> =
-            fa.ev().map(f)
+    override fun <A, B> map(fa: OptionTKind<F, A>, f: (A) -> B): OptionT<F, B> = fa.ev().map(f)
 
     override fun <A, B> tailRecM(a: A, f: (A) -> HK<OptionTF<F>, Either<A, B>>): OptionT<F, B> =
             OptionT(MF(), MF().tailRecM(a, {
@@ -36,22 +34,18 @@ interface OptionTTraverse<F> :
 
     fun MF(): Monad<F>
 
-    override fun <G, A, B> traverse(fa: HK<OptionTF<F>, A>, f: (A) -> HK<G, B>, GA: Applicative<G>): HK<G, HK<OptionTF<F>, B>> =
-            fa.ev().traverse(f, GA, FF(), MF())
+    override fun <G, A, B> traverse(fa: HK<OptionTF<F>, A>, f: (A) -> HK<G, B>, GA: Applicative<G>): HK<G, HK<OptionTF<F>, B>> = fa.ev().traverse(f, GA, FF(), MF())
 
-    override fun <A, B> foldL(fa: HK<OptionTF<F>, A>, b: B, f: (B, A) -> B): B =
-            fa.ev().foldL(b, f, FF())
+    override fun <A, B> foldL(fa: HK<OptionTF<F>, A>, b: B, f: (B, A) -> B): B = fa.ev().foldL(b, f, FF())
 
-    override fun <A, B> foldR(fa: HK<OptionTF<F>, A>, lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> =
-            fa.ev().foldR(lb, f, FF())
+    override fun <A, B> foldR(fa: HK<OptionTF<F>, A>, lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> = fa.ev().foldR(lb, f, FF())
 }
 
 interface OptionTSemigroupK<F> : SemigroupK<OptionTF<F>> {
 
     fun F(): Monad<F>
 
-    override fun <A> combineK(x: HK<OptionTF<F>, A>, y: HK<OptionTF<F>, A>): OptionT<F, A> =
-            x.ev().orElse { y.ev() }
+    override fun <A> combineK(x: HK<OptionTF<F>, A>, y: HK<OptionTF<F>, A>): OptionT<F, A> = x.ev().orElse { y.ev() }
 }
 
 interface OptionTMonoidK<F> : MonoidK<OptionTF<F>>, OptionTSemigroupK<F> {

--- a/kategory/src/main/kotlin/kategory/instances/StateTInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/StateTInstances.kt
@@ -8,27 +8,20 @@ interface StateTInstances<F, S> :
 
     fun MF(): Monad<F>
 
-    override fun <A, B> flatMap(fa: HK<StateTF<F, S>, A>, f: (A) -> HK<StateTF<F, S>, B>): StateT<F, S, B> =
-            fa.ev().flatMap(f)
+    override fun <A, B> flatMap(fa: HK<StateTF<F, S>, A>, f: (A) -> HK<StateTF<F, S>, B>): StateT<F, S, B> = fa.ev().flatMap(f)
 
-    override fun <A, B> map(fa: HK<StateTF<F, S>, A>, f: (A) -> B): StateT<F, S, B> =
-            fa.ev().map(f)
+    override fun <A, B> map(fa: HK<StateTF<F, S>, A>, f: (A) -> B): StateT<F, S, B> = fa.ev().map(f)
 
-    override fun <A> pure(a: A): StateT<F, S, A> =
-            StateT(MF(), MF().pure({ s: S -> MF().pure(Tuple2(s, a)) }))
+    override fun <A> pure(a: A): StateT<F, S, A> = StateT(MF(), MF().pure({ s: S -> MF().pure(Tuple2(s, a)) }))
 
-    override fun <A, B> ap(fa: HK<StateTF<F, S>, A>, ff: HK<StateTF<F, S>, (A) -> B>): StateT<F, S, B> =
-            ff.ev().map2(fa.ev()) { f, a -> f(a) }
+    override fun <A, B> ap(fa: HK<StateTF<F, S>, A>, ff: HK<StateTF<F, S>, (A) -> B>): StateT<F, S, B> = ff.ev().map2(fa.ev()) { f, a -> f(a) }
 
-    override fun <A, B, Z> map2(fa: HK<StateTF<F, S>, A>, fb: HK<StateTF<F, S>, B>, f: (Tuple2<A, B>) -> Z): StateT<F, S, Z> =
-            fa.ev().map2(fb.ev(), { a, b -> f(Tuple2(a, b)) })
+    override fun <A, B, Z> map2(fa: HK<StateTF<F, S>, A>, fb: HK<StateTF<F, S>, B>, f: (Tuple2<A, B>) -> Z): StateT<F, S, Z> = fa.ev().map2(fb.ev(), { a, b -> f(Tuple2(a, b)) })
 
     @Suppress("UNCHECKED_CAST")
-    override fun <A, B, Z> map2Eval(fa: HK<StateTF<F, S>, A>, fb: Eval<HK<StateTF<F, S>, B>>, f: (Tuple2<A, B>) -> Z): Eval<StateT<F, S, Z>> =
-            fa.ev().map2Eval(fb as Eval<StateT<F, S, B>>) { a, b -> f(Tuple2(a, b)) }
+    override fun <A, B, Z> map2Eval(fa: HK<StateTF<F, S>, A>, fb: Eval<HK<StateTF<F, S>, B>>, f: (Tuple2<A, B>) -> Z): Eval<StateT<F, S, Z>> = fa.ev().map2Eval(fb as Eval<StateT<F, S, B>>) { a, b -> f(Tuple2(a, b)) }
 
-    override fun <A, B> product(fa: HK<StateTF<F, S>, A>, fb: HK<StateTF<F, S>, B>): HK<StateTF<F, S>, Tuple2<A, B>> =
-            fa.ev().product(fb.ev())
+    override fun <A, B> product(fa: HK<StateTF<F, S>, A>, fb: HK<StateTF<F, S>, B>): HK<StateTF<F, S>, Tuple2<A, B>> = fa.ev().product(fb.ev())
 
     override fun <A, B> tailRecM(a: A, f: (A) -> HK<StateTF<F, S>, Either<A, B>>): StateT<F, S, B> =
             StateT(MF(), MF().pure({ s: S ->
@@ -39,11 +32,9 @@ interface StateTInstances<F, S> :
                 })
             }))
 
-    override fun get(): StateT<F, S, S> =
-            StateT(MF(), MF().pure({ s: S -> MF().pure(Tuple2(s, s)) }))
+    override fun get(): StateT<F, S, S> = StateT(MF(), MF().pure({ s: S -> MF().pure(Tuple2(s, s)) }))
 
-    override fun set(s: S): StateT<F, S, Unit> =
-            StateT(MF(), MF().pure({ _: S -> MF().pure(Tuple2(s, Unit)) }))
+    override fun set(s: S): StateT<F, S, Unit> = StateT(MF(), MF().pure({ _: S -> MF().pure(Tuple2(s, Unit)) }))
 
 }
 
@@ -52,6 +43,5 @@ interface StateTSemigroupK<F, S> : SemigroupK<StateTF<F, S>> {
     fun F(): Monad<F>
     fun G(): SemigroupK<F>
 
-    override fun <A> combineK(x: HK<HK2<StateT.F, F, S>, A>, y: HK<HK2<StateT.F, F, S>, A>): StateT<F, S, A> =
-            StateT(F(), F().pure({ s -> G().combineK(x.ev().run(s), y.ev().run(s)) }))
+    override fun <A> combineK(x: HK<HK2<StateT.F, F, S>, A>, y: HK<HK2<StateT.F, F, S>, A>): StateT<F, S, A> = StateT(F(), F().pure({ s -> G().combineK(x.ev().run(s), y.ev().run(s)) }))
 }

--- a/kategory/src/main/kotlin/kategory/instances/TryInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/TryInstances.kt
@@ -16,18 +16,13 @@ interface TryInstances :
 
     override fun <A> raiseError(e: Throwable): Try<A> = Try.Failure(e)
 
-    override fun <A> handleErrorWith(fa: TryKind<A>, f: (Throwable) -> TryKind<A>): Try<A> =
-            fa.ev().recoverWith { f(it).ev() }
+    override fun <A> handleErrorWith(fa: TryKind<A>, f: (Throwable) -> TryKind<A>): Try<A> = fa.ev().recoverWith { f(it).ev() }
 
-    override fun <A, B> tailRecM(a: A, f: (A) -> TryKind<Either<A, B>>): Try<B> =
-            f(a).ev().fold({ Try.raiseError(it) }, { either -> either.fold({ tailRecM(it, f) }, { Try.Success(it) }) })
+    override fun <A, B> tailRecM(a: A, f: (A) -> TryKind<Either<A, B>>): Try<B> = f(a).ev().fold({ Try.raiseError(it) }, { either -> either.fold({ tailRecM(it, f) }, { Try.Success(it) }) })
 
-    override fun <G, A, B> traverse(fa: HK<Try.F, A>, f: (A) -> HK<G, B>, GA: Applicative<G>): HK<G, HK<Try.F, B>> =
-            fa.ev().fold({ GA.pure(Try.raise(IllegalStateException())) }, { GA.map(f(it), { Try { it } }) })
+    override fun <G, A, B> traverse(fa: HK<Try.F, A>, f: (A) -> HK<G, B>, GA: Applicative<G>): HK<G, HK<Try.F, B>> = fa.ev().fold({ GA.pure(Try.raise(IllegalStateException())) }, { GA.map(f(it), { Try { it } }) })
 
-    override fun <A, B> foldL(fa: HK<Try.F, A>, b: B, f: (B, A) -> B): B =
-            fa.ev().fold({ b }, { f(b, it) })
+    override fun <A, B> foldL(fa: HK<Try.F, A>, b: B, f: (B, A) -> B): B = fa.ev().fold({ b }, { f(b, it) })
 
-    override fun <A, B> foldR(fa: HK<Try.F, A>, lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> =
-            fa.ev().fold({ lb }, { f(it, lb) })
+    override fun <A, B> foldR(fa: HK<Try.F, A>, lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> = fa.ev().fold({ lb }, { f(it, lb) })
 }

--- a/kategory/src/main/kotlin/kategory/instances/ValidatedInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/ValidatedInstances.kt
@@ -14,16 +14,13 @@ interface ValidatedInstances<E> :
 
     override fun <A> pure(a: A): Validated<E, A> = Validated.Valid(a)
 
-    override fun <A, B> map(fa: HK<ValidatedF<E>, A>, f: (A) -> B): Validated<E, B> =
-        fa.ev().map(f)
+    override fun <A, B> map(fa: HK<ValidatedF<E>, A>, f: (A) -> B): Validated<E, B> = fa.ev().map(f)
 
     override fun <A> raiseError(e: E): Validated<E, A> = Validated.Invalid(e)
 
-    override fun <A> handleErrorWith(fa: ValidatedKind<E, A>, f: (E) -> ValidatedKind<E, A>): Validated<E, A> =
-            fa.ev().fold({ f(it).ev() }, { Validated.Valid(it) })
+    override fun <A> handleErrorWith(fa: ValidatedKind<E, A>, f: (E) -> ValidatedKind<E, A>): Validated<E, A> = fa.ev().fold({ f(it).ev() }, { Validated.Valid(it) })
 
-    override fun <A, B> ap(fa: ValidatedKind<E, A>, ff: HK<ValidatedF<E>, (A) -> B>): Validated<E, B> =
-            fa.ev().ap(ff.ev(), SE())
+    override fun <A, B> ap(fa: ValidatedKind<E, A>, ff: HK<ValidatedF<E>, (A) -> B>): Validated<E, B> = fa.ev().ap(ff.ev(), SE())
 
     override fun <G, A, B> traverse(fa: HK<ValidatedF<E>, A>, f: (A) -> HK<G, B>, GA: Applicative<G>): HK<G, Validated<E, B>> =
             fa.ev().let { validated ->

--- a/kategory/src/main/kotlin/kategory/instances/WriterTInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/WriterTInstances.kt
@@ -9,14 +9,11 @@ interface WriterTInstances<F, W> :
 
     fun SG(): Monoid<W>
 
-    override fun <A> pure(a: A): HK<WriterF<F, W>, A> =
-            WriterT(MM(), MM().pure(SG().empty() toT a))
+    override fun <A> pure(a: A): HK<WriterF<F, W>, A> = WriterT(MM(), MM().pure(SG().empty() toT a))
 
-    override fun <A, B> map(fa: HK<WriterF<F, W>, A>, f: (A) -> B): HK<WriterF<F, W>, B> =
-            fa.ev().map { f(it) }
+    override fun <A, B> map(fa: HK<WriterF<F, W>, A>, f: (A) -> B): HK<WriterF<F, W>, B> = fa.ev().map { f(it) }
 
-    override fun <A, B> flatMap(fa: WriterTKind<F, W, A>, f: (A) -> HK<WriterF<F, W>, B>): WriterT<F, W, B> =
-            fa.ev().flatMap({ f(it).ev() }, SG())
+    override fun <A, B> flatMap(fa: WriterTKind<F, W, A>, f: (A) -> HK<WriterF<F, W>, B>): WriterT<F, W, B> = fa.ev().flatMap({ f(it).ev() }, SG())
 
     override fun <A, B> tailRecM(a: A, f: (A) -> HK<WriterF<F, W>, Either<A, B>>): WriterT<F, W, B> =
             WriterT(MM(), MM().tailRecM(a, {
@@ -36,8 +33,7 @@ interface WriterTSemigroupK<F, W> : SemigroupK<WriterF<F, W>> {
 
     fun F0(): SemigroupK<F>
 
-    override fun <A> combineK(x: HK<WriterF<F, W>, A>, y: HK<WriterF<F, W>, A>): WriterT<F, W, A> =
-            WriterT(MF(), F0().combineK(x.ev().value, y.ev().value))
+    override fun <A> combineK(x: HK<WriterF<F, W>, A>, y: HK<WriterF<F, W>, A>): WriterT<F, W, A> = WriterT(MF(), F0().combineK(x.ev().value, y.ev().value))
 }
 
 interface WriterTMonoidK<F, W> : MonoidK<WriterF<F, W>>, WriterTSemigroupK<F, W> {

--- a/kategory/src/main/kotlin/kategory/instances/YonedaInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/YonedaInstances.kt
@@ -4,6 +4,5 @@ interface YonedaInstances<U> : Functor<YonedaF<U>> {
 
     fun FM(): Functor<U>
 
-    override fun <A, B> map(fa: HK<YonedaF<U>, A>, f: (A) -> B): HK<YonedaF<U>, B> =
-            fa.ev().map(f, FM())
+    override fun <A, B> map(fa: HK<YonedaF<U>, A>, f: (A) -> B): HK<YonedaF<U>, B> = fa.ev().map(f, FM())
 }

--- a/kategory/src/main/kotlin/kategory/predef.kt
+++ b/kategory/src/main/kotlin/kategory/predef.kt
@@ -2,6 +2,4 @@ package kategory
 
 fun <A> identity(a: A): A = a
 
-fun <A, B, Z> ((A, B) -> Z).curry(): (A) -> (B) -> Z {
-    return { p1: A -> { p2: B -> this(p1, p2) } }
-}
+fun <A, B, Z> ((A, B) -> Z).curry(): (A) -> (B) -> Z = { p1: A -> { p2: B -> this(p1, p2) } }

--- a/kategory/src/main/kotlin/kategory/typeclasses/Applicative.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/Applicative.kt
@@ -8,31 +8,24 @@ interface Applicative<F> : Functor<F>, Typeclass {
 
     fun <A, B> ap(fa: HK<F, A>, ff: HK<F, (A) -> B>): HK<F, B>
 
-    fun <A, B> product(fa: HK<F, A>, fb: HK<F, B>): HK<F, Tuple2<A, B>> =
-            ap(fb, map(fa) { a: A -> { b: B -> Tuple2(a, b) } })
+    fun <A, B> product(fa: HK<F, A>, fb: HK<F, B>): HK<F, Tuple2<A, B>> = ap(fb, map(fa) { a: A -> { b: B -> Tuple2(a, b) } })
 
     override fun <A, B> map(fa: HK<F, A>, f: (A) -> B): HK<F, B> = ap(fa, pure(f))
 
-    fun <A, B, Z> map2(fa: HK<F, A>, fb: HK<F, B>, f: (Tuple2<A, B>) -> Z): HK<F, Z> =
-            map(product(fa, fb), f)
+    fun <A, B, Z> map2(fa: HK<F, A>, fb: HK<F, B>, f: (Tuple2<A, B>) -> Z): HK<F, Z> = map(product(fa, fb), f)
 
-    fun <A, B, Z> map2Eval(fa: HK<F, A>, fb: Eval<HK<F, B>>, f: (Tuple2<A, B>) -> Z): Eval<HK<F, Z>> =
-            fb.map { fc -> map2(fa, fc, f) }
+    fun <A, B, Z> map2Eval(fa: HK<F, A>, fb: Eval<HK<F, B>>, f: (Tuple2<A, B>) -> Z): Eval<HK<F, Z>> = fb.map { fc -> map2(fa, fc, f) }
 }
 
 // Syntax
 
-inline fun <reified F, A> A.pure(FT : Applicative<F> = applicative()): HK<F, A> =
-        FT.pure(this)
+inline fun <reified F, A> A.pure(FT : Applicative<F> = applicative()): HK<F, A> = FT.pure(this)
 
-inline fun <reified F, A, B> HK<F, A>.ap(FT : Applicative<F> = applicative(), ff: HK<F, (A) -> B>): HK<F, B> =
-        FT.ap(this, ff)
+inline fun <reified F, A, B> HK<F, A>.ap(FT : Applicative<F> = applicative(), ff: HK<F, (A) -> B>): HK<F, B> = FT.ap(this, ff)
 
-inline fun <reified F, A, B, Z> HK<F, A>.map2(FT : Applicative<F> = applicative(), fb: HK<F, B>, noinline f: (Tuple2<A, B>) -> Z): HK<F, Z> =
-        FT.map2(this, fb, f)
+inline fun <reified F, A, B, Z> HK<F, A>.map2(FT : Applicative<F> = applicative(), fb: HK<F, B>, noinline f: (Tuple2<A, B>) -> Z): HK<F, Z> = FT.map2(this, fb, f)
 
-inline fun <reified F, A, B, Z> HK<F, A>.map2Eval(FT : Applicative<F> = applicative(), fb: Eval<HK<F, B>>, noinline f: (Tuple2<A, B>) -> Z): Eval<HK<F, Z>> =
-        FT.map2Eval(this, fb, f)
+inline fun <reified F, A, B, Z> HK<F, A>.map2Eval(FT : Applicative<F> = applicative(), fb: Eval<HK<F, B>>, noinline f: (Tuple2<A, B>) -> Z): Eval<HK<F, Z>> = FT.map2Eval(this, fb, f)
 
 //Applicative Builder
 
@@ -74,29 +67,25 @@ infix operator fun <A, B, C, D> Tuple3<A, B, C>.plus(d: D): Tuple4<A, B, C, D> =
 infix operator fun <A, B, C> Tuple2<A, B>.plus(c: C): Tuple3<A, B, C> = Tuple3(this.a, this.b, c)
 infix fun <A, B> A.toT(b: B): Tuple2<A, B> = Tuple2(this, b)
 
-fun <HKF, A, Z> HK<HKF, A>.product(AP: Applicative<HKF>, other: HK<HKF, Z>): HK<HKF, Tuple2<A, Z>> =
-        AP.product(this, other)
+fun <HKF, A, Z> HK<HKF, A>.product(AP: Applicative<HKF>, other: HK<HKF, Z>): HK<HKF, Tuple2<A, Z>> = AP.product(this, other)
 
 fun <HKF, A, B, Z> HK<HKF, Tuple2<A, B>>.product(
         AP: Applicative<HKF>,
         other: HK<HKF, Z>,
-        dummyImplicit: Any? = null): HK<HKF, Tuple3<A, B, Z>> =
-        AP.map(AP.product(this, other), { Tuple3(it.a.a, it.a.b, it.b) })
+        dummyImplicit: Any? = null): HK<HKF, Tuple3<A, B, Z>> = AP.map(AP.product(this, other), { Tuple3(it.a.a, it.a.b, it.b) })
 
 fun <HKF, A, B, C, Z> HK<HKF, Tuple3<A, B, C>>.product(
         AP: Applicative<HKF>,
         other: HK<HKF, Z>,
         dummyImplicit: Any? = null,
-        dummyImplicit2: Any? = null): HK<HKF, Tuple4<A, B, C, Z>> =
-        AP.map(AP.product(this, other), { Tuple4(it.a.a, it.a.b, it.a.c, it.b) })
+        dummyImplicit2: Any? = null): HK<HKF, Tuple4<A, B, C, Z>> = AP.map(AP.product(this, other), { Tuple4(it.a.a, it.a.b, it.a.c, it.b) })
 
 fun <HKF, A, B, C, D, Z> HK<HKF, Tuple4<A, B, C, D>>.product(
         AP: Applicative<HKF>,
         other: HK<HKF, Z>,
         dummyImplicit: Any? = null,
         dummyImplicit2: Any? = null,
-        dummyImplicit3: Any? = null): HK<HKF, Tuple5<A, B, C, D, Z>> =
-        AP.map(AP.product(this, other), { Tuple5(it.a.a, it.a.b, it.a.c, it.a.d, it.b) })
+        dummyImplicit3: Any? = null): HK<HKF, Tuple5<A, B, C, D, Z>> = AP.map(AP.product(this, other), { Tuple5(it.a.a, it.a.b, it.a.c, it.a.d, it.b) })
 
 fun <HKF, A, B, C, D, E, Z> HK<HKF, Tuple5<A, B, C, D, E>>.product(
         AP: Applicative<HKF>,
@@ -104,8 +93,7 @@ fun <HKF, A, B, C, D, E, Z> HK<HKF, Tuple5<A, B, C, D, E>>.product(
         dummyImplicit: Any? = null,
         dummyImplicit2: Any? = null,
         dummyImplicit3: Any? = null,
-        dummyImplicit4: Any? = null): HK<HKF, Tuple6<A, B, C, D, E, Z>> =
-        AP.map(AP.product(this, other), { Tuple6(it.a.a, it.a.b, it.a.c, it.a.d, it.a.e, it.b) })
+        dummyImplicit4: Any? = null): HK<HKF, Tuple6<A, B, C, D, E, Z>> = AP.map(AP.product(this, other), { Tuple6(it.a.a, it.a.b, it.a.c, it.a.d, it.a.e, it.b) })
 
 fun <HKF, A, B, C, D, E, F, Z> HK<HKF, Tuple6<A, B, C, D, E, F>>.product(
         AP: Applicative<HKF>,
@@ -114,8 +102,7 @@ fun <HKF, A, B, C, D, E, F, Z> HK<HKF, Tuple6<A, B, C, D, E, F>>.product(
         dummyImplicit2: Any? = null,
         dummyImplicit3: Any? = null,
         dummyImplicit4: Any? = null,
-        dummyImplicit5: Any? = null): HK<HKF, Tuple7<A, B, C, D, E, F, Z>> =
-        AP.map(AP.product(this, other), { Tuple7(it.a.a, it.a.b, it.a.c, it.a.d, it.a.e, it.a.f, it.b) })
+        dummyImplicit5: Any? = null): HK<HKF, Tuple7<A, B, C, D, E, F, Z>> = AP.map(AP.product(this, other), { Tuple7(it.a.a, it.a.b, it.a.c, it.a.d, it.a.e, it.a.f, it.b) })
 
 fun <HKF, A, B, C, D, E, F, G, Z> HK<HKF, Tuple7<A, B, C, D, E, F, G>>.product(
         AP: Applicative<HKF>,
@@ -125,8 +112,7 @@ fun <HKF, A, B, C, D, E, F, G, Z> HK<HKF, Tuple7<A, B, C, D, E, F, G>>.product(
         dummyImplicit3: Any? = null,
         dummyImplicit4: Any? = null,
         dummyImplicit5: Any? = null,
-        dummyImplicit6: Any? = null): HK<HKF, Tuple8<A, B, C, D, E, F, G, Z>> =
-        AP.map(AP.product(this, other), { Tuple8(it.a.a, it.a.b, it.a.c, it.a.d, it.a.e, it.a.f, it.a.g, it.b) })
+        dummyImplicit6: Any? = null): HK<HKF, Tuple8<A, B, C, D, E, F, G, Z>> = AP.map(AP.product(this, other), { Tuple8(it.a.a, it.a.b, it.a.c, it.a.d, it.a.e, it.a.f, it.a.g, it.b) })
 
 fun <HKF, A, B, C, D, E, F, G, H, Z> HK<HKF, Tuple8<A, B, C, D, E, F, G, H>>.product(
         AP: Applicative<HKF>,
@@ -137,8 +123,7 @@ fun <HKF, A, B, C, D, E, F, G, H, Z> HK<HKF, Tuple8<A, B, C, D, E, F, G, H>>.pro
         dummyImplicit4: Any? = null,
         dummyImplicit5: Any? = null,
         dummyImplicit6: Any? = null,
-        dummyImplicit7: Any? = null): HK<HKF, Tuple9<A, B, C, D, E, F, G, H, Z>> =
-        AP.map(AP.product(this, other), { Tuple9(it.a.a, it.a.b, it.a.c, it.a.d, it.a.e, it.a.f, it.a.g, it.a.h, it.b) })
+        dummyImplicit7: Any? = null): HK<HKF, Tuple9<A, B, C, D, E, F, G, H, Z>> = AP.map(AP.product(this, other), { Tuple9(it.a.a, it.a.b, it.a.c, it.a.d, it.a.e, it.a.f, it.a.g, it.a.h, it.b) })
 
 fun <HKF, A, B, C, D, E, F, G, H, I, Z> HK<HKF, Tuple9<A, B, C, D, E, F, G, H, I>>.product(
         AP: Applicative<HKF>,
@@ -150,34 +135,29 @@ fun <HKF, A, B, C, D, E, F, G, H, I, Z> HK<HKF, Tuple9<A, B, C, D, E, F, G, H, I
         dummyImplicit5: Any? = null,
         dummyImplicit6: Any? = null,
         dummyImplicit7: Any? = null,
-        dummyImplicit9: Any? = null): HK<HKF, Tuple10<A, B, C, D, E, F, G, H, I, Z>> =
-        AP.map(AP.product(this, other), { Tuple10(it.a.a, it.a.b, it.a.c, it.a.d, it.a.e, it.a.f, it.a.g, it.a.h, it.a.i, it.b) })
+        dummyImplicit9: Any? = null): HK<HKF, Tuple10<A, B, C, D, E, F, G, H, I, Z>> = AP.map(AP.product(this, other), { Tuple10(it.a.a, it.a.b, it.a.c, it.a.d, it.a.e, it.a.f, it.a.g, it.a.h, it.a.i, it.b) })
 
 fun <HKF, A, B> Applicative<HKF>.tupled(
         a: HK<HKF, A>,
-        b: HK<HKF, B>): HK<HKF, Tuple2<A, B>> =
-        a.product(this, b)
+        b: HK<HKF, B>): HK<HKF, Tuple2<A, B>> = a.product(this, b)
 
 fun <HKF, A, B, C> Applicative<HKF>.tupled(
         a: HK<HKF, A>,
         b: HK<HKF, B>,
-        c: HK<HKF, C>): HK<HKF, Tuple3<A, B, C>> =
-        a.product(this, b).product(this, c)
+        c: HK<HKF, C>): HK<HKF, Tuple3<A, B, C>> = a.product(this, b).product(this, c)
 
 fun <HKF, A, B, C, D> Applicative<HKF>.tupled(
         a: HK<HKF, A>,
         b: HK<HKF, B>,
         c: HK<HKF, C>,
-        d: HK<HKF, D>): HK<HKF, Tuple4<A, B, C, D>> =
-        a.product(this, b).product(this, c).product(this, d)
+        d: HK<HKF, D>): HK<HKF, Tuple4<A, B, C, D>> = a.product(this, b).product(this, c).product(this, d)
 
 fun <HKF, A, B, C, D, E> Applicative<HKF>.tupled(
         a: HK<HKF, A>,
         b: HK<HKF, B>,
         c: HK<HKF, C>,
         d: HK<HKF, D>,
-        e: HK<HKF, E>): HK<HKF, Tuple5<A, B, C, D, E>> =
-        a.product(this, b).product(this, c).product(this, d).product(this, e)
+        e: HK<HKF, E>): HK<HKF, Tuple5<A, B, C, D, E>> = a.product(this, b).product(this, c).product(this, d).product(this, e)
 
 fun <HKF, A, B, C, D, E, F> Applicative<HKF>.tupled(
         a: HK<HKF, A>,
@@ -185,8 +165,7 @@ fun <HKF, A, B, C, D, E, F> Applicative<HKF>.tupled(
         c: HK<HKF, C>,
         d: HK<HKF, D>,
         e: HK<HKF, E>,
-        f: HK<HKF, F>): HK<HKF, Tuple6<A, B, C, D, E, F>> =
-        a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f)
+        f: HK<HKF, F>): HK<HKF, Tuple6<A, B, C, D, E, F>> = a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f)
 
 fun <HKF, A, B, C, D, E, F, G> Applicative<HKF>.tupled(
         a: HK<HKF, A>,
@@ -195,8 +174,7 @@ fun <HKF, A, B, C, D, E, F, G> Applicative<HKF>.tupled(
         d: HK<HKF, D>,
         e: HK<HKF, E>,
         f: HK<HKF, F>,
-        g: HK<HKF, G>): HK<HKF, Tuple7<A, B, C, D, E, F, G>> =
-        a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g)
+        g: HK<HKF, G>): HK<HKF, Tuple7<A, B, C, D, E, F, G>> = a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g)
 
 fun <HKF, A, B, C, D, E, F, G, H> Applicative<HKF>.tupled(
         a: HK<HKF, A>,
@@ -206,8 +184,7 @@ fun <HKF, A, B, C, D, E, F, G, H> Applicative<HKF>.tupled(
         e: HK<HKF, E>,
         f: HK<HKF, F>,
         g: HK<HKF, G>,
-        h: HK<HKF, H>): HK<HKF, Tuple8<A, B, C, D, E, F, G, H>> =
-        a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g).product(this, h)
+        h: HK<HKF, H>): HK<HKF, Tuple8<A, B, C, D, E, F, G, H>> = a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g).product(this, h)
 
 fun <HKF, A, B, C, D, E, F, G, H, I> Applicative<HKF>.tupled(
         a: HK<HKF, A>,
@@ -218,8 +195,7 @@ fun <HKF, A, B, C, D, E, F, G, H, I> Applicative<HKF>.tupled(
         f: HK<HKF, F>,
         g: HK<HKF, G>,
         h: HK<HKF, H>,
-        i: HK<HKF, I>): HK<HKF, Tuple9<A, B, C, D, E, F, G, H, I>> =
-        a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g).product(this, h).product(this, i)
+        i: HK<HKF, I>): HK<HKF, Tuple9<A, B, C, D, E, F, G, H, I>> = a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g).product(this, h).product(this, i)
 
 fun <HKF, A, B, C, D, E, F, G, H, I, J> Applicative<HKF>.tupled(
         a: HK<HKF, A>,
@@ -231,29 +207,25 @@ fun <HKF, A, B, C, D, E, F, G, H, I, J> Applicative<HKF>.tupled(
         g: HK<HKF, G>,
         h: HK<HKF, H>,
         i: HK<HKF, I>,
-        j: HK<HKF, J>): HK<HKF, Tuple10<A, B, C, D, E, F, G, H, I, J>> =
-        a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g).product(this, h).product(this, i).product(this, j)
+        j: HK<HKF, J>): HK<HKF, Tuple10<A, B, C, D, E, F, G, H, I, J>> = a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g).product(this, h).product(this, i).product(this, j)
 
 fun <HKF, A, B, Z> Applicative<HKF>.map(
         a: HK<HKF, A>,
         b: HK<HKF, B>,
-        lbd: (Tuple2<A, B>) -> Z): HK<HKF, Z> =
-        this.map(a.product(this, b), lbd)
+        lbd: (Tuple2<A, B>) -> Z): HK<HKF, Z> = this.map(a.product(this, b), lbd)
 
 fun <HKF, A, B, C, Z> Applicative<HKF>.map(
         a: HK<HKF, A>,
         b: HK<HKF, B>,
         c: HK<HKF, C>,
-        lbd: (Tuple3<A, B, C>) -> Z): HK<HKF, Z> =
-        this.map(a.product(this, b).product(this, c), lbd)
+        lbd: (Tuple3<A, B, C>) -> Z): HK<HKF, Z> = this.map(a.product(this, b).product(this, c), lbd)
 
 fun <HKF, A, B, C, D, Z> Applicative<HKF>.map(
         a: HK<HKF, A>,
         b: HK<HKF, B>,
         c: HK<HKF, C>,
         d: HK<HKF, D>,
-        lbd: (Tuple4<A, B, C, D>) -> Z): HK<HKF, Z> =
-        this.map(a.product(this, b).product(this, c).product(this, d), lbd)
+        lbd: (Tuple4<A, B, C, D>) -> Z): HK<HKF, Z> = this.map(a.product(this, b).product(this, c).product(this, d), lbd)
 
 fun <HKF, A, B, C, D, E, Z> Applicative<HKF>.map(
         a: HK<HKF, A>,
@@ -261,8 +233,7 @@ fun <HKF, A, B, C, D, E, Z> Applicative<HKF>.map(
         c: HK<HKF, C>,
         d: HK<HKF, D>,
         e: HK<HKF, E>,
-        lbd: (Tuple5<A, B, C, D, E>) -> Z): HK<HKF, Z> =
-        this.map(a.product(this, b).product(this, c).product(this, d).product(this, e), lbd)
+        lbd: (Tuple5<A, B, C, D, E>) -> Z): HK<HKF, Z> = this.map(a.product(this, b).product(this, c).product(this, d).product(this, e), lbd)
 
 fun <HKF, A, B, C, D, E, F, Z> Applicative<HKF>.map(
         a: HK<HKF, A>,
@@ -271,8 +242,7 @@ fun <HKF, A, B, C, D, E, F, Z> Applicative<HKF>.map(
         d: HK<HKF, D>,
         e: HK<HKF, E>,
         f: HK<HKF, F>,
-        lbd: (Tuple6<A, B, C, D, E, F>) -> Z): HK<HKF, Z> =
-        this.map(a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f), lbd)
+        lbd: (Tuple6<A, B, C, D, E, F>) -> Z): HK<HKF, Z> = this.map(a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f), lbd)
 
 fun <HKF, A, B, C, D, E, F, G, Z> Applicative<HKF>.map(
         a: HK<HKF, A>,
@@ -282,8 +252,7 @@ fun <HKF, A, B, C, D, E, F, G, Z> Applicative<HKF>.map(
         e: HK<HKF, E>,
         f: HK<HKF, F>,
         g: HK<HKF, G>,
-        lbd: (Tuple7<A, B, C, D, E, F, G>) -> Z): HK<HKF, Z> =
-        this.map(a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g), lbd)
+        lbd: (Tuple7<A, B, C, D, E, F, G>) -> Z): HK<HKF, Z> = this.map(a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g), lbd)
 
 fun <HKF, A, B, C, D, E, F, G, H, Z> Applicative<HKF>.map(
         a: HK<HKF, A>,
@@ -294,8 +263,7 @@ fun <HKF, A, B, C, D, E, F, G, H, Z> Applicative<HKF>.map(
         f: HK<HKF, F>,
         g: HK<HKF, G>,
         h: HK<HKF, H>,
-        lbd: (Tuple8<A, B, C, D, E, F, G, H>) -> Z): HK<HKF, Z> =
-        this.map(a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g).product(this, h), lbd)
+        lbd: (Tuple8<A, B, C, D, E, F, G, H>) -> Z): HK<HKF, Z> = this.map(a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g).product(this, h), lbd)
 
 fun <HKF, A, B, C, D, E, F, G, H, I, Z> Applicative<HKF>.map(
         a: HK<HKF, A>,
@@ -307,8 +275,7 @@ fun <HKF, A, B, C, D, E, F, G, H, I, Z> Applicative<HKF>.map(
         g: HK<HKF, G>,
         h: HK<HKF, H>,
         i: HK<HKF, I>,
-        lbd: (Tuple9<A, B, C, D, E, F, G, H, I>) -> Z): HK<HKF, Z> =
-        this.map(a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g).product(this, h).product(this, i), lbd)
+        lbd: (Tuple9<A, B, C, D, E, F, G, H, I>) -> Z): HK<HKF, Z> = this.map(a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g).product(this, h).product(this, i), lbd)
 
 fun <HKF, A, B, C, D, E, F, G, H, I, J, Z> Applicative<HKF>.map(
         a: HK<HKF, A>,
@@ -321,8 +288,6 @@ fun <HKF, A, B, C, D, E, F, G, H, I, J, Z> Applicative<HKF>.map(
         h: HK<HKF, H>,
         i: HK<HKF, I>,
         j: HK<HKF, J>,
-        lbd: (Tuple10<A, B, C, D, E, F, G, H, I, J>) -> Z): HK<HKF, Z> =
-        this.map(a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g).product(this, h).product(this, i).product(this, j), lbd)
+        lbd: (Tuple10<A, B, C, D, E, F, G, H, I, J>) -> Z): HK<HKF, Z> = this.map(a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g).product(this, h).product(this, i).product(this, j), lbd)
 
-inline fun <reified F> applicative(): Applicative<F> =
-        instance(InstanceParametrizedType(Applicative::class.java, listOf(F::class.java)))
+inline fun <reified F> applicative(): Applicative<F> = instance(InstanceParametrizedType(Applicative::class.java, listOf(F::class.java)))

--- a/kategory/src/main/kotlin/kategory/typeclasses/ApplicativeError.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/ApplicativeError.kt
@@ -6,16 +6,14 @@ interface ApplicativeError<F, E> : Applicative<F>, Typeclass {
 
     fun <A> handleErrorWith(fa: HK<F, A>, f: (E) -> HK<F, A>): HK<F, A>
 
-    fun <A> handleError(fa: HK<F, A>, f: (E) -> A): HK<F, A> =
-            handleErrorWith(fa) { pure(f(it)) }
+    fun <A> handleError(fa: HK<F, A>, f: (E) -> A): HK<F, A> = handleErrorWith(fa) { pure(f(it)) }
 
     fun <A> attempt(fa: HK<F, A>): HK<F, Either<E, A>> =
             handleErrorWith(map(fa) { Either.Right(it) }) {
                 pure(Either.Left(it))
             }
 
-    fun <A> fromEither(fab: Either<E, A>): HK<F, A> =
-            fab.fold({ raiseError<A>(it) }, { pure(it) })
+    fun <A> fromEither(fab: Either<E, A>): HK<F, A> = fab.fold({ raiseError<A>(it) }, { pure(it) })
 
     fun <A> catch(f: () -> A, recover: (Throwable) -> E): HK<F, A> =
             try {
@@ -25,20 +23,15 @@ interface ApplicativeError<F, E> : Applicative<F>, Typeclass {
             }
 }
 
-inline fun <reified F, reified E, A> A.raiseError(FT: ApplicativeError<F, E> = applicativeError(), e: E): HK<F, A> =
-        FT.raiseError<A>(e)
+inline fun <reified F, reified E, A> A.raiseError(FT: ApplicativeError<F, E> = applicativeError(), e: E): HK<F, A> = FT.raiseError<A>(e)
 
-inline fun <reified F, reified E, A> HK<F, A>.handlerErrorWith(FT: ApplicativeError<F, E> = applicativeError(), noinline f: (E) -> HK<F, A>): HK<F, A> =
-        FT.handleErrorWith(this, f)
+inline fun <reified F, reified E, A> HK<F, A>.handlerErrorWith(FT: ApplicativeError<F, E> = applicativeError(), noinline f: (E) -> HK<F, A>): HK<F, A> = FT.handleErrorWith(this, f)
 
-inline fun <reified F, reified E, A> HK<F, A>.attempt(FT: ApplicativeError<F, E> = applicativeError()): HK<F, Either<E, A>> =
-        FT.attempt(this)
+inline fun <reified F, reified E, A> HK<F, A>.attempt(FT: ApplicativeError<F, E> = applicativeError()): HK<F, Either<E, A>> = FT.attempt(this)
 
-inline fun <reified F, reified E, A> Either<E, A>.toError(FT: ApplicativeError<F, E> = applicativeError()): HK<F, A> =
-        FT.fromEither(this)
+inline fun <reified F, reified E, A> Either<E, A>.toError(FT: ApplicativeError<F, E> = applicativeError()): HK<F, A> = FT.fromEither(this)
 
-inline fun <reified F, A> (() -> A).catch(FT: ApplicativeError<F, Throwable> = applicativeError()): HK<F, A> =
-        FT.catch(this)
+inline fun <reified F, A> (() -> A).catch(FT: ApplicativeError<F, Throwable> = applicativeError()): HK<F, A> = FT.catch(this)
 
 fun <F, A> ApplicativeError<F, Throwable>.catch(f: () -> A): HK<F, A> =
         try {
@@ -48,5 +41,4 @@ fun <F, A> ApplicativeError<F, Throwable>.catch(f: () -> A): HK<F, A> =
             raiseError(e)
         }
 
-inline fun <reified F, reified E> applicativeError(): ApplicativeError<F, E> =
-        instance(InstanceParametrizedType(ApplicativeError::class.java, listOf(F::class.java, E::class.java)))
+inline fun <reified F, reified E> applicativeError(): ApplicativeError<F, E> = instance(InstanceParametrizedType(ApplicativeError::class.java, listOf(F::class.java, E::class.java)))

--- a/kategory/src/main/kotlin/kategory/typeclasses/Bimonad.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/Bimonad.kt
@@ -5,5 +5,4 @@ package kategory
  */
 interface Bimonad<F> : Monad<F>, Comonad<F>, Typeclass
 
-inline fun <reified F> bimonad(): Bimonad<F> =
-        instance(InstanceParametrizedType(Bimonad::class.java, listOf(F::class.java)))
+inline fun <reified F> bimonad(): Bimonad<F> = instance(InstanceParametrizedType(Bimonad::class.java, listOf(F::class.java)))

--- a/kategory/src/main/kotlin/kategory/typeclasses/Comonad.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/Comonad.kt
@@ -17,18 +17,14 @@ interface Comonad<F> : Functor<F>, Typeclass {
 
     fun <A> extract(fa: HK<F, A>): A
 
-    fun <A> duplicate(fa: HK<F, A>): HK<F, HK<F, A>> =
-            coflatMap(fa, { it })
+    fun <A> duplicate(fa: HK<F, A>): HK<F, HK<F, A>> = coflatMap(fa, { it })
 }
 
-inline fun <reified F, A, B> HK<F, A>.coflatMap(FT: Comonad<F> = comonad(), noinline f: (HK<F, A>) -> B): HK<F, B> =
-        FT.coflatMap(this, f)
+inline fun <reified F, A, B> HK<F, A>.coflatMap(FT: Comonad<F> = comonad(), noinline f: (HK<F, A>) -> B): HK<F, B> = FT.coflatMap(this, f)
 
-inline fun <reified F, A> HK<F, A>.extract(FT: Comonad<F> = comonad()): A =
-        FT.extract(this)
+inline fun <reified F, A> HK<F, A>.extract(FT: Comonad<F> = comonad()): A = FT.extract(this)
 
-inline fun <reified F, A> HK<F, A>.duplicate(FT: Comonad<F> = comonad()): HK<F, HK<F, A>> =
-        FT.duplicate(this)
+inline fun <reified F, A> HK<F, A>.duplicate(FT: Comonad<F> = comonad()): HK<F, HK<F, A>> = FT.duplicate(this)
 
 @RestrictsSuspension
 open class ComonadContinuation<F, A : Any>(val CM: Comonad<F>) : Serializable, Continuation<A> {
@@ -71,5 +67,4 @@ fun <F, B : Any> Comonad<F>.cobinding(c: suspend ComonadContinuation<F, *>.() ->
     return continuation.returnedMonad
 }
 
-inline fun <reified F> comonad(): Comonad<F> =
-        instance(InstanceParametrizedType(Comonad::class.java, listOf(F::class.java)))
+inline fun <reified F> comonad(): Comonad<F> = instance(InstanceParametrizedType(Comonad::class.java, listOf(F::class.java)))

--- a/kategory/src/main/kotlin/kategory/typeclasses/Eq.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/Eq.kt
@@ -3,28 +3,21 @@ package kategory
 interface Eq<in F> : Typeclass {
     fun eqv(a: F, b: F): Boolean
 
-    fun neqv(a: F, b: F): Boolean =
-            !eqv(a, b)
+    fun neqv(a: F, b: F): Boolean = !eqv(a, b)
 
     companion object {
-        fun any(): Eq<Any?> =
-                EqAny
+        fun any(): Eq<Any?> = EqAny
 
         object EqAny : Eq<Any?> {
-            override fun eqv(a: Any?, b: Any?): Boolean =
-                    a == b
+            override fun eqv(a: Any?, b: Any?): Boolean = a == b
 
-            override fun neqv(a: Any?, b: Any?): Boolean =
-                    a != b
+            override fun neqv(a: Any?, b: Any?): Boolean = a != b
         }
     }
 }
 
-inline fun <reified F> eq(): Eq<F> =
-        instance(InstanceParametrizedType(Eq::class.java, listOf(F::class.java)))
+inline fun <reified F> eq(): Eq<F> = instance(InstanceParametrizedType(Eq::class.java, listOf(F::class.java)))
 
-inline fun <reified F> F.eqv(EQ: Eq<F> = eq(), b: F) : Boolean =
-        EQ.eqv(this, b)
+inline fun <reified F> F.eqv(EQ: Eq<F> = eq(), b: F) : Boolean = EQ.eqv(this, b)
 
-inline fun <reified F> F.neqv(EQ: Eq<F> = eq(), b: F) : Boolean =
-        EQ.neqv(this, b)
+inline fun <reified F> F.neqv(EQ: Eq<F> = eq(), b: F) : Boolean = EQ.neqv(this, b)

--- a/kategory/src/main/kotlin/kategory/typeclasses/Foldable.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/Foldable.kt
@@ -33,8 +33,7 @@ interface Foldable<in F> : Typeclass {
     /**
      * Fold implemented using the given Monoid<A> instance.
      */
-    fun <A> fold(ma: Monoid<A>, fa: HK<F, A>): A =
-            foldL(fa, ma.empty(), { acc, a -> ma.combine(acc, a) })
+    fun <A> fold(ma: Monoid<A>, fa: HK<F, A>): A = foldL(fa, ma.empty(), { acc, a -> ma.combine(acc, a) })
 
     /**
      * Alias for fold.
@@ -44,8 +43,7 @@ interface Foldable<in F> : Typeclass {
     /**
      * Fold implemented by mapping A values into B and then combining them using the given Monoid<B> instance.
      */
-    fun <A, B> foldMap(mb: Monoid<B>, fa: HK<F, A>, f: (A) -> B): B =
-            foldL(fa, mb.empty(), { b, a -> mb.combine(b, f(a)) })
+    fun <A, B> foldMap(mb: Monoid<B>, fa: HK<F, A>, f: (A) -> B): B = foldL(fa, mb.empty(), { b, a -> mb.combine(b, f(a)) })
 
     /**
      * Traverse F<A> using Applicative<G>.
@@ -55,16 +53,14 @@ interface Foldable<in F> : Typeclass {
      * This method is primarily useful when G<_> represents an action or effect, and the specific A aspect of G<A> is
      * not otherwise needed.
      */
-    fun <G, A, B> traverse_(ag: Applicative<G>, fa: HK<F, A>, f: (A) -> HK<G, B>): HK<G, Unit> =
-            foldR(fa, always { ag.pure(Unit) }, { a, acc -> ag.map2Eval(f(a), acc) { Unit } }).value()
+    fun <G, A, B> traverse_(ag: Applicative<G>, fa: HK<F, A>, f: (A) -> HK<G, B>): HK<G, Unit> = foldR(fa, always { ag.pure(Unit) }, { a, acc -> ag.map2Eval(f(a), acc) { Unit } }).value()
 
     /**
      * Sequence F<G<A>> using Applicative<G>.
      *
      * Similar to traverse except it operates on F<G<A>> values, so no additional functions are needed.
      */
-    fun <G, A> sequence_(ag: Applicative<G>, fga: HK<F, HK<G, A>>): HK<G, Unit> =
-            traverse_(ag, fga, { it })
+    fun <G, A> sequence_(ag: Applicative<G>, fga: HK<F, HK<G, A>>): HK<G, Unit> = traverse_(ag, fga, { it })
 
     /**
      * Find the first element matching the predicate, if one exists.
@@ -79,25 +75,21 @@ interface Foldable<in F> : Typeclass {
      *
      * If there are no elements, the result is false.
      */
-    fun <A> exists(fa: HK<F, A>, p: (A) -> Boolean): Boolean =
-            foldR(fa, Eval.False, { a, lb -> if (p(a)) Eval.True else lb }).value()
+    fun <A> exists(fa: HK<F, A>, p: (A) -> Boolean): Boolean = foldR(fa, Eval.False, { a, lb -> if (p(a)) Eval.True else lb }).value()
 
     /**
      * Check whether all elements satisfy the predicate.
      *
      * If there are no elements, the result is true.
      */
-    fun <A> forall(fa: HK<F, A>, p: (A) -> Boolean): Boolean =
-            foldR(fa, Eval.True, { a, lb -> if (p(a)) lb else Eval.False }).value()
+    fun <A> forall(fa: HK<F, A>, p: (A) -> Boolean): Boolean = foldR(fa, Eval.True, { a, lb -> if (p(a)) lb else Eval.False }).value()
 
     /**
      * Returns true if there are no elements. Otherwise false.
      */
-    fun <A> isEmpty(fa: HK<F, A>): Boolean =
-            foldR(fa, Eval.True, { _, _ -> Eval.False }).value()
+    fun <A> isEmpty(fa: HK<F, A>): Boolean = foldR(fa, Eval.True, { _, _ -> Eval.False }).value()
 
-    fun <A> nonEmpty(fa: HK<F, A>): Boolean =
-            !isEmpty(fa)
+    fun <A> nonEmpty(fa: HK<F, A>): Boolean = !isEmpty(fa)
 
     companion object {
         fun <A, B> iterateRight(it: Iterator<A>, lb: Eval<B>): (f: (A, Eval<B>) -> Eval<B>) -> Eval<B> = {
@@ -114,8 +106,7 @@ interface Foldable<in F> : Typeclass {
  *
  * Similar to foldM, but using a Monoid<B>.
  */
-inline fun <F, reified G, A, reified B> Foldable<F>.foldMapM(fa: HK<F, A>, noinline f: (A) -> HK<G, B>, MG: Monad<G> = monad(), bb: Monoid<B> = monoid()): HK<G, B> =
-        foldM(fa, bb.empty(), { b, a -> MG.map(f(a)) { bb.combine(b, it) } }, MG)
+inline fun <F, reified G, A, reified B> Foldable<F>.foldMapM(fa: HK<F, A>, noinline f: (A) -> HK<G, B>, MG: Monad<G> = monad(), bb: Monoid<B> = monoid()): HK<G, B> = foldM(fa, bb.empty(), { b, a -> MG.map(f(a)) { bb.combine(b, it) } }, MG)
 
 /**
  * Left associative monadic folding on F.
@@ -124,47 +115,32 @@ inline fun <F, reified G, A, reified B> Foldable<F>.foldMapM(fa: HK<F, A>, noinl
  * Certain structures are able to implement this in such a way that folds can be short-circuited (not traverse the
  * entirety of the structure), depending on the G result produced at a given step.
  */
-inline fun <F, reified G, A, B> Foldable<F>.foldM(fa: HK<F, A>, z: B, crossinline f: (B, A) -> HK<G, B>, MG: Monad<G> = monad()): HK<G, B> =
-        foldL(fa, MG.pure(z), { gb, a -> MG.flatMap(gb) { f(it, a) } })
+inline fun <F, reified G, A, B> Foldable<F>.foldM(fa: HK<F, A>, z: B, crossinline f: (B, A) -> HK<G, B>, MG: Monad<G> = monad()): HK<G, B> = foldL(fa, MG.pure(z), { gb, a -> MG.flatMap(gb) { f(it, a) } })
 
-inline fun <reified F> foldable(): Foldable<F> =
-        instance(InstanceParametrizedType(Foldable::class.java, listOf(F::class.java)))
+inline fun <reified F> foldable(): Foldable<F> = instance(InstanceParametrizedType(Foldable::class.java, listOf(F::class.java)))
 
-inline fun <reified F, A, B> HK<F, A>.foldL(FT: Foldable<F> = foldable(), b: B, noinline f: (B, A) -> B): B =
-        FT.foldL(this, b, f)
+inline fun <reified F, A, B> HK<F, A>.foldL(FT: Foldable<F> = foldable(), b: B, noinline f: (B, A) -> B): B = FT.foldL(this, b, f)
 
-inline fun <reified F, A, B> HK<F, A>.foldR(FT: Foldable<F> = foldable(), b: Eval<B>, noinline f: (A, Eval<B>) -> Eval<B>): Eval<B> =
-        FT.foldR(this, b, f)
+inline fun <reified F, A, B> HK<F, A>.foldR(FT: Foldable<F> = foldable(), b: Eval<B>, noinline f: (A, Eval<B>) -> Eval<B>): Eval<B> = FT.foldR(this, b, f)
 
-inline fun <reified F, reified A> HK<F, A>.fold(FT: Foldable<F> = foldable(), MA: Monoid<A> = monoid()): A =
-        FT.fold(MA, this)
+inline fun <reified F, reified A> HK<F, A>.fold(FT: Foldable<F> = foldable(), MA: Monoid<A> = monoid()): A = FT.fold(MA, this)
 
-inline fun <reified F, reified A> HK<F, A>.combineAll(FT: Foldable<F> = foldable(), MA: Monoid<A> = monoid()): A =
-        FT.combineAll(MA, this)
+inline fun <reified F, reified A> HK<F, A>.combineAll(FT: Foldable<F> = foldable(), MA: Monoid<A> = monoid()): A = FT.combineAll(MA, this)
 
-inline fun <reified F, A, reified B> HK<F, A>.foldMap(FT: Foldable<F> = foldable(), MB: Monoid<B> = monoid(), noinline f: (A) -> B): B =
-        FT.foldMap(MB, this, f)
+inline fun <reified F, A, reified B> HK<F, A>.foldMap(FT: Foldable<F> = foldable(), MB: Monoid<B> = monoid(), noinline f: (A) -> B): B = FT.foldMap(MB, this, f)
 
-inline fun <reified F, reified G, A, B> HK<F, A>.traverse_(FT: Foldable<F> = foldable(), AG: Applicative<G> = applicative(), noinline f: (A) -> HK<G, B>): HK<G, Unit> =
-        FT.traverse_(AG, this, f)
+inline fun <reified F, reified G, A, B> HK<F, A>.traverse_(FT: Foldable<F> = foldable(), AG: Applicative<G> = applicative(), noinline f: (A) -> HK<G, B>): HK<G, Unit> = FT.traverse_(AG, this, f)
 
-inline fun <reified F, reified G, A> HK<F, HK<G, A>>.sequence_(FT: Foldable<F> = foldable(), AG: Applicative<G> = applicative()): HK<G, Unit> =
-        FT.sequence_(AG, this)
+inline fun <reified F, reified G, A> HK<F, HK<G, A>>.sequence_(FT: Foldable<F> = foldable(), AG: Applicative<G> = applicative()): HK<G, Unit> = FT.sequence_(AG, this)
 
-inline fun <reified F, A> HK<F, A>.find(FT: Foldable<F> = foldable(), noinline f: (A) -> Boolean): Option<A> =
-        FT.find(this, f)
+inline fun <reified F, A> HK<F, A>.find(FT: Foldable<F> = foldable(), noinline f: (A) -> Boolean): Option<A> = FT.find(this, f)
 
-inline fun <reified F, A> HK<F, A>.exists(FT: Foldable<F> = foldable(), noinline f: (A) -> Boolean): Boolean =
-        FT.exists(this, f)
+inline fun <reified F, A> HK<F, A>.exists(FT: Foldable<F> = foldable(), noinline f: (A) -> Boolean): Boolean = FT.exists(this, f)
 
-inline fun <reified F, A> HK<F, A>.forall(FT: Foldable<F> = foldable(), noinline f: (A) -> Boolean): Boolean =
-        FT.forall(this, f)
+inline fun <reified F, A> HK<F, A>.forall(FT: Foldable<F> = foldable(), noinline f: (A) -> Boolean): Boolean = FT.forall(this, f)
 
-inline fun <reified F, A> HK<F, A>.isEmpty(FT: Foldable<F> = foldable()): Boolean =
-        FT.isEmpty(this)
+inline fun <reified F, A> HK<F, A>.isEmpty(FT: Foldable<F> = foldable()): Boolean = FT.isEmpty(this)
 
-inline fun <reified F, A> HK<F, A>.nonEmpty(FT: Foldable<F> = foldable()): Boolean =
-        FT.nonEmpty(this)
+inline fun <reified F, A> HK<F, A>.nonEmpty(FT: Foldable<F> = foldable()): Boolean = FT.nonEmpty(this)
 
-fun <A, B> Iterator<A>.iterateRight(lb: Eval<B>): (f: (A, Eval<B>) -> Eval<B>) -> Eval<B> =
-    Foldable.iterateRight(this, lb)
+fun <A, B> Iterator<A>.iterateRight(lb: Eval<B>): (f: (A, Eval<B>) -> Eval<B>) -> Eval<B> = Foldable.iterateRight(this, lb)

--- a/kategory/src/main/kotlin/kategory/typeclasses/Functor.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/Functor.kt
@@ -10,13 +10,10 @@ interface Functor<F> : Typeclass {
             }
 }
 
-inline fun <reified F> functor(): Functor<F> =
-        instance(InstanceParametrizedType(Functor::class.java, listOf(F::class.java)))
+inline fun <reified F> functor(): Functor<F> = instance(InstanceParametrizedType(Functor::class.java, listOf(F::class.java)))
 
 //Syntax
 
-inline fun <reified F, A, B> HK<F, A>.map(FT : Functor<F> = functor(), noinline f: (A) -> B): HK<F, B> =
-        FT.map(this, f)
+inline fun <reified F, A, B> HK<F, A>.map(FT : Functor<F> = functor(), noinline f: (A) -> B): HK<F, B> = FT.map(this, f)
 
-inline fun <reified F, A, B> ((A) -> B).lift(FT : Functor<F> = functor()): (HK<F, A>) -> HK<F, B> =
-        FT.lift(this)
+inline fun <reified F, A, B> ((A) -> B).lift(FT : Functor<F> = functor()): (HK<F, A>) -> HK<F, B> = FT.lift(this)

--- a/kategory/src/main/kotlin/kategory/typeclasses/Inject.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/Inject.kt
@@ -13,8 +13,6 @@ interface Inject<in F, out G> : Typeclass {
 
 }
 
-inline fun <reified F, reified G> inject(): Inject<F, G> =
-        instance(InstanceParametrizedType(Inject::class.java, listOf(F::class.java, G::class.java)))
+inline fun <reified F, reified G> inject(): Inject<F, G> = instance(InstanceParametrizedType(Inject::class.java, listOf(F::class.java, G::class.java)))
 
-inline fun <reified F, reified G, A> HK<F, A>.inj(FT: Inject<F, G> = inject()) : HK<G, A> =
-        FT.invoke(this)
+inline fun <reified F, reified G, A> HK<F, A>.inj(FT: Inject<F, G> = inject()) : HK<G, A> = FT.invoke(this)

--- a/kategory/src/main/kotlin/kategory/typeclasses/Monad.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/Monad.kt
@@ -12,20 +12,16 @@ interface Monad<F> : Applicative<F>, Typeclass {
 
     fun <A, B> flatMap(fa: HK<F, A>, f: (A) -> HK<F, B>): HK<F, B>
 
-    override fun <A, B> ap(fa: HK<F, A>, ff: HK<F, (A) -> B>): HK<F, B> =
-            flatMap(ff, { f -> map(fa, f) })
+    override fun <A, B> ap(fa: HK<F, A>, ff: HK<F, (A) -> B>): HK<F, B> = flatMap(ff, { f -> map(fa, f) })
 
-    fun <A> flatten(ffa: HK<F, HK<F, A>>): HK<F, A> =
-            flatMap(ffa, { it })
+    fun <A> flatten(ffa: HK<F, HK<F, A>>): HK<F, A> = flatMap(ffa, { it })
 
     fun <A, B> tailRecM(a: A, f: (A) -> HK<F, Either<A, B>>): HK<F, B>
 }
 
-inline fun <reified F, A, B> HK<F, A>.flatMap(FT: Monad<F> = monad(), noinline f: (A) -> HK<F, B>): HK<F, B> =
-        FT.flatMap(this, f)
+inline fun <reified F, A, B> HK<F, A>.flatMap(FT: Monad<F> = monad(), noinline f: (A) -> HK<F, B>): HK<F, B> = FT.flatMap(this, f)
 
-inline fun <reified F, A, B> HK<F, HK<F, A>>.flatten(FT: Monad<F> = monad()): HK<F, A> =
-        FT.flatten(this)
+inline fun <reified F, A, B> HK<F, HK<F, A>>.flatten(FT: Monad<F> = monad()): HK<F, A> = FT.flatten(this)
 
 @RestrictsSuspension
 open class MonadContinuation<F, A>(val M: Monad<F>) : Serializable, Continuation<HK<F, A>> {
@@ -123,5 +119,4 @@ fun <F, B> Monad<F>.bindingStackSafe(c: suspend StackSafeMonadContinuation<F, *>
     return continuation.returnedMonad
 }
 
-inline fun <reified F> monad(): Monad<F> =
-        instance(InstanceParametrizedType(Monad::class.java, listOf(F::class.java)))
+inline fun <reified F> monad(): Monad<F> = instance(InstanceParametrizedType(Monad::class.java, listOf(F::class.java)))

--- a/kategory/src/main/kotlin/kategory/typeclasses/MonadError.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/MonadError.kt
@@ -17,8 +17,7 @@ interface MonadError<F, E> : ApplicativeError<F, E>, Monad<F>, Typeclass {
 inline fun <reified F, A, reified E> HK<F, A>.ensure(
         FT: MonadError<F, E> = monadError(),
         noinline error: () -> E,
-        noinline predicate: (A) -> Boolean): HK<F, A> =
-        FT.ensure(this, error, predicate)
+        noinline predicate: (A) -> Boolean): HK<F, A> = FT.ensure(this, error, predicate)
 
 @RestrictsSuspension
 class MonadErrorContinuation<F, A>(val ME: MonadError<F, Throwable>) : Serializable, MonadContinuation<F, A>(ME) {
@@ -43,5 +42,4 @@ fun <F, B> MonadError<F, Throwable>.bindingE(c: suspend MonadErrorContinuation<F
     return continuation.returnedMonad
 }
 
-inline fun <reified F, reified E> monadError(): MonadError<F, E> =
-        instance(InstanceParametrizedType(MonadError::class.java, listOf(F::class.java, E::class.java)))
+inline fun <reified F, reified E> monadError(): MonadError<F, E> = instance(InstanceParametrizedType(MonadError::class.java, listOf(F::class.java, E::class.java)))

--- a/kategory/src/main/kotlin/kategory/typeclasses/MonadReader.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/MonadReader.kt
@@ -11,11 +11,8 @@ interface MonadReader<F, D> : Monad<F> {
     fun <A> reader(f: (D) -> A): HK<F, A> = map(ask(), f)
 }
 
-inline fun <reified F, A, reified D> HK<F, A>.local(FT: MonadReader<F, D> = monadReader(), noinline f: (D) -> D): HK<F, A> =
-    FT.local(f, this)
+inline fun <reified F, A, reified D> HK<F, A>.local(FT: MonadReader<F, D> = monadReader(), noinline f: (D) -> D): HK<F, A> = FT.local(f, this)
 
-inline fun <reified F, A, reified D> ((D) -> A).reader(FT: MonadReader<F, D> = monadReader()): HK<F, A> =
-        FT.reader(this)
+inline fun <reified F, A, reified D> ((D) -> A).reader(FT: MonadReader<F, D> = monadReader()): HK<F, A> = FT.reader(this)
 
-inline fun <reified F, reified D> monadReader(): MonadReader<F, D> =
-        instance(InstanceParametrizedType(MonadReader::class.java, listOf(F::class.java, D::class.java)))
+inline fun <reified F, reified D> monadReader(): MonadReader<F, D> = instance(InstanceParametrizedType(MonadReader::class.java, listOf(F::class.java, D::class.java)))

--- a/kategory/src/main/kotlin/kategory/typeclasses/MonadState.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/MonadState.kt
@@ -2,18 +2,15 @@ package kategory
 
 interface MonadState<F, S> : Monad<F>, Typeclass {
 
-    fun <A> state(f: (S) -> Tuple2<S, A>): HK<F, A> =
-            flatMap(get(), { s -> f(s).let { (a, b) -> map(set(a), { b }) } })
+    fun <A> state(f: (S) -> Tuple2<S, A>): HK<F, A> = flatMap(get(), { s -> f(s).let { (a, b) -> map(set(a), { b }) } })
 
     fun get(): HK<F, S>
 
     fun set(s: S): HK<F, Unit>
 
-    fun modify(f: (S) -> S): HK<F, Unit> =
-            flatMap(get(), { s -> set(f(s)) })
+    fun modify(f: (S) -> S): HK<F, Unit> = flatMap(get(), { s -> set(f(s)) })
 
     fun <A> inspect(f: (S) -> A): HK<F, A> = map(get(), f)
 }
 
-inline fun <reified F, reified S> monadState(): MonadState<F, S> =
-        instance(InstanceParametrizedType(MonadState::class.java, listOf(F::class.java, S::class.java)))
+inline fun <reified F, reified S> monadState(): MonadState<F, S> = instance(InstanceParametrizedType(MonadState::class.java, listOf(F::class.java, S::class.java)))

--- a/kategory/src/main/kotlin/kategory/typeclasses/Monoid.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/Monoid.kt
@@ -8,8 +8,6 @@ interface Monoid<A> : Semigroup<A> {
 
 }
 
-inline fun <reified A> A.empty(FT: Monoid<A> = monoid()): A =
-    FT.empty()
+inline fun <reified A> A.empty(FT: Monoid<A> = monoid()): A = FT.empty()
 
-inline fun <reified A> monoid(): Monoid<A> =
-        instance(InstanceParametrizedType(Monoid::class.java, listOf(A::class.java)))
+inline fun <reified A> monoid(): Monoid<A> = instance(InstanceParametrizedType(Monoid::class.java, listOf(A::class.java)))

--- a/kategory/src/main/kotlin/kategory/typeclasses/MonoidK.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/MonoidK.kt
@@ -21,5 +21,4 @@ interface MonoidK<F> : SemigroupK<F> {
     }
 }
 
-inline fun <reified F> monoidK(): MonoidK<F> =
-        instance(InstanceParametrizedType(MonoidK::class.java, listOf(F::class.java)))
+inline fun <reified F> monoidK(): MonoidK<F> = instance(InstanceParametrizedType(MonoidK::class.java, listOf(F::class.java)))

--- a/kategory/src/main/kotlin/kategory/typeclasses/Semigroup.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/Semigroup.kt
@@ -17,11 +17,8 @@ interface Semigroup<A> : Typeclass {
     fun combineAll(elems: Collection<A>): A = elems.reduce { a, b -> combine(a, b) }
 }
 
-inline fun <reified A> A.combine(FT: Semigroup<A> = semigroup(), b: A): A =
-    FT.combine(this, b)
+inline fun <reified A> A.combine(FT: Semigroup<A> = semigroup(), b: A): A = FT.combine(this, b)
 
-inline fun <reified A> Collection<A>.combineAll(FT: Semigroup<A> = semigroup()): A =
-        FT.combineAll(this)
+inline fun <reified A> Collection<A>.combineAll(FT: Semigroup<A> = semigroup()): A = FT.combineAll(this)
 
-inline fun <reified A> semigroup(): Semigroup<A> =
-        instance(InstanceParametrizedType(Semigroup::class.java, listOf(A::class.java)))
+inline fun <reified A> semigroup(): Semigroup<A> = instance(InstanceParametrizedType(Semigroup::class.java, listOf(A::class.java)))

--- a/kategory/src/main/kotlin/kategory/typeclasses/SemigroupK.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/SemigroupK.kt
@@ -16,5 +16,4 @@ interface SemigroupK<F> : Typeclass {
     }
 }
 
-inline fun <reified F> semigroupK(): SemigroupK<F> =
-        instance(InstanceParametrizedType(SemigroupK::class.java, listOf(F::class.java)))
+inline fun <reified F> semigroupK(): SemigroupK<F> = instance(InstanceParametrizedType(SemigroupK::class.java, listOf(F::class.java)))

--- a/kategory/src/main/kotlin/kategory/typeclasses/Traverse.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/Traverse.kt
@@ -11,30 +11,24 @@ interface Traverse<F> : Functor<F>, Foldable<F>, Typeclass {
      */
     fun <G, A, B> traverse(fa: HK<F, A>, f: (A) -> HK<G, B>, GA: Applicative<G>): HK<G, HK<F, B>>
 
-    override fun <A, B> map(fa: HK<F, A>, f: (A) -> B): HK<F, B> =
-            traverse(fa, { Id(f(it)) }, Id).value()
+    override fun <A, B> map(fa: HK<F, A>, f: (A) -> B): HK<F, B> = traverse(fa, { Id(f(it)) }, Id).value()
 }
 
 inline fun <reified F, reified G, A, B> HK<F, A>.traverse(
         FT: Traverse<F> = traverse(),
         GA: Applicative<G> = applicative(),
-        noinline f: (A) -> HK<G, B>): HK<G, HK<F, B>> =
-        FT.traverse(this, f, GA)
+        noinline f: (A) -> HK<G, B>): HK<G, HK<F, B>> = FT.traverse(this, f, GA)
 
 inline fun <reified F, reified G, A, B> HK<F, A>.flatTraverse(
         FT: Traverse<F> = traverse(),
         GA: Applicative<G> = applicative(),
-        FM: Monad<F> = monad(), noinline f: (A) -> HK<G, HK<F, B>>): HK<G, HK<F, B>> =
-        GA.map(FT.traverse(this, f, GA), { FM.flatten(it) })
+        FM: Monad<F> = monad(), noinline f: (A) -> HK<G, HK<F, B>>): HK<G, HK<F, B>> = GA.map(FT.traverse(this, f, GA), { FM.flatten(it) })
 
-inline fun <reified F, reified G, A, B> Traverse<F>.flatTraverse(fa: HK<F, A>, noinline f: (A) -> HK<G, HK<F, B>>, GA: Applicative<G> = applicative(), FM: Monad<F> = monad()): HK<G, HK<F, B>> =
-        GA.map(traverse(fa, f, GA), { FM.flatten(it) })
+inline fun <reified F, reified G, A, B> Traverse<F>.flatTraverse(fa: HK<F, A>, noinline f: (A) -> HK<G, HK<F, B>>, GA: Applicative<G> = applicative(), FM: Monad<F> = monad()): HK<G, HK<F, B>> = GA.map(traverse(fa, f, GA), { FM.flatten(it) })
 
 /**
  * Thread all the G effects through the F structure to invert the structure from F<G<A>> to G<F<A>>.
  */
-inline fun <F, reified G, A> Traverse<F>.sequence(fga: HK<F, HK<G, A>>, GA: Applicative<G> = applicative()): HK<G, HK<F, A>> =
-        traverse(fga, { it }, GA)
+inline fun <F, reified G, A> Traverse<F>.sequence(fga: HK<F, HK<G, A>>, GA: Applicative<G> = applicative()): HK<G, HK<F, A>> = traverse(fga, { it }, GA)
 
-inline fun <reified F> traverse(): Traverse<F> =
-        instance(InstanceParametrizedType(Traverse::class.java, listOf(F::class.java)))
+inline fun <reified F> traverse(): Traverse<F> = instance(InstanceParametrizedType(Traverse::class.java, listOf(F::class.java)))

--- a/kategory/src/main/kotlin/kategory/typeclasses/Typeclass.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/Typeclass.kt
@@ -59,15 +59,11 @@ class InstanceParametrizedType(val raw: Type, val typeArgs: List<Type>) : Parame
             return false
     }
 
-    override fun hashCode(): Int {
-        return Arrays.hashCode(actualTypeArguments) xor
+    override fun hashCode(): Int = Arrays.hashCode(actualTypeArguments) xor
                 hashCode(ownerType) xor
                 hashCode(rawType)
-    }
 
-    fun hashCode(o: Any?): Int {
-        return o?.hashCode() ?: 0
-    }
+    fun hashCode(o: Any?): Int = o?.hashCode() ?: 0
 
 }
 
@@ -83,8 +79,7 @@ open class GlobalInstance<T : Typeclass> : TypeLiteral<T>() {
     /**
      * Recursively scan all implemented interfaces and add as global instances all the ones that match a Typeclass
      */
-    fun recurseInterfaces(c: Class<*>) {
-        return when {
+    fun recurseInterfaces(c: Class<*>) = when {
             c.interfaces.isEmpty() -> Unit
             else -> {
                 c.interfaces.filter {
@@ -96,7 +91,6 @@ open class GlobalInstance<T : Typeclass> : TypeLiteral<T>() {
                 }
             }
         }
-    }
 
 }
 

--- a/kategory/src/main/kotlin/kategory/typeclasses/Typeclass.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/Typeclass.kt
@@ -2,7 +2,7 @@ package kategory
 
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
-import java.util.Arrays
+import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -79,7 +79,7 @@ open class GlobalInstance<T : Typeclass> : TypeLiteral<T>() {
     /**
      * Recursively scan all implemented interfaces and add as global instances all the ones that match a Typeclass
      */
-    fun recurseInterfaces(c: Class<*>) = when {
+    fun recurseInterfaces(c: Class<*>): Unit = when {
             c.interfaces.isEmpty() -> Unit
             else -> {
                 c.interfaces.filter {

--- a/kategory/src/main/kotlin/kategory/typeclasses/Typeclass.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/Typeclass.kt
@@ -2,7 +2,7 @@ package kategory
 
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
-import java.util.*
+import java.util.Arrays
 import java.util.concurrent.ConcurrentHashMap
 
 /**

--- a/reports/baseline.xml
+++ b/reports/baseline.xml
@@ -1,17 +1,89 @@
 <?xml version="1.0" ?>
 <SmellBaseline>
   <Blacklist timestamp="1490879306930"></Blacklist>
-  <Whitelist timestamp="1502159270801">
+  <Whitelist timestamp="1502159604387">
+    <ID>LabeledExpression:FunctionK.kt$&lt;no name provided&gt;$this@or</ID>
+    <ID>LabeledExpression:PartialFunction.kt$&lt;no name provided&gt;$this@orElse</ID>
+    <ID>LabeledExpression:PartialFunction.kt$&lt;no name provided&gt;$this@andThen</ID>
+    <ID>LabeledExpression:Composed.kt$&lt;no name provided&gt;$this@compose</ID>
+    <ID>LabeledExpression:Eval.kt$Eval.&lt;no name provided&gt;$this@Eval</ID>
+    <ID>LabeledExpression:Eval.kt$Eval.&lt;no name provided&gt;.&lt;no name provided&gt;$this@Eval</ID>
+    <ID>LabeledExpression:Eval.kt$Eval.Call.Companion$break@loop</ID>
+    <ID>LabeledExpression:Eval.kt$Eval.Call.Companion$loop@ while (true) { when (lfa) { is Call -&gt; { lfa = lfa.thunk() } is Compute -&gt; { val clfa: Compute&lt;A&gt; = lfa object : Compute&lt;A&gt;() { override fun &lt;S&gt; start(): Eval&lt;S&gt; = clfa.start() override fun &lt;S&gt; run(s: S): Eval&lt;A&gt; { lfa = clfa.run(s) return lfa } } } else -&gt; break@loop } }</ID>
+    <ID>LabeledExpression:Eval.kt$Eval.Compute$break@loop</ID>
+    <ID>LabeledExpression:Eval.kt$Eval.Compute$loop@ while (true) { when (curr) { is Compute -&gt; { val currComp: Compute&lt;A&gt; = curr currComp.start&lt;A&gt;().let { cc -&gt; when (cc) { is Compute -&gt; { val inStartFun: (Any?) -&gt; Eval&lt;A&gt; = { cc.run(it) } val outStartFun: (Any?) -&gt; Eval&lt;A&gt; = { currComp.run(it) } curr = cc.start&lt;A&gt;() fs = listOf(inStartFun, outStartFun) + fs } else -&gt; { curr = currComp.run(cc.value()) } } } } else -&gt; if (fs.isNotEmpty()) { curr = fs[0](curr.value()) fs = fs.drop(1) } else { break@loop } } }</ID>
     <ID>ComplexMethod:AndThen.kt$AndThen$ @Suppress("UNCHECKED_CAST") internal fun runLoop(_success: A?, _failure: Throwable?, _isSuccess: Boolean): B</ID>
+    <ID>LabeledExpression:Yoneda.kt$Yoneda.&lt;no name provided&gt;$this@Yoneda</ID>
+    <ID>LabeledExpression:ContinuationUtils.kt$this@label</ID>
+    <ID>LabeledExpression:ContinuationUtils.kt$this@completion</ID>
+    <ID>LabeledExpression:MonoidK.kt$MonoidK.&lt;no name provided&gt;$this@MonoidK</ID>
     <ID>EmptyClassBlock:Typeclass.kt$&lt;no name provided&gt; : TypeLiteral</ID>
     <ID>OptionalUnit:AndThen.kt$AndThen$Unit</ID>
     <ID>OptionalUnit:IO.kt$IO$Unit</ID>
     <ID>OptionalUnit:FreeApplicative.kt$FreeApplicative$Unit</ID>
     <ID>OptionalUnit:Typeclass.kt$GlobalInstance$Unit</ID>
+    <ID>UnsafeCast:Function0.kt$this as Function0&lt;A&gt;</ID>
+    <ID>UnsafeCast:Function1.kt$this as Function1&lt;I, O&gt;</ID>
+    <ID>UnsafeCast:Kleisli.kt$this as Kleisli&lt;F, D, A&gt;</ID>
+    <ID>UnsafeCast:Cokleisli.kt$this as Cokleisli&lt;F, A, B&gt;</ID>
+    <ID>UnsafeCast:Composed.kt$this as HK&lt;ComposedType&lt;F, G&gt;, A&gt;</ID>
+    <ID>UnsafeCast:Composed.kt$this as HK&lt;F, HK&lt;G, A&gt;&gt;</ID>
+    <ID>UnsafeCast:Coproduct.kt$this as Coproduct&lt;F, G, A&gt;</ID>
+    <ID>UnsafeCast:Either.kt$this as Either&lt;A, B&gt;</ID>
+    <ID>UnsafeCast:EitherT.kt$this as EitherT&lt;F, A, B&gt;</ID>
+    <ID>UnsafeCast:Eval.kt$this as Eval&lt;A&gt;</ID>
+    <ID>UnsafeCast:Eval.kt$Eval.&lt;no name provided&gt;.&lt;no name provided&gt;$(this@Eval).run(s) as Eval&lt;S1&gt;</ID>
+    <ID>UnsafeCast:Eval.kt$Eval.&lt;no name provided&gt;.&lt;no name provided&gt;$s as A</ID>
+    <ID>UnsafeCast:Eval.kt$Eval.&lt;no name provided&gt;$this@Eval.thunk() as Eval&lt;S&gt;</ID>
+    <ID>UnsafeCast:Eval.kt$Eval.&lt;no name provided&gt;$s as A</ID>
+    <ID>UnsafeCast:Eval.kt$Eval.&lt;no name provided&gt;$this@Eval as Eval&lt;S&gt;</ID>
+    <ID>UnsafeCast:Id.kt$this as Id&lt;A&gt;</ID>
+    <ID>UnsafeCast:Ior.kt$this as Ior&lt;A, B&gt;</ID>
+    <ID>UnsafeCast:NonEmptyList.kt$this as NonEmptyList&lt;A&gt;</ID>
+    <ID>UnsafeCast:NonEmptyList.kt$NonEmptyList$other as NonEmptyList&lt;*&gt;</ID>
+    <ID>UnsafeCast:Option.kt$this as Option&lt;A&gt;</ID>
+    <ID>UnsafeCast:OptionT.kt$this as OptionT&lt;F, A&gt;</ID>
+    <ID>UnsafeCast:StateT.kt$this as StateT&lt;F, S, A&gt;</ID>
+    <ID>UnsafeCast:Try.kt$this as Try&lt;A&gt;</ID>
+    <ID>UnsafeCast:Validated.kt$this as Validated&lt;E, A&gt;</ID>
+    <ID>UnsafeCast:WriterT.kt$this as WriterT&lt;F, A, B&gt;</ID>
     <ID>UnsafeCallOnNullableType:AndThen.kt$AndThen$failure!!</ID>
+    <ID>UnsafeCast:AndThen.kt$AndThen$this as AndThen&lt;Any?, Any?&gt;</ID>
+    <ID>UnsafeCast:AndThen.kt$AndThen$_right as AndThen&lt;Any?, Any?&gt;</ID>
+    <ID>UnsafeCast:AndThen.kt$AndThen$me as Concat&lt;Any?, Any?, Any?&gt;</ID>
+    <ID>UnsafeCast:AndThen.kt$AndThen$me as AndThen&lt;A, E&gt;</ID>
+    <ID>UnsafeCast:AndThen.kt$AndThen$self.left as AndThen&lt;Any?, Any?&gt;</ID>
+    <ID>UnsafeCast:AndThen.kt$AndThen$self.right as AndThen&lt;Any?, Any?&gt;</ID>
+    <ID>UnsafeCast:AndThen.kt$AndThen$success as B</ID>
+    <ID>UnsafeCast:IO.kt$this as IO&lt;A&gt;</ID>
+    <ID>UnsafeCast:IO.kt$IO$current.f as AndThen&lt;Any?, IO&lt;A&gt;&gt;</ID>
+    <ID>UnsafeCast:Cofree.kt$this as Cofree&lt;S, A&gt;</ID>
+    <ID>UnsafeCast:CoYoneda.kt$this as CoYoneda&lt;U, A, B&gt;</ID>
+    <ID>UnsafeCast:CoYoneda.kt$CoYoneda$curr as A</ID>
+    <ID>UnsafeCast:CoYoneda.kt$CoYoneda$f as AnyFunc</ID>
+    <ID>UnsafeCast:CoYoneda.kt$CoYoneda.Companion$f as AnyFunc</ID>
+    <ID>UnsafeCast:Free.kt$this as Free&lt;S, A&gt;</ID>
+    <ID>UnsafeCast:Free.kt$this.f as (A) -&gt; Free&lt;S, A&gt;</ID>
+    <ID>UnsafeCast:Free.kt$this.c.c as Free&lt;S, A&gt;</ID>
+    <ID>UnsafeCast:Free.kt$this.c.f as (A) -&gt; Free&lt;S, A&gt;</ID>
+    <ID>UnsafeCast:Free.kt$this.c.a as A</ID>
+    <ID>UnsafeCast:Free.kt$x.f as (A) -&gt; Free&lt;S, A&gt;</ID>
+    <ID>UnsafeCast:Free.kt$x.c as Free&lt;S, A&gt;</ID>
+    <ID>UnsafeCast:FreeApplicative.kt$this as FreeApplicative&lt;F, A&gt;</ID>
+    <ID>UnsafeCast:FreeApplicative.kt$FreeApplicative$argF as Ap&lt;F, Any?, Any?&gt;</ID>
+    <ID>UnsafeCast:FreeApplicative.kt$FreeApplicative$argF as FreeApplicative&lt;F, (Any?) -&gt; Any?&gt;</ID>
+    <ID>UnsafeCast:FreeApplicative.kt$FreeApplicative$res as HK&lt;G, (Any?) -&gt; Any?&gt;</ID>
+    <ID>UnsafeCast:FreeApplicative.kt$FreeApplicative$loop() as HK&lt;G, A&gt;</ID>
+    <ID>UnsafeCast:FreeApplicative.kt$node as FreeApplicative.Lift&lt;F, A&gt;</ID>
+    <ID>UnsafeCast:Yoneda.kt$this as Yoneda&lt;F, A&gt;</ID>
+    <ID>UnsafeCast:StateTInstances.kt$StateTInstances$fb as Eval&lt;StateT&lt;F, S, B&gt;&gt;</ID>
     <ID>LateinitUsage:Comonad.kt$ComonadContinuation$internal lateinit var returnedMonad: A</ID>
+    <ID>UnsafeCast:ContinuationUtils.kt$completionField.get(this) as Continuation&lt;*&gt;</ID>
     <ID>LateinitUsage:Monad.kt$MonadContinuation$internal lateinit var returnedMonad: HK&lt;F, A&gt;</ID>
     <ID>LateinitUsage:Monad.kt$StackSafeMonadContinuation$internal lateinit var returnedMonad: Free&lt;F, A&gt;</ID>
+    <ID>UnsafeCast:Typeclass.kt$TypeLiteral$javaClass.genericSuperclass as ParameterizedType</ID>
+    <ID>UnsafeCast:Typeclass.kt$TypeLiteral$t as ParameterizedType</ID>
+    <ID>UnsafeCast:Typeclass.kt$GlobalInstances.getValue(t) as T</ID>
     <ID>MaxLineLength:Kleisli.kt$kategory.Kleisli.kt</ID>
     <ID>MaxLineLength:Composed.kt$kategory.Composed.kt</ID>
     <ID>MaxLineLength:Coproduct.kt$kategory.Coproduct.kt</ID>

--- a/reports/baseline.xml
+++ b/reports/baseline.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" ?>
 <SmellBaseline>
   <Blacklist timestamp="1490879306930"></Blacklist>
-  <Whitelist timestamp="1502158266953">
+  <Whitelist timestamp="1502159270801">
     <ID>ComplexMethod:AndThen.kt$AndThen$ @Suppress("UNCHECKED_CAST") internal fun runLoop(_success: A?, _failure: Throwable?, _isSuccess: Boolean): B</ID>
     <ID>EmptyClassBlock:Typeclass.kt$&lt;no name provided&gt; : TypeLiteral</ID>
     <ID>OptionalUnit:AndThen.kt$AndThen$Unit</ID>
     <ID>OptionalUnit:IO.kt$IO$Unit</ID>
     <ID>OptionalUnit:FreeApplicative.kt$FreeApplicative$Unit</ID>
+    <ID>OptionalUnit:Typeclass.kt$GlobalInstance$Unit</ID>
     <ID>UnsafeCallOnNullableType:AndThen.kt$AndThen$failure!!</ID>
     <ID>LateinitUsage:Comonad.kt$ComonadContinuation$internal lateinit var returnedMonad: A</ID>
     <ID>LateinitUsage:Monad.kt$MonadContinuation$internal lateinit var returnedMonad: HK&lt;F, A&gt;</ID>

--- a/reports/baseline.xml
+++ b/reports/baseline.xml
@@ -1,15 +1,43 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" ?>
 <SmellBaseline>
-    <Blacklist timestamp="1490879306930"/>
-    <Whitelist timestamp="1492411880669">
-        <ID>EmptyClassBlock:Typeclass.kt$&lt;no name provided&gt; : TypeLiteral</ID>
-        <ID>ComplexMethod:AndThen.kt$AndThen$ @Suppress("UNCHECKED_CAST") internal fun runLoop(_success: A?, _failure: Throwable?, _isSuccess: Boolean): B</ID>
-        <ID>OptionalUnit:IO.kt$IO$Unit</ID>
-        <ID>OptionalUnit:AndThen.kt$AndThen$Unit</ID>
-        <ID>OptionalUnit:FreeApplicative.kt$FreeApplicative$Unit</ID>
-        <ID>OptionalUnit:NonEmptyListMonad.kt$NonEmptyListMonad$Unit</ID>
-        <ID>NestedBlockDepth:AndThen.kt$AndThen$ @Suppress("UNCHECKED_CAST") internal fun runLoop(_success: A?, _failure: Throwable?, _isSuccess: Boolean): B</ID>
-        <ID>NestedBlockDepth:Eval.kt$Eval.Compute$override fun value(): A</ID>
-        <ID><![CDATA[NestedBlockDepth:FreeApplicative.kt$FreeApplicative$// Beware: smart code @Suppress("UNCHECKED_CAST") fun <G> foldMap(f: FunctionK<F, G>, GA: Applicative<G>): HK<G, A>]]></ID>
-    </Whitelist>
+  <Blacklist timestamp="1490879306930"></Blacklist>
+  <Whitelist timestamp="1502158266953">
+    <ID>ComplexMethod:AndThen.kt$AndThen$ @Suppress("UNCHECKED_CAST") internal fun runLoop(_success: A?, _failure: Throwable?, _isSuccess: Boolean): B</ID>
+    <ID>EmptyClassBlock:Typeclass.kt$&lt;no name provided&gt; : TypeLiteral</ID>
+    <ID>OptionalUnit:AndThen.kt$AndThen$Unit</ID>
+    <ID>OptionalUnit:IO.kt$IO$Unit</ID>
+    <ID>OptionalUnit:FreeApplicative.kt$FreeApplicative$Unit</ID>
+    <ID>UnsafeCallOnNullableType:AndThen.kt$AndThen$failure!!</ID>
+    <ID>LateinitUsage:Comonad.kt$ComonadContinuation$internal lateinit var returnedMonad: A</ID>
+    <ID>LateinitUsage:Monad.kt$MonadContinuation$internal lateinit var returnedMonad: HK&lt;F, A&gt;</ID>
+    <ID>LateinitUsage:Monad.kt$StackSafeMonadContinuation$internal lateinit var returnedMonad: Free&lt;F, A&gt;</ID>
+    <ID>MaxLineLength:Kleisli.kt$kategory.Kleisli.kt</ID>
+    <ID>MaxLineLength:Composed.kt$kategory.Composed.kt</ID>
+    <ID>MaxLineLength:Coproduct.kt$kategory.Coproduct.kt</ID>
+    <ID>MaxLineLength:Either.kt$kategory.Either.kt</ID>
+    <ID>MaxLineLength:EitherT.kt$kategory.EitherT.kt</ID>
+    <ID>MaxLineLength:OptionT.kt$kategory.OptionT.kt</ID>
+    <ID>MaxLineLength:WriterT.kt$kategory.WriterT.kt</ID>
+    <ID>MaxLineLength:IO.kt$kategory.IO.kt</ID>
+    <ID>MaxLineLength:Free.kt$kategory.Free.kt</ID>
+    <ID>MaxLineLength:FreeApplicative.kt$kategory.FreeApplicative.kt</ID>
+    <ID>MaxLineLength:CoproductInstances.kt$kategory.CoproductInstances.kt</ID>
+    <ID>MaxLineLength:EitherInstances.kt$kategory.EitherInstances.kt</ID>
+    <ID>MaxLineLength:EitherTInstances.kt$kategory.EitherTInstances.kt</ID>
+    <ID>MaxLineLength:FreeApplicativeInstances.kt$kategory.FreeApplicativeInstances.kt</ID>
+    <ID>MaxLineLength:FreeInstances.kt$kategory.FreeInstances.kt</ID>
+    <ID>MaxLineLength:IorInstances.kt$kategory.IorInstances.kt</ID>
+    <ID>MaxLineLength:KleisliInstances.kt$kategory.KleisliInstances.kt</ID>
+    <ID>MaxLineLength:OptionTInstances.kt$kategory.OptionTInstances.kt</ID>
+    <ID>MaxLineLength:StateTInstances.kt$kategory.StateTInstances.kt</ID>
+    <ID>MaxLineLength:TryInstances.kt$kategory.TryInstances.kt</ID>
+    <ID>MaxLineLength:ValidatedInstances.kt$kategory.ValidatedInstances.kt</ID>
+    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
+    <ID>MaxLineLength:ApplicativeError.kt$kategory.ApplicativeError.kt</ID>
+    <ID>MaxLineLength:Foldable.kt$kategory.Foldable.kt</ID>
+    <ID>MaxLineLength:MonadError.kt$kategory.MonadError.kt</ID>
+    <ID>MaxLineLength:MonadReader.kt$kategory.MonadReader.kt</ID>
+    <ID>MaxLineLength:MonadState.kt$kategory.MonadState.kt</ID>
+    <ID>MaxLineLength:Traverse.kt$kategory.Traverse.kt</ID>
+  </Whitelist>
 </SmellBaseline>


### PR DESCRIPTION
I've updated detekt to M13:

- Add new rules for ExpressionBodySyntax.
- Add MaxLineLength to 160.
- Suppress max methods.
- Enable unsafe cast, labeled expressions to be required to be added to the baseline.
- Apply auto-fix rules for ExpressionBodySyntax and ExpressionBodySyntaxLineBreaks.


After applying those changes I've added a new baseline.