### PR TITLE
Add Traverse law for Sequential Composition: required ComposedFunctor and ComposedApplicative

### DIFF
--- a/kategory/src/main/kotlin/kategory/data/Composed.kt
+++ b/kategory/src/main/kotlin/kategory/data/Composed.kt
@@ -47,20 +47,79 @@ interface ComposedSemigroupK<F, G> : SemigroupK<ComposedType<F, G>> {
 
     override fun <A> combineK(x: HK<ComposedType<F, G>, A>, y: HK<ComposedType<F, G>, A>): HK<ComposedType<F, G>, A> = F().combineK(x.lower(), y.lower()).lift()
 
-    fun <A> combineKC(x: HK<F, HK<G, A>>, y: HK<F, HK<G, A>>): HK<ComposedType<F, G>, A> = combineK(x.lift(), y.lift())
+    fun <A> combineKC(x: HK<F, HK<G, A>>, y: HK<F, HK<G, A>>): HK<F, HK<G, A>> = combineK(x.lift(), y.lift()).lower()
+
+    companion object {
+        inline operator fun <reified F, G> invoke(FF: SemigroupK<F> = monoidK<F>()): ComposedSemigroupK<F, G> = object : ComposedSemigroupK<F, G> {
+            override fun F(): SemigroupK<F> = FF
+        }
+    }
 }
 
-inline fun <F, reified G> SemigroupK<F>.compose(): SemigroupK<ComposedType<F, G>> = object : ComposedSemigroupK<F, G> {
-    override fun F(): SemigroupK<F> = this@compose
-}
+inline fun <reified F, G> SemigroupK<F>.compose(): SemigroupK<ComposedType<F, G>> = ComposedSemigroupK(this)
 
 interface ComposedMonoidK<F, G> : MonoidK<ComposedType<F, G>>, ComposedSemigroupK<F, G> {
 
     override fun F(): MonoidK<F>
 
     override fun <A> empty(): HK<ComposedType<F, G>, A> = F().empty<HK<G, A>>().lift()
+
+    companion object {
+        inline operator fun <reified F, G> invoke(FF: MonoidK<F> = monoidK<F>()): ComposedMonoidK<F, G> = object : ComposedMonoidK<F, G> {
+            override fun F(): MonoidK<F> = FF
+        }
+    }
 }
 
-fun <F, G> MonoidK<F>.compose(): MonoidK<ComposedType<F, G>> = object : ComposedMonoidK<F, G> {
-    override fun F(): MonoidK<F> = this@compose
+inline fun <reified F, G> MonoidK<F>.compose(): MonoidK<ComposedType<F, G>> = ComposedMonoidK(this)
+
+interface ComposedFunctor<F, G> : Functor<ComposedType<F, G>> {
+    fun F(): Functor<F>
+
+    fun G(): Functor<G>
+
+    override fun <A, B> map(fa: HK<ComposedType<F, G>, A>, f: (A) -> B): HK<ComposedType<F, G>, B> =
+            F().map(fa.lower(), { G().map(it, f) }).lift()
+
+    fun <A, B> mapC(fa: HK<F, HK<G, A>>, f: (A) -> B): HK<F, HK<G, B>> =
+            map(fa.lift(), f).lower()
+
+    companion object {
+        inline operator fun <reified F, reified G> invoke(FF: Functor<F> = functor<F>(), GF: Functor<G> = functor<G>()): Functor<ComposedType<F, G>> = object : ComposedFunctor<F, G> {
+            override fun F(): Functor<F> = FF
+
+            override fun G(): Functor<G> = GF
+        }
+    }
 }
+
+inline fun <reified F, reified G> Functor<F>.compose(GF: Functor<G> = functor<G>()): Functor<ComposedType<F, G>> = ComposedFunctor(this, GF)
+
+interface ComposedApplicative<F, G> : Applicative<ComposedType<F, G>>, ComposedFunctor<F, G> {
+    override fun F(): Applicative<F>
+
+    override fun G(): Applicative<G>
+
+    override fun <A, B> map(fa: HK<ComposedType<F, G>, A>, f: (A) -> B): HK<ComposedType<F, G>, B> =
+            ap(fa, pure(f))
+
+    override fun <A> pure(a: A): HK<ComposedType<F, G>, A> =
+            F().pure(G().pure(a)).lift()
+
+    override fun <A, B> ap(fa: HK<ComposedType<F, G>, A>, ff: HK<ComposedType<F, G>, (A) -> B>): HK<ComposedType<F, G>, B> =
+            F().ap(fa.lower(), F().map(ff.lower(), { gfa: HK<G, (A) -> B> -> { ga: HK<G, A> -> G().ap(ga, gfa) } })).lift()
+
+    fun <A, B> apC(fa: HK<F, HK<G, A>>, ff: HK<F, HK<G, (A) -> B>>): HK<F, HK<G, B>> =
+            ap(fa.lift(), ff.lift()).lower()
+
+    companion object {
+        inline operator fun <reified F, reified G> invoke(FF: Applicative<F> = applicative<F>(), GF: Applicative<G> = applicative<G>()): Applicative<ComposedType<F, G>> = object : ComposedApplicative<F, G> {
+            override fun F(): Applicative<F> = FF
+
+            override fun G(): Applicative<G> = GF
+        }
+    }
+}
+
+inline fun <reified F, reified G> Applicative<F>.compose(GA: Applicative<G> = applicative<G>()): Applicative<ComposedType<F, G>> =
+        ComposedApplicative(this, GA)

--- a/kategory/src/main/kotlin/kategory/data/Composed.kt
+++ b/kategory/src/main/kotlin/kategory/data/Composed.kt
@@ -78,11 +78,9 @@ interface ComposedFunctor<F, G> : Functor<ComposedType<F, G>> {
 
     fun G(): Functor<G>
 
-    override fun <A, B> map(fa: HK<ComposedType<F, G>, A>, f: (A) -> B): HK<ComposedType<F, G>, B> =
-            F().map(fa.lower(), { G().map(it, f) }).lift()
+    override fun <A, B> map(fa: HK<ComposedType<F, G>, A>, f: (A) -> B): HK<ComposedType<F, G>, B> = F().map(fa.lower(), { G().map(it, f) }).lift()
 
-    fun <A, B> mapC(fa: HK<F, HK<G, A>>, f: (A) -> B): HK<F, HK<G, B>> =
-            map(fa.lift(), f).lower()
+    fun <A, B> mapC(fa: HK<F, HK<G, A>>, f: (A) -> B): HK<F, HK<G, B>> = map(fa.lift(), f).lower()
 
     companion object {
         inline operator fun <reified F, reified G> invoke(FF: Functor<F> = functor<F>(), GF: Functor<G> = functor<G>()): Functor<ComposedType<F, G>> = object : ComposedFunctor<F, G> {
@@ -100,17 +98,13 @@ interface ComposedApplicative<F, G> : Applicative<ComposedType<F, G>>, ComposedF
 
     override fun G(): Applicative<G>
 
-    override fun <A, B> map(fa: HK<ComposedType<F, G>, A>, f: (A) -> B): HK<ComposedType<F, G>, B> =
-            ap(fa, pure(f))
+    override fun <A, B> map(fa: HK<ComposedType<F, G>, A>, f: (A) -> B): HK<ComposedType<F, G>, B> = ap(fa, pure(f))
 
-    override fun <A> pure(a: A): HK<ComposedType<F, G>, A> =
-            F().pure(G().pure(a)).lift()
+    override fun <A> pure(a: A): HK<ComposedType<F, G>, A> = F().pure(G().pure(a)).lift()
 
-    override fun <A, B> ap(fa: HK<ComposedType<F, G>, A>, ff: HK<ComposedType<F, G>, (A) -> B>): HK<ComposedType<F, G>, B> =
-            F().ap(fa.lower(), F().map(ff.lower(), { gfa: HK<G, (A) -> B> -> { ga: HK<G, A> -> G().ap(ga, gfa) } })).lift()
+    override fun <A, B> ap(fa: HK<ComposedType<F, G>, A>, ff: HK<ComposedType<F, G>, (A) -> B>): HK<ComposedType<F, G>, B> = F().ap(fa.lower(), F().map(ff.lower(), { gfa: HK<G, (A) -> B> -> { ga: HK<G, A> -> G().ap(ga, gfa) } })).lift()
 
-    fun <A, B> apC(fa: HK<F, HK<G, A>>, ff: HK<F, HK<G, (A) -> B>>): HK<F, HK<G, B>> =
-            ap(fa.lift(), ff.lift()).lower()
+    fun <A, B> apC(fa: HK<F, HK<G, A>>, ff: HK<F, HK<G, (A) -> B>>): HK<F, HK<G, B>> = ap(fa.lift(), ff.lift()).lower()
 
     companion object {
         inline operator fun <reified F, reified G> invoke(FF: Applicative<F> = applicative<F>(), GF: Applicative<G> = applicative<G>()): Applicative<ComposedType<F, G>> = object : ComposedApplicative<F, G> {
@@ -121,5 +115,4 @@ interface ComposedApplicative<F, G> : Applicative<ComposedType<F, G>>, ComposedF
     }
 }
 
-inline fun <reified F, reified G> Applicative<F>.compose(GA: Applicative<G> = applicative<G>()): Applicative<ComposedType<F, G>> =
-        ComposedApplicative(this, GA)
+inline fun <reified F, reified G> Applicative<F>.compose(GA: Applicative<G> = applicative<G>()): Applicative<ComposedType<F, G>> = ComposedApplicative(this, GA)

--- a/kategory/src/main/kotlin/kategory/data/Reader.kt
+++ b/kategory/src/main/kotlin/kategory/data/Reader.kt
@@ -12,8 +12,8 @@ object Reader {
 
     operator fun <D, A> invoke(run: (D) -> A, MF: Monad<IdHK> = Id): ReaderT<IdHK, D, A> = Kleisli(run.andThen { Id(it) }, MF)
 
-    fun <D, A> pure(x: A, MF: Monad<IdHK> = Id): ReaderT<IdHK, D, A> = Kleisli.pure<IdHK, D, A>(x, Id)
+    fun <D, A> pure(x: A, MF: Monad<IdHK> = Id): ReaderT<IdHK, D, A> = Kleisli.pure<IdHK, D, A>(x, MF)
 
-    fun <D> ask(MF: Monad<IdHK> = Id): ReaderT<IdHK, D, D> = Kleisli.ask<IdHK, D>(Id)
+    fun <D> ask(MF: Monad<IdHK> = Id): ReaderT<IdHK, D, D> = Kleisli.ask<IdHK, D>(MF)
 
 }

--- a/kategory/src/test/kotlin/kategory/laws/TraverseLaws.kt
+++ b/kategory/src/test/kotlin/kategory/laws/TraverseLaws.kt
@@ -17,11 +17,10 @@ class TIF {
 }
 
 object TraverseLaws {
-    inline fun <reified F> laws(FF: Traverse<F> = traverse<F>(), AP: Applicative<F> = applicative<F>(), crossinline cf: (Int) -> HK<F, Int>, EQ: Eq<HK<F, Int>>): List<Law> =
-            FoldableLaws.laws(FF, cf, Eq.any()) + FunctorLaws.laws(AP, EQ) + listOf(
-                    Law("Traverse Laws: Identity", { identityTraverse(FF, AP, cf, EQ) }),
-                    // TODO (#136)
-                    // Law("Traverse Laws: Sequential composition", { sequentialComposition(FF, AP, cf, EQ) })
+    inline fun <reified F> laws(FF: Traverse<F> = traverse<F>(), APF: Applicative<F> = applicative<F>(), crossinline cf: (Int) -> HK<F, Int>, EQ: Eq<HK<F, Int>>): List<Law> =
+            FoldableLaws.laws(FF, cf, Eq.any()) + FunctorLaws.laws(APF, EQ) + listOf(
+                    Law("Traverse Laws: Identity", { identityTraverse(FF, APF, cf, EQ) }),
+                    Law("Traverse Laws: Sequential composition", { sequentialComposition(FF, cf, EQ) }),
                     Law("Traverse Laws: Parallel composition", { parallelComposition(FF, cf, EQ) })
                     // TODO (#136)
                     // Law("Traverse Laws: FoldMap derived", { foldMapDerived(FF, AP, cf, EQ) })
@@ -30,6 +29,14 @@ object TraverseLaws {
     inline fun <reified F> identityTraverse(FF: Traverse<F>, AP: Applicative<F> = applicative<F>(), crossinline cf: (Int) -> HK<F, Int>, EQ: Eq<HK<F, Int>>) =
             forAll(genFunctionAToB<Int, HK<IdHK, Int>>(genConstructor(genIntSmall(), ::Id)), genConstructor(genIntSmall(), cf), { f: (Int) -> HK<IdHK, Int>, fa: HK<F, Int> ->
                 FF.traverse(fa, f, Id).value().equalUnderTheLaw(FF.map(fa, f).map(AP) { it.value() }, EQ)
+            })
+
+    inline fun <reified F> sequentialComposition(FF: Traverse<F>, crossinline cf: (Int) -> HK<F, Int>, EQ: Eq<HK<F, Int>>) =
+            forAll(genFunctionAToB<Int, HK<IdHK, Int>>(genConstructor(genIntSmall(), ::Id)), genFunctionAToB<Int, HK<IdHK, Int>>(genConstructor(genIntSmall(), ::Id)), genConstructor(genIntSmall(), cf), { f: (Int) -> HK<IdHK, Int>, g: (Int) -> HK<IdHK, Int>, fha: HK<F, Int> ->
+                val fa = fha.traverse(FF, Id, f).ev()
+                val composed = Id.map(fa, { it.traverse(FF, Id, g) }).value.value()
+                val expected = fha.traverse(FF, ComposedApplicative(Id, Id), { a: Int -> Id.map(f(a), g).lift() }).lower().value().value()
+                composed.equalUnderTheLaw(expected, EQ)
             })
 
     inline fun <reified F> parallelComposition(FF: Traverse<F>, crossinline cf: (Int) -> HK<F, Int>, EQ: Eq<HK<F, Int>>) =

--- a/kategory/src/test/kotlin/kategory/laws/TraverseLaws.kt
+++ b/kategory/src/test/kotlin/kategory/laws/TraverseLaws.kt
@@ -17,9 +17,9 @@ class TIF {
 }
 
 object TraverseLaws {
-    inline fun <reified F> laws(FF: Traverse<F> = traverse<F>(), APF: Applicative<F> = applicative<F>(), crossinline cf: (Int) -> HK<F, Int>, EQ: Eq<HK<F, Int>>): List<Law> =
-            FoldableLaws.laws(FF, cf, Eq.any()) + FunctorLaws.laws(APF, EQ) + listOf(
-                    Law("Traverse Laws: Identity", { identityTraverse(FF, APF, cf, EQ) }),
+    inline fun <reified F> laws(FF: Traverse<F> = traverse<F>(), AP: Applicative<F> = applicative<F>(), crossinline cf: (Int) -> HK<F, Int>, EQ: Eq<HK<F, Int>>): List<Law> =
+            FoldableLaws.laws(FF, cf, Eq.any()) + FunctorLaws.laws(AP, EQ) + listOf(
+                    Law("Traverse Laws: Identity", { identityTraverse(FF, AP, cf, EQ) }),
                     Law("Traverse Laws: Sequential composition", { sequentialComposition(FF, cf, EQ) }),
                     Law("Traverse Laws: Parallel composition", { parallelComposition(FF, cf, EQ) })
                     // TODO (#136)


### PR DESCRIPTION
This PR touches the Composed file to add ComposedApplicative. With ComposedApplicative the Traverse law for sequential composition can be written.

With apologies to @Guardiola31337 for the disruption.