### PR TITLE
Remove kategory bintray repository in favour of jcenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,9 @@ Add it in your root `build.gradle` at the end of repositories.
 ```groovy
 allprojects {
     repositories {
-        maven { url "http://dl.bintray.com/kategory/maven" }
+        jcenter()
         maven { url 'https://kotlin.bintray.com/kotlinx' }
         maven { url "http://dl.bintray.com/kotlin/kotlin-dev" }
-        maven { url "http://dl.bintray.com/kategory/maven" } // can be removed once the annotations project is in jcenter as well
     }
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,6 @@ subprojects { project ->
         jcenter()
         maven { url 'https://kotlin.bintray.com/kotlinx' }
         maven { url "http://dl.bintray.com/kotlin/kotlin-dev" }
-        maven { url "http://dl.bintray.com/kategory/maven" } // can be removed once the annotations project is in jcenter as well
     }
 
     apply plugin: 'kotlin'

--- a/kategory/build.gradle
+++ b/kategory/build.gradle
@@ -4,11 +4,6 @@ test {
     }
 }
 
-repositories {
-    jcenter()
-    maven { url "http://dl.bintray.com/kotlin/kotlin-dev" }
-}
-
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlinVersion"
     compile "org.jetbrains.kotlinx:kotlinx-collections-immutable:$kotlinxCollectionsImmutableVersion"


### PR DESCRIPTION
Now that all binaries are mirrored in jcenter, that's the only one we need.
Removed as well redundant dependencies in kategory/build.gradle