### PR TITLE
Add Traverse law for FoldMap derived: required Const

### DIFF
--- a/kategory/src/main/kotlin/kategory/data/Const.kt
+++ b/kategory/src/main/kotlin/kategory/data/Const.kt
@@ -1,7 +1,6 @@
 package kategory
 
-fun <A, T> ConstKind<A, T>.value(): A =
-        this.ev().value
+fun <A, T> ConstKind<A, T>.value(): A = this.ev().value
 
 typealias ConstF<A> = HK<ConstHK, A>
 
@@ -10,8 +9,7 @@ typealias ConstF<A> = HK<ConstHK, A>
     @Suppress("UNCHECKED_CAST")
     fun <U> retag(): Const<A, U> = this as Const<A, U>
 
-    inline fun <F, U> traverse(f: (T) -> HK<F, U>, FA: Applicative<F>): HK<F, Const<A, U>> =
-            FA.pure(retag())
+    inline fun <F, U> traverse(f: (T) -> HK<F, U>, FA: Applicative<F>): HK<F, Const<A, U>> = FA.pure(retag())
 
     companion object {
         fun <T, A> pure(a: A): Const<A, T> = Const(a)
@@ -34,10 +32,8 @@ typealias ConstF<A> = HK<ConstHK, A>
     }
 }
 
-fun <A, T> ConstKind<A, T>.combine(that: ConstKind<A, T>, SG: Semigroup<A>): Const<A, T> =
-        Const(SG.combine(this.value(), that.value()))
+fun <A, T> ConstKind<A, T>.combine(that: ConstKind<A, T>, SG: Semigroup<A>): Const<A, T> = Const(SG.combine(this.value(), that.value()))
 
-fun <A, T, U> ConstKind<A, T>.ap(ff: ConstKind<A, (T) -> U>, SG: Semigroup<A>): Const<A, U> =
-        ff.ev().retag<U>().combine(this.ev().retag(), SG)
+fun <A, T, U> ConstKind<A, T>.ap(ff: ConstKind<A, (T) -> U>, SG: Semigroup<A>): Const<A, U> = ff.ev().retag<U>().combine(this.ev().retag(), SG)
 
 fun <A> A.const(): Const<A, Nothing> = Const(this)

--- a/kategory/src/main/kotlin/kategory/data/Const.kt
+++ b/kategory/src/main/kotlin/kategory/data/Const.kt
@@ -39,3 +39,5 @@ fun <A, T> ConstKind<A, T>.combine(that: ConstKind<A, T>, SG: Semigroup<A>): Con
 
 fun <A, T, U> ConstKind<A, T>.ap(ff: ConstKind<A, (T) -> U>, SG: Semigroup<A>): Const<A, U> =
         ff.ev().retag<U>().combine(this.ev().retag(), SG)
+
+fun <A> A.const(): Const<A, Nothing> = Const(this)

--- a/kategory/src/main/kotlin/kategory/data/Const.kt
+++ b/kategory/src/main/kotlin/kategory/data/Const.kt
@@ -1,0 +1,41 @@
+package kategory
+
+fun <A, T> ConstKind<A, T>.value(): A =
+        this.ev().value
+
+typealias ConstF<A> = HK<ConstHK, A>
+
+@higherkind data class Const<out A, out T>(val value: A) : ConstKind<A, T> {
+
+    @Suppress("UNCHECKED_CAST")
+    fun <U> retag(): Const<A, U> = this as Const<A, U>
+
+    inline fun <F, U> traverse(f: (T) -> HK<F, U>, FA: Applicative<F>): HK<F, Const<A, U>> =
+            FA.pure(retag())
+
+    companion object {
+        fun <T, A> pure(a: A): Const<A, T> = Const(a)
+
+        fun <A> instances(MA: Monoid<A>): ConstInstances<A> = object : ConstInstances<A> {
+            override fun MA(): Monoid<A> = MA
+        }
+
+        inline fun <reified A> applicative(MA: Monoid<A> = kategory.monoid<A>()): Applicative<ConstF<A>> = instances(MA)
+
+        inline fun <reified A> traverse(MA: Monoid<A> = kategory.monoid<A>()): Traverse<ConstF<A>> = instances(MA)
+
+        fun <A, T> semigroup(MA: Monoid<A>): Semigroup<ConstKind<A, T>> = object : ConstMonoid<A, T> {
+            override fun MA(): Monoid<A> = MA
+        }
+
+        fun <A, T> monoid(MA: Monoid<A>): Monoid<ConstKind<A, T>> = object : ConstMonoid<A, T> {
+            override fun MA(): Monoid<A> = MA
+        }
+    }
+}
+
+fun <A, T> ConstKind<A, T>.combine(that: ConstKind<A, T>, SG: Semigroup<A>): Const<A, T> =
+        Const(SG.combine(this.value(), that.value()))
+
+fun <A, T, U> ConstKind<A, T>.ap(ff: ConstKind<A, (T) -> U>, SG: Semigroup<A>): Const<A, U> =
+        ff.ev().retag<U>().combine(this.ev().retag(), SG)

--- a/kategory/src/main/kotlin/kategory/data/Const.kt
+++ b/kategory/src/main/kotlin/kategory/data/Const.kt
@@ -14,21 +14,15 @@ typealias ConstF<A> = HK<ConstHK, A>
     companion object {
         fun <T, A> pure(a: A): Const<A, T> = Const(a)
 
-        fun <A> instances(MA: Monoid<A>): ConstInstances<A> = object : ConstInstances<A> {
-            override fun MA(): Monoid<A> = MA
-        }
+        inline fun <reified A> instances(MA: Monoid<A> = kategory.monoid<A>()): ConstInstances<A> = ConstInstances(MA)
 
         inline fun <reified A> applicative(MA: Monoid<A> = kategory.monoid<A>()): Applicative<ConstF<A>> = instances(MA)
 
         inline fun <reified A> traverse(MA: Monoid<A> = kategory.monoid<A>()): Traverse<ConstF<A>> = instances(MA)
 
-        fun <A, T> semigroup(MA: Monoid<A>): Semigroup<ConstKind<A, T>> = object : ConstMonoid<A, T> {
-            override fun MA(): Monoid<A> = MA
-        }
+        inline fun <reified A, T> semigroup(MA: Monoid<A> = kategory.monoid<A>()): Semigroup<ConstKind<A, T>> = ConstMonoid(MA)
 
-        fun <A, T> monoid(MA: Monoid<A>): Monoid<ConstKind<A, T>> = object : ConstMonoid<A, T> {
-            override fun MA(): Monoid<A> = MA
-        }
+        inline fun <reified A, T> monoid(MA: Monoid<A> = kategory.monoid<A>()): Monoid<ConstKind<A, T>> = ConstMonoid(MA)
     }
 }
 

--- a/kategory/src/main/kotlin/kategory/data/Either.kt
+++ b/kategory/src/main/kotlin/kategory/data/Either.kt
@@ -101,8 +101,8 @@ typealias EitherF<L> = HK<EitherHK, L>
      * The left side of the disjoint union, as opposed to the [Right] side.
      */
     data class Left<out A, out B>(val a: A, private val dummy: Unit) : Either<A, B>() {
-        override internal val isLeft = true
-        override internal val isRight = false
+        override val isLeft = true
+        override val isRight = false
 
         companion object {
             inline operator fun <A> invoke(a: A): Either<A, Nothing> = Left(a, Unit)
@@ -113,8 +113,8 @@ typealias EitherF<L> = HK<EitherHK, L>
      * The right side of the disjoint union, as opposed to the [Left] side.
      */
     data class Right<out A, out B>(val b: B, private val dummy: Unit) : Either<A, B>() {
-        override internal val isLeft = false
-        override internal val isRight = true
+        override val isLeft = false
+        override val isRight = true
 
         companion object {
             inline operator fun <B> invoke(b: B): Either<Nothing, B> = Right(b, Unit)

--- a/kategory/src/main/kotlin/kategory/instances/ConstInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/ConstInstances.kt
@@ -6,7 +6,7 @@ interface ConstInstances<A> :
 
     fun MA(): Monoid<A>
 
-    override fun <T> pure(a: T): Const<A, T> = Const.monoid<A, T>(MA()).empty().ev()
+    override fun <T> pure(a: T): Const<A, T> = ConstMonoid<A, T>(MA()).empty().ev()
 
     override fun <T, U> ap(fa: HK<ConstF<A>, T>, ff: HK<ConstF<A>, (T) -> U>): Const<A, U> = fa.ap(ff, MA())
 
@@ -17,6 +17,12 @@ interface ConstInstances<A> :
     override fun <T, U> foldR(fa: HK<ConstF<A>, T>, lb: Eval<U>, f: (T, Eval<U>) -> Eval<U>): Eval<U> = lb
 
     override fun <G, T, U> traverse(fa: HK<ConstF<A>, T>, f: (T) -> HK<G, U>, GA: Applicative<G>): HK<G, HK<ConstF<A>, U>> = fa.ev().traverse(f, GA)
+
+    companion object {
+        operator fun <A> invoke(MA: Monoid<A>): ConstInstances<A> = object : kategory.ConstInstances<A> {
+            override fun MA(): kategory.Monoid<A> = MA
+        }
+    }
 }
 
 interface ConstMonoid<A, T> : Monoid<ConstKind<A, T>> {
@@ -26,4 +32,10 @@ interface ConstMonoid<A, T> : Monoid<ConstKind<A, T>> {
     override fun combine(a: ConstKind<A, T>, b: ConstKind<A, T>): Const<A, T> = a.combine(b, MA())
 
     override fun empty(): Const<A, T> = Const(MA().empty())
+
+    companion object {
+        operator fun <A, T> invoke(MA: Monoid<A>): ConstMonoid<A, T> = object : ConstMonoid<A, T> {
+            override fun MA(): Monoid<A> = MA
+        }
+    }
 }

--- a/kategory/src/main/kotlin/kategory/instances/ConstInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/ConstInstances.kt
@@ -6,30 +6,24 @@ interface ConstInstances<A> :
 
     fun MA(): Monoid<A>
 
-    override fun <T> pure(a: T): Const<A, T> =
-            Const.monoid<A, T>(MA()).empty().ev()
+    override fun <T> pure(a: T): Const<A, T> = Const.monoid<A, T>(MA()).empty().ev()
 
-    override fun <T, U> ap(fa: HK<ConstF<A>, T>, ff: HK<ConstF<A>, (T) -> U>): Const<A, U> =
-            fa.ap(ff, MA())
+    override fun <T, U> ap(fa: HK<ConstF<A>, T>, ff: HK<ConstF<A>, (T) -> U>): Const<A, U> = fa.ap(ff, MA())
 
-    override fun <T, U> map(fa: HK<ConstF<A>, T>, f: (T) -> U): Const<A, U> =
-            fa.ev().retag()
+    override fun <T, U> map(fa: HK<ConstF<A>, T>, f: (T) -> U): Const<A, U> = fa.ev().retag()
 
     override fun <T, U> foldL(fa: HK<ConstF<A>, T>, b: U, f: (U, T) -> U): U = b
 
     override fun <T, U> foldR(fa: HK<ConstF<A>, T>, lb: Eval<U>, f: (T, Eval<U>) -> Eval<U>): Eval<U> = lb
 
-    override fun <G, T, U> traverse(fa: HK<ConstF<A>, T>, f: (T) -> HK<G, U>, GA: Applicative<G>): HK<G, HK<ConstF<A>, U>> =
-            fa.ev().traverse(f, GA)
+    override fun <G, T, U> traverse(fa: HK<ConstF<A>, T>, f: (T) -> HK<G, U>, GA: Applicative<G>): HK<G, HK<ConstF<A>, U>> = fa.ev().traverse(f, GA)
 }
 
 interface ConstMonoid<A, T> : Monoid<ConstKind<A, T>> {
 
     fun MA(): Monoid<A>
 
-    override fun combine(a: ConstKind<A, T>, b: ConstKind<A, T>): Const<A, T> =
-            a.combine(b, MA())
+    override fun combine(a: ConstKind<A, T>, b: ConstKind<A, T>): Const<A, T> = a.combine(b, MA())
 
-    override fun empty(): Const<A, T> =
-            Const(MA().empty())
+    override fun empty(): Const<A, T> = Const(MA().empty())
 }

--- a/kategory/src/main/kotlin/kategory/instances/ConstInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/ConstInstances.kt
@@ -1,0 +1,35 @@
+package kategory
+
+interface ConstInstances<A> :
+        Applicative<ConstF<A>>,
+        Traverse<ConstF<A>> {
+
+    fun MA(): Monoid<A>
+
+    override fun <T> pure(a: T): Const<A, T> =
+            Const.monoid<A, T>(MA()).empty().ev()
+
+    override fun <T, U> ap(fa: HK<ConstF<A>, T>, ff: HK<ConstF<A>, (T) -> U>): Const<A, U> =
+            fa.ap(ff, MA())
+
+    override fun <T, U> map(fa: HK<ConstF<A>, T>, f: (T) -> U): Const<A, U> =
+            fa.ev().retag()
+
+    override fun <T, U> foldL(fa: HK<ConstF<A>, T>, b: U, f: (U, T) -> U): U = b
+
+    override fun <T, U> foldR(fa: HK<ConstF<A>, T>, lb: Eval<U>, f: (T, Eval<U>) -> Eval<U>): Eval<U> = lb
+
+    override fun <G, T, U> traverse(fa: HK<ConstF<A>, T>, f: (T) -> HK<G, U>, GA: Applicative<G>): HK<G, HK<ConstF<A>, U>> =
+            fa.ev().traverse(f, GA)
+}
+
+interface ConstMonoid<A, T> : Monoid<ConstKind<A, T>> {
+
+    fun MA(): Monoid<A>
+
+    override fun combine(a: ConstKind<A, T>, b: ConstKind<A, T>): Const<A, T> =
+            a.combine(b, MA())
+
+    override fun empty(): Const<A, T> =
+            Const(MA().empty())
+}

--- a/kategory/src/test/kotlin/kategory/data/ConstTest.kt
+++ b/kategory/src/test/kotlin/kategory/data/ConstTest.kt
@@ -1,0 +1,13 @@
+package kategory
+
+import io.kotlintest.KTestJUnitRunner
+import org.junit.runner.RunWith
+
+@RunWith(KTestJUnitRunner::class)
+class ConstTest : UnitSpec() {
+    init {
+        testLaws(TraverseLaws.laws(Const.traverse(IntMonoid), Const.applicative(IntMonoid), { Const(it) }, Eq.any()))
+        testLaws(ApplicativeLaws.laws(Const.applicative(IntMonoid), Eq.any()))
+    }
+}
+

--- a/kategory/src/test/kotlin/kategory/data/ConstTest.kt
+++ b/kategory/src/test/kotlin/kategory/data/ConstTest.kt
@@ -10,4 +10,3 @@ class ConstTest : UnitSpec() {
         testLaws(ApplicativeLaws.laws(Const.applicative(IntMonoid), Eq.any()))
     }
 }
-

--- a/kategory/src/test/kotlin/kategory/laws/TraverseLaws.kt
+++ b/kategory/src/test/kotlin/kategory/laws/TraverseLaws.kt
@@ -60,7 +60,7 @@ object TraverseLaws {
 
     inline fun <reified F> foldMapDerived(FF: Traverse<F>, AP: Applicative<F> = applicative<F>(), crossinline cf: (Int) -> HK<F, Int>, EQ: Eq<HK<F, Int>>) =
             forAll(genFunctionAToB<Int, Int>(genIntSmall()), genConstructor(genIntSmall(), cf), { f: (Int) -> Int, fa: HK<F, Int> ->
-                val traversed = fa.traverse(FF, Const.applicative(IntMonoid), { a -> Const<Int, String>(f(a)) }).value()
+                val traversed = fa.traverse(FF, Const.applicative(IntMonoid), { a -> f(a).const() }).value()
                 val mapped = fa.foldMap(FF, IntMonoid, f)
                 mapped.equalUnderTheLaw(traversed, Eq.any())
             })

--- a/kategory/src/test/kotlin/kategory/laws/TraverseLaws.kt
+++ b/kategory/src/test/kotlin/kategory/laws/TraverseLaws.kt
@@ -17,14 +17,14 @@ class TIF {
 }
 
 object TraverseLaws {
+    // FIXME(paco): cf is only required because AP::pure will crash the inliner
     inline fun <reified F> laws(FF: Traverse<F> = traverse<F>(), AP: Applicative<F> = applicative<F>(), crossinline cf: (Int) -> HK<F, Int>, EQ: Eq<HK<F, Int>>): List<Law> =
             FoldableLaws.laws(FF, cf, Eq.any()) + FunctorLaws.laws(AP, EQ) + listOf(
                     Law("Traverse Laws: Identity", { identityTraverse(FF, AP, cf, EQ) }),
                     // TODO (#136)
                     // Law("Traverse Laws: Sequential composition", { sequentialComposition(FF, AP, cf, EQ) })
-                    Law("Traverse Laws: Parallel composition", { parallelComposition(FF, cf, EQ) })
-                    // TODO (#136)
-                    // Law("Traverse Laws: FoldMap derived", { foldMapDerived(FF, AP, cf, EQ) })
+                    Law("Traverse Laws: Parallel composition", { parallelComposition(FF, cf, EQ) }),
+                    Law("Traverse Laws: FoldMap derived", { foldMapDerived(FF, AP, cf, EQ) })
             )
 
     inline fun <reified F> identityTraverse(FF: Traverse<F>, AP: Applicative<F> = applicative<F>(), crossinline cf: (Int) -> HK<F, Int>, EQ: Eq<HK<F, Int>>) =
@@ -56,5 +56,12 @@ object TraverseLaws {
                 val expected: TI<HK<F, Int>> = TIC(FF.traverse(fha, f, Id) toT FF.traverse(fha, g, Id)).ti
 
                 seen.equalUnderTheLaw(expected, TIEQ)
+            })
+
+    inline fun <reified F> foldMapDerived(FF: Traverse<F>, AP: Applicative<F> = applicative<F>(), crossinline cf: (Int) -> HK<F, Int>, EQ: Eq<HK<F, Int>>) =
+            forAll(genFunctionAToB<Int, Int>(genIntSmall()), genConstructor(genIntSmall(), cf), { f: (Int) -> Int, fa: HK<F, Int> ->
+                val traversed = fa.traverse(FF, Const.applicative(IntMonoid), { a -> Const<Int, String>(f(a)) }).value()
+                val mapped = fa.foldMap(FF, IntMonoid, f)
+                mapped.equalUnderTheLaw(traversed, Eq.any())
             })
 }


### PR DESCRIPTION
Along with #179, these add the last two missing laws for traverse compared to Cats.

It required porting Const, which is a nice HK2 whose bias is towards a non-existing value Tag.