### PR TITLE
Add analyze to FreeApplicative

### DIFF
--- a/kategory/src/main/kotlin/kategory/free/FreeApplicative.kt
+++ b/kategory/src/main/kotlin/kategory/free/FreeApplicative.kt
@@ -56,8 +56,10 @@ inline fun <reified F, A> FreeApplicativeKind<F, A>.foldK(FA: Applicative<F> = a
 
     fun <G> flatCompile(f: FunctionK<F, FreeApplicativeF<G>>, GFA: Applicative<FreeApplicativeF<G>>): FreeApplicative<G, A> = foldMap(f, GFA).ev()
 
-    // TODO(paco): requires Const
-    // final def analyze[M: Monoid](f: FunctionK[F, λ[α => M]]): M
+    fun <M> analyze(f: FunctionK<F, ConstF<M>>, MM: Monoid<M>): M =
+            foldMap(object : FunctionK<F, ConstF<M>> {
+                override fun <A> invoke(fa: HK<F, A>): Const<M, A> = f(fa).ev()
+            }, Const.instances(MM)).value()
 
     fun monad(): Free<F, A> = foldMap(Free.functionKF(), Free.applicativeF()).ev()
 

--- a/kategory/src/main/kotlin/kategory/free/FreeApplicative.kt
+++ b/kategory/src/main/kotlin/kategory/free/FreeApplicative.kt
@@ -59,7 +59,7 @@ inline fun <reified F, A> FreeApplicativeKind<F, A>.foldK(FA: Applicative<F> = a
     fun <M> analyze(f: FunctionK<F, ConstF<M>>, MM: Monoid<M>): M =
             foldMap(object : FunctionK<F, ConstF<M>> {
                 override fun <A> invoke(fa: HK<F, A>): Const<M, A> = f(fa).ev()
-            }, Const.instances(MM)).value()
+            }, ConstInstances(MM)).value()
 
     fun monad(): Free<F, A> = foldMap(Free.functionKF(), Free.applicativeF()).ev()
 


### PR DESCRIPTION
Now that Const is in the repo via #180, the missing method in FreeApplicative can be added.

Please note that it requires to have merged #179 and #180 beforehand.

Closes #136