### PR TITLE
Add support for CoroutineContext to execute binding in separate threads

### DIFF
--- a/kategory-test/src/main/kotlin/kategory/concurrency/CoroutineDispatchers.kt
+++ b/kategory-test/src/main/kotlin/kategory/concurrency/CoroutineDispatchers.kt
@@ -1,0 +1,15 @@
+package kategory
+
+import kotlinx.coroutines.experimental.CoroutineDispatcher
+import kotlinx.coroutines.experimental.asCoroutineDispatcher
+import java.util.concurrent.LinkedBlockingDeque
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+
+fun newCoroutineDispatcher(name: String): CoroutineDispatcher =
+        ThreadPoolExecutor(10, 50, 30, TimeUnit.SECONDS, LinkedBlockingDeque(), ThreadFactory { run ->
+            Thread(run).apply {
+                this.name = name
+            }
+        }).asCoroutineDispatcher()

--- a/kategory-test/src/main/kotlin/kategory/laws/Law.kt
+++ b/kategory-test/src/main/kotlin/kategory/laws/Law.kt
@@ -1,6 +1,70 @@
 package kategory
 
+import io.kotlintest.properties.Gen
+
 data class Law(val name: String, val test: () -> Unit)
 
 inline fun <reified A> A.equalUnderTheLaw(b: A, eq: Eq<A>): Boolean =
         eq.eqv(this, b)
+
+fun <A> forFew(amount: Int, gena: Gen<A>, fn: (a: A) -> Boolean): Unit {
+    for (k in 0..amount) {
+        val a = gena.generate()
+        val passed = fn(a)
+        if (!passed) {
+            throw AssertionError("Property failed for\n$a)")
+        }
+    }
+}
+
+fun <A, B> forFew(amount: Int, gena: Gen<A>, genb: Gen<B>, fn: (a: A, b: B) -> Boolean): Unit {
+    for (k in 0..amount) {
+        val a = gena.generate()
+        val b = genb.generate()
+        val passed = fn(a, b)
+        if (!passed) {
+            throw AssertionError("Property failed for\n$a\n$b)")
+        }
+    }
+}
+
+
+fun <A, B, C> forFew(amount: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, fn: (a: A, b: B, c: C) -> Boolean): Unit {
+    for (k in 0..amount) {
+        val a = gena.generate()
+        val b = genb.generate()
+        val c = genc.generate()
+        val passed = fn(a, b, c)
+        if (!passed) {
+            throw AssertionError("Property failed for\n$a\n$b\n$c)")
+        }
+    }
+}
+
+
+fun <A, B, C, D> forFew(amount: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, gend: Gen<D>, fn: (a: A, b: B, c: C, d: D) -> Boolean): Unit {
+    for (k in 0..amount) {
+        val a = gena.generate()
+        val b = genb.generate()
+        val c = genc.generate()
+        val d = gend.generate()
+        val passed = fn(a, b, c, d)
+        if (!passed) {
+            throw AssertionError("Property failed for\n$a\n$b\n$c\n$d)")
+        }
+    }
+}
+
+fun <A, B, C, D, E> forFew(amount: Int, gena: Gen<A>, genb: Gen<B>, genc: Gen<C>, gend: Gen<D>, gene: Gen<E>, fn: (a: A, b: B, c: C, d: D, e: E) -> Boolean): Unit {
+    for (k in 0..amount) {
+        val a = gena.generate()
+        val b = genb.generate()
+        val c = genc.generate()
+        val d = gend.generate()
+        val e = gene.generate()
+        val passed = fn(a, b, c, d , e)
+        if (!passed) {
+            throw AssertionError("Property failed for\n$a\n$b\n$c\n$d\$e)")
+        }
+    }
+}

--- a/kategory-test/src/main/kotlin/kategory/laws/MonadLaws.kt
+++ b/kategory-test/src/main/kotlin/kategory/laws/MonadLaws.kt
@@ -15,7 +15,8 @@ object MonadLaws {
                     Law("Monad Laws: monad comprehensions", { monadComprehensions(M, EQ) }),
                     Law("Monad Laws: stack-safe//unsafe monad comprehensions equivalence", { equivalentComprehensions(M, EQ) }),
                     Law("Monad / JVM: stack safe", { stackSafety(5000, M, EQ) }),
-                    Law("Monad / JVM: stack safe comprehensions", { stackSafetyComprehensions(5000, M, EQ) })
+                    Law("Monad / JVM: stack safe comprehensions", { stackSafetyComprehensions(5000, M, EQ) }),
+                    Law("Monad / JVM: monad comprehension support context change", { monadComprehensionsContext(M, EQ) })
             )
 
     inline fun <reified F> leftIdentity(M: Monad<F> = monad<F>(), EQ: Eq<HK<F, Int>>): Unit =
@@ -81,11 +82,27 @@ object MonadLaws {
                 }.equalUnderTheLaw(M.pure(num + 2), EQ)
             })
 
+    inline fun <reified F> monadComprehensionsContext(M: Monad<F> = monad<F>(), EQ: Eq<HK<F, Int>>): Unit =
+            forFew(10, genIntSmall(), genIntSmall(), genIntSmall(), { a: Int, b: Int, c: Int ->
+                val CDA = newCoroutineDispatcher("$a")
+                val CDB = newCoroutineDispatcher("$b")
+                val CDC = newCoroutineDispatcher("$c")
+                val result: HK<F, Int> = M.binding {
+                    val x = bindInContext(CDA) { M.pure(getThreadNumber()) }
+                    val y = bindInContext(CDB) { M.pure(getThreadNumber()) }
+                    val z = bindInContext(CDC) { M.pure(getThreadNumber()) }
+                    yields(x + y + z)
+                }
+                result.equalUnderTheLaw(M.pure(a + b + c), EQ)
+            })
+
+    // The thread name has some values appended at the end by the koroutines library
+    inline fun getThreadNumber() = Thread.currentThread().name.split(" ").first().toInt()
+
     fun <F> stackSafeTestProgram(M: Monad<F>, n: Int, stopAt: Int): Free<F, Int> = M.bindingStackSafe {
         val v = M.pure(n + 1).bind()
         val r = if (v < stopAt) stackSafeTestProgram(M, v, stopAt).bind() else M.pure(v).bind()
         yields(r)
     }
-
 
 }

--- a/kategory-test/src/main/kotlin/kategory/laws/TraverseLaws.kt
+++ b/kategory-test/src/main/kotlin/kategory/laws/TraverseLaws.kt
@@ -23,7 +23,7 @@ object TraverseLaws {
                     Law("Traverse Laws: Identity", { identityTraverse(FF, AP, cf, EQ) }),
                     Law("Traverse Laws: Sequential composition", { sequentialComposition(FF, cf, EQ) }),
                     Law("Traverse Laws: Parallel composition", { parallelComposition(FF, cf, EQ) }),
-                    Law("Traverse Laws: FoldMap derived", { foldMapDerived(FF, AP, cf, EQ) })
+                    Law("Traverse Laws: FoldMap derived", { foldMapDerived(FF, cf) })
             )
 
     inline fun <reified F> identityTraverse(FF: Traverse<F>, AP: Applicative<F> = applicative<F>(), crossinline cf: (Int) -> HK<F, Int>, EQ: Eq<HK<F, Int>>) =

--- a/kategory-test/src/main/kotlin/kategory/laws/TraverseLaws.kt
+++ b/kategory-test/src/main/kotlin/kategory/laws/TraverseLaws.kt
@@ -65,7 +65,7 @@ object TraverseLaws {
                 seen.equalUnderTheLaw(expected, TIEQ)
             })
 
-    inline fun <reified F> foldMapDerived(FF: Traverse<F>, AP: Applicative<F> = applicative<F>(), crossinline cf: (Int) -> HK<F, Int>, EQ: Eq<HK<F, Int>>) =
+    inline fun <reified F> foldMapDerived(FF: Traverse<F>, crossinline cf: (Int) -> HK<F, Int>) =
             forAll(genFunctionAToB<Int, Int>(genIntSmall()), genConstructor(genIntSmall(), cf), { f: (Int) -> Int, fa: HK<F, Int> ->
                 val traversed = fa.traverse(FF, Const.applicative(IntMonoid), { a -> f(a).const() }).value()
                 val mapped = fa.foldMap(FF, IntMonoid, f)

--- a/kategory/src/main/kotlin/kategory/typeclasses/Monad.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/Monad.kt
@@ -2,9 +2,13 @@ package kategory
 
 import kotlinx.coroutines.experimental.runBlocking
 import java.io.Serializable
-import kotlin.coroutines.experimental.*
+import kotlin.coroutines.experimental.Continuation
+import kotlin.coroutines.experimental.CoroutineContext
+import kotlin.coroutines.experimental.EmptyCoroutineContext
+import kotlin.coroutines.experimental.RestrictsSuspension
 import kotlin.coroutines.experimental.intrinsics.COROUTINE_SUSPENDED
 import kotlin.coroutines.experimental.intrinsics.suspendCoroutineOrReturn
+import kotlin.coroutines.experimental.startCoroutine
 
 interface Monad<F> : Applicative<F>, Typeclass {
 

--- a/reports/baseline.xml
+++ b/reports/baseline.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" ?>
 <SmellBaseline>
   <Blacklist timestamp="1490879306930"></Blacklist>
-  <Whitelist timestamp="1502654393507">
+  <Whitelist timestamp="1502670811218">
     <ID>LabeledExpression:FunctionK.kt$&lt;no name provided&gt;$this@or</ID>
     <ID>LabeledExpression:PartialFunction.kt$&lt;no name provided&gt;$this@orElse</ID>
+    <ID>LabeledExpression:PartialFunction.kt$&lt;no name provided&gt;$this@orElse</ID>
+    <ID>LabeledExpression:PartialFunction.kt$&lt;no name provided&gt;$this@orElse</ID>
     <ID>LabeledExpression:PartialFunction.kt$&lt;no name provided&gt;$this@andThen</ID>
+    <ID>LabeledExpression:PartialFunction.kt$&lt;no name provided&gt;$this@andThen</ID>
+    <ID>LabeledExpression:Eval.kt$Eval.&lt;no name provided&gt;$this@Eval</ID>
     <ID>LabeledExpression:Eval.kt$Eval.&lt;no name provided&gt;.&lt;no name provided&gt;$this@Eval</ID>
+    <ID>LabeledExpression:Eval.kt$Eval.&lt;no name provided&gt;$this@Eval</ID>
     <ID>LabeledExpression:Eval.kt$Eval.&lt;no name provided&gt;$this@Eval</ID>
     <ID>LabeledExpression:Eval.kt$Eval.Compute$break@loop</ID>
     <ID>LabeledExpression:Eval.kt$Eval.Compute$loop@ while (true) { when (curr) { is Compute -&gt; { val currComp: Compute&lt;A&gt; = curr currComp.start&lt;A&gt;().let { cc -&gt; when (cc) { is Compute -&gt; { val inStartFun: (Any?) -&gt; Eval&lt;A&gt; = { cc.run(it) } val outStartFun: (Any?) -&gt; Eval&lt;A&gt; = { currComp.run(it) } curr = cc.start&lt;A&gt;() fs = listOf(inStartFun, outStartFun) + fs } else -&gt; { curr = currComp.run(cc.value()) } } } } else -&gt; if (fs.isNotEmpty()) { curr = fs[0](curr.value()) fs = fs.drop(1) } else { break@loop } } }</ID>
@@ -13,45 +18,110 @@
     <ID>LabeledExpression:ContinuationUtils.kt$this@label</ID>
     <ID>LabeledExpression:ContinuationUtils.kt$this@completion</ID>
     <ID>LabeledExpression:MonoidK.kt$MonoidK.&lt;no name provided&gt;$this@MonoidK</ID>
+    <ID>LabeledExpression:MonoidK.kt$MonoidK.&lt;no name provided&gt;$this@MonoidK</ID>
     <ID>ComplexMethod:AndThen.kt$AndThen$ @Suppress("UNCHECKED_CAST") internal fun runLoop(_success: A?, _failure: Throwable?, _isSuccess: Boolean): B</ID>
     <ID>EmptyClassBlock:Typeclass.kt$&lt;no name provided&gt; : TypeLiteral</ID>
     <ID>OptionalUnit:FreeApplicative.kt$FreeApplicative$Unit</ID>
     <ID>OptionalUnit:Typeclass.kt$GlobalInstance$Unit</ID>
+    <ID>OptionalUnit:AndThen.kt$AndThen$Unit</ID>
     <ID>OptionalUnit:AndThen.kt$AndThen$Unit</ID>
     <ID>OptionalUnit:IO.kt$IO$Unit</ID>
     <ID>LateinitUsage:Comonad.kt$ComonadContinuation$internal lateinit var returnedMonad: A</ID>
     <ID>LateinitUsage:Monad.kt$MonadContinuation$protected lateinit var returnedMonad: HK&lt;F, A&gt;</ID>
     <ID>LateinitUsage:Monad.kt$StackSafeMonadContinuation$protected lateinit var returnedMonad: Free&lt;F, A&gt;</ID>
     <ID>UnsafeCallOnNullableType:AndThen.kt$AndThen$failure!!</ID>
+    <ID>UnsafeCallOnNullableType:AndThen.kt$AndThen$failure!!</ID>
     <ID>MaxLineLength:Kleisli.kt$kategory.Kleisli.kt</ID>
     <ID>MaxLineLength:Composed.kt$kategory.Composed.kt</ID>
+    <ID>MaxLineLength:Composed.kt$kategory.Composed.kt</ID>
+    <ID>MaxLineLength:Composed.kt$kategory.Composed.kt</ID>
+    <ID>MaxLineLength:Composed.kt$kategory.Composed.kt</ID>
+    <ID>MaxLineLength:Composed.kt$kategory.Composed.kt</ID>
+    <ID>MaxLineLength:Composed.kt$kategory.Composed.kt</ID>
+    <ID>MaxLineLength:Composed.kt$kategory.Composed.kt</ID>
+    <ID>MaxLineLength:Composed.kt$kategory.Composed.kt</ID>
+    <ID>MaxLineLength:Coproduct.kt$kategory.Coproduct.kt</ID>
+    <ID>MaxLineLength:Coproduct.kt$kategory.Coproduct.kt</ID>
+    <ID>MaxLineLength:Coproduct.kt$kategory.Coproduct.kt</ID>
     <ID>MaxLineLength:Coproduct.kt$kategory.Coproduct.kt</ID>
     <ID>MaxLineLength:Either.kt$kategory.Either.kt</ID>
     <ID>MaxLineLength:EitherT.kt$kategory.EitherT.kt</ID>
+    <ID>MaxLineLength:EitherT.kt$kategory.EitherT.kt</ID>
+    <ID>MaxLineLength:OptionT.kt$kategory.OptionT.kt</ID>
+    <ID>MaxLineLength:OptionT.kt$kategory.OptionT.kt</ID>
     <ID>MaxLineLength:OptionT.kt$kategory.OptionT.kt</ID>
     <ID>MaxLineLength:WriterT.kt$kategory.WriterT.kt</ID>
+    <ID>MaxLineLength:WriterT.kt$kategory.WriterT.kt</ID>
+    <ID>MaxLineLength:WriterT.kt$kategory.WriterT.kt</ID>
+    <ID>MaxLineLength:WriterT.kt$kategory.WriterT.kt</ID>
+    <ID>MaxLineLength:WriterT.kt$kategory.WriterT.kt</ID>
+    <ID>MaxLineLength:WriterT.kt$kategory.WriterT.kt</ID>
+    <ID>MaxLineLength:WriterT.kt$kategory.WriterT.kt</ID>
     <ID>MaxLineLength:Free.kt$kategory.Free.kt</ID>
+    <ID>MaxLineLength:FreeApplicative.kt$kategory.FreeApplicative.kt</ID>
     <ID>MaxLineLength:FreeApplicative.kt$kategory.FreeApplicative.kt</ID>
     <ID>MaxLineLength:CoproductInstances.kt$kategory.CoproductInstances.kt</ID>
     <ID>MaxLineLength:EitherInstances.kt$kategory.EitherInstances.kt</ID>
     <ID>MaxLineLength:EitherTInstances.kt$kategory.EitherTInstances.kt</ID>
     <ID>MaxLineLength:FreeApplicativeInstances.kt$kategory.FreeApplicativeInstances.kt</ID>
+    <ID>MaxLineLength:FreeApplicativeInstances.kt$kategory.FreeApplicativeInstances.kt</ID>
+    <ID>MaxLineLength:FreeApplicativeInstances.kt$kategory.FreeApplicativeInstances.kt</ID>
     <ID>MaxLineLength:FreeInstances.kt$kategory.FreeInstances.kt</ID>
     <ID>MaxLineLength:IorInstances.kt$kategory.IorInstances.kt</ID>
+    <ID>MaxLineLength:IorInstances.kt$kategory.IorInstances.kt</ID>
+    <ID>MaxLineLength:KleisliInstances.kt$kategory.KleisliInstances.kt</ID>
+    <ID>MaxLineLength:KleisliInstances.kt$kategory.KleisliInstances.kt</ID>
     <ID>MaxLineLength:KleisliInstances.kt$kategory.KleisliInstances.kt</ID>
     <ID>MaxLineLength:OptionTInstances.kt$kategory.OptionTInstances.kt</ID>
     <ID>MaxLineLength:StateTInstances.kt$kategory.StateTInstances.kt</ID>
+    <ID>MaxLineLength:StateTInstances.kt$kategory.StateTInstances.kt</ID>
+    <ID>MaxLineLength:StateTInstances.kt$kategory.StateTInstances.kt</ID>
+    <ID>MaxLineLength:StateTInstances.kt$kategory.StateTInstances.kt</ID>
+    <ID>MaxLineLength:StateTInstances.kt$kategory.StateTInstances.kt</ID>
+    <ID>MaxLineLength:TryInstances.kt$kategory.TryInstances.kt</ID>
     <ID>MaxLineLength:TryInstances.kt$kategory.TryInstances.kt</ID>
     <ID>MaxLineLength:ValidatedInstances.kt$kategory.ValidatedInstances.kt</ID>
     <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
+    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
+    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
+    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
+    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
+    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
+    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
+    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
+    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
+    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
+    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
+    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
+    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
+    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
+    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
+    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
+    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
+    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
+    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
+    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
+    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
+    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
+    <ID>MaxLineLength:ApplicativeError.kt$kategory.ApplicativeError.kt</ID>
     <ID>MaxLineLength:ApplicativeError.kt$kategory.ApplicativeError.kt</ID>
     <ID>MaxLineLength:Foldable.kt$kategory.Foldable.kt</ID>
+    <ID>MaxLineLength:Foldable.kt$kategory.Foldable.kt</ID>
+    <ID>MaxLineLength:Foldable.kt$kategory.Foldable.kt</ID>
+    <ID>MaxLineLength:Foldable.kt$kategory.Foldable.kt</ID>
+    <ID>MaxLineLength:Foldable.kt$kategory.Foldable.kt</ID>
+    <ID>MaxLineLength:Monad.kt$kategory.Monad.kt</ID>
+    <ID>MaxLineLength:Monad.kt$kategory.Monad.kt</ID>
     <ID>MaxLineLength:MonadError.kt$kategory.MonadError.kt</ID>
     <ID>MaxLineLength:MonadReader.kt$kategory.MonadReader.kt</ID>
     <ID>MaxLineLength:MonadState.kt$kategory.MonadState.kt</ID>
     <ID>MaxLineLength:Traverse.kt$kategory.Traverse.kt</ID>
     <ID>MaxLineLength:IO.kt$kategory.IO.kt</ID>
+    <ID>MaxLineLength:IO.kt$kategory.IO.kt</ID>
     <ID>MaxLineLength:IOInstances.kt$kategory.IOInstances.kt</ID>
+    <ID>MaxLineLength:Async.kt$kategory.Async.kt</ID>
+    <ID>MaxLineLength:Async.kt$kategory.Async.kt</ID>
+    <ID>MaxLineLength:Async.kt$kategory.Async.kt</ID>
     <ID>MaxLineLength:Async.kt$kategory.Async.kt</ID>
   </Whitelist>
 </SmellBaseline>

--- a/reports/baseline.xml
+++ b/reports/baseline.xml
@@ -4,124 +4,55 @@
   <Whitelist timestamp="1502670811218">
     <ID>LabeledExpression:FunctionK.kt$&lt;no name provided&gt;$this@or</ID>
     <ID>LabeledExpression:PartialFunction.kt$&lt;no name provided&gt;$this@orElse</ID>
-    <ID>LabeledExpression:PartialFunction.kt$&lt;no name provided&gt;$this@orElse</ID>
-    <ID>LabeledExpression:PartialFunction.kt$&lt;no name provided&gt;$this@orElse</ID>
-    <ID>LabeledExpression:PartialFunction.kt$&lt;no name provided&gt;$this@andThen</ID>
     <ID>LabeledExpression:PartialFunction.kt$&lt;no name provided&gt;$this@andThen</ID>
     <ID>LabeledExpression:Eval.kt$Eval.&lt;no name provided&gt;$this@Eval</ID>
     <ID>LabeledExpression:Eval.kt$Eval.&lt;no name provided&gt;.&lt;no name provided&gt;$this@Eval</ID>
-    <ID>LabeledExpression:Eval.kt$Eval.&lt;no name provided&gt;$this@Eval</ID>
-    <ID>LabeledExpression:Eval.kt$Eval.&lt;no name provided&gt;$this@Eval</ID>
     <ID>LabeledExpression:Eval.kt$Eval.Compute$break@loop</ID>
     <ID>LabeledExpression:Eval.kt$Eval.Compute$loop@ while (true) { when (curr) { is Compute -&gt; { val currComp: Compute&lt;A&gt; = curr currComp.start&lt;A&gt;().let { cc -&gt; when (cc) { is Compute -&gt; { val inStartFun: (Any?) -&gt; Eval&lt;A&gt; = { cc.run(it) } val outStartFun: (Any?) -&gt; Eval&lt;A&gt; = { currComp.run(it) } curr = cc.start&lt;A&gt;() fs = listOf(inStartFun, outStartFun) + fs } else -&gt; { curr = currComp.run(cc.value()) } } } } else -&gt; if (fs.isNotEmpty()) { curr = fs[0](curr.value()) fs = fs.drop(1) } else { break@loop } } }</ID>
     <ID>LabeledExpression:Yoneda.kt$Yoneda.&lt;no name provided&gt;$this@Yoneda</ID>
     <ID>LabeledExpression:ContinuationUtils.kt$this@label</ID>
     <ID>LabeledExpression:ContinuationUtils.kt$this@completion</ID>
     <ID>LabeledExpression:MonoidK.kt$MonoidK.&lt;no name provided&gt;$this@MonoidK</ID>
-    <ID>LabeledExpression:MonoidK.kt$MonoidK.&lt;no name provided&gt;$this@MonoidK</ID>
     <ID>ComplexMethod:AndThen.kt$AndThen$ @Suppress("UNCHECKED_CAST") internal fun runLoop(_success: A?, _failure: Throwable?, _isSuccess: Boolean): B</ID>
     <ID>EmptyClassBlock:Typeclass.kt$&lt;no name provided&gt; : TypeLiteral</ID>
     <ID>OptionalUnit:FreeApplicative.kt$FreeApplicative$Unit</ID>
     <ID>OptionalUnit:Typeclass.kt$GlobalInstance$Unit</ID>
-    <ID>OptionalUnit:AndThen.kt$AndThen$Unit</ID>
     <ID>OptionalUnit:AndThen.kt$AndThen$Unit</ID>
     <ID>OptionalUnit:IO.kt$IO$Unit</ID>
     <ID>LateinitUsage:Comonad.kt$ComonadContinuation$internal lateinit var returnedMonad: A</ID>
     <ID>LateinitUsage:Monad.kt$MonadContinuation$protected lateinit var returnedMonad: HK&lt;F, A&gt;</ID>
     <ID>LateinitUsage:Monad.kt$StackSafeMonadContinuation$protected lateinit var returnedMonad: Free&lt;F, A&gt;</ID>
     <ID>UnsafeCallOnNullableType:AndThen.kt$AndThen$failure!!</ID>
-    <ID>UnsafeCallOnNullableType:AndThen.kt$AndThen$failure!!</ID>
     <ID>MaxLineLength:Kleisli.kt$kategory.Kleisli.kt</ID>
     <ID>MaxLineLength:Composed.kt$kategory.Composed.kt</ID>
-    <ID>MaxLineLength:Composed.kt$kategory.Composed.kt</ID>
-    <ID>MaxLineLength:Composed.kt$kategory.Composed.kt</ID>
-    <ID>MaxLineLength:Composed.kt$kategory.Composed.kt</ID>
-    <ID>MaxLineLength:Composed.kt$kategory.Composed.kt</ID>
-    <ID>MaxLineLength:Composed.kt$kategory.Composed.kt</ID>
-    <ID>MaxLineLength:Composed.kt$kategory.Composed.kt</ID>
-    <ID>MaxLineLength:Composed.kt$kategory.Composed.kt</ID>
-    <ID>MaxLineLength:Coproduct.kt$kategory.Coproduct.kt</ID>
-    <ID>MaxLineLength:Coproduct.kt$kategory.Coproduct.kt</ID>
-    <ID>MaxLineLength:Coproduct.kt$kategory.Coproduct.kt</ID>
     <ID>MaxLineLength:Coproduct.kt$kategory.Coproduct.kt</ID>
     <ID>MaxLineLength:Either.kt$kategory.Either.kt</ID>
     <ID>MaxLineLength:EitherT.kt$kategory.EitherT.kt</ID>
-    <ID>MaxLineLength:EitherT.kt$kategory.EitherT.kt</ID>
     <ID>MaxLineLength:OptionT.kt$kategory.OptionT.kt</ID>
-    <ID>MaxLineLength:OptionT.kt$kategory.OptionT.kt</ID>
-    <ID>MaxLineLength:OptionT.kt$kategory.OptionT.kt</ID>
-    <ID>MaxLineLength:WriterT.kt$kategory.WriterT.kt</ID>
-    <ID>MaxLineLength:WriterT.kt$kategory.WriterT.kt</ID>
-    <ID>MaxLineLength:WriterT.kt$kategory.WriterT.kt</ID>
-    <ID>MaxLineLength:WriterT.kt$kategory.WriterT.kt</ID>
-    <ID>MaxLineLength:WriterT.kt$kategory.WriterT.kt</ID>
-    <ID>MaxLineLength:WriterT.kt$kategory.WriterT.kt</ID>
     <ID>MaxLineLength:WriterT.kt$kategory.WriterT.kt</ID>
     <ID>MaxLineLength:Free.kt$kategory.Free.kt</ID>
-    <ID>MaxLineLength:FreeApplicative.kt$kategory.FreeApplicative.kt</ID>
     <ID>MaxLineLength:FreeApplicative.kt$kategory.FreeApplicative.kt</ID>
     <ID>MaxLineLength:CoproductInstances.kt$kategory.CoproductInstances.kt</ID>
     <ID>MaxLineLength:EitherInstances.kt$kategory.EitherInstances.kt</ID>
     <ID>MaxLineLength:EitherTInstances.kt$kategory.EitherTInstances.kt</ID>
     <ID>MaxLineLength:FreeApplicativeInstances.kt$kategory.FreeApplicativeInstances.kt</ID>
-    <ID>MaxLineLength:FreeApplicativeInstances.kt$kategory.FreeApplicativeInstances.kt</ID>
-    <ID>MaxLineLength:FreeApplicativeInstances.kt$kategory.FreeApplicativeInstances.kt</ID>
     <ID>MaxLineLength:FreeInstances.kt$kategory.FreeInstances.kt</ID>
     <ID>MaxLineLength:IorInstances.kt$kategory.IorInstances.kt</ID>
-    <ID>MaxLineLength:IorInstances.kt$kategory.IorInstances.kt</ID>
-    <ID>MaxLineLength:KleisliInstances.kt$kategory.KleisliInstances.kt</ID>
-    <ID>MaxLineLength:KleisliInstances.kt$kategory.KleisliInstances.kt</ID>
     <ID>MaxLineLength:KleisliInstances.kt$kategory.KleisliInstances.kt</ID>
     <ID>MaxLineLength:OptionTInstances.kt$kategory.OptionTInstances.kt</ID>
     <ID>MaxLineLength:StateTInstances.kt$kategory.StateTInstances.kt</ID>
-    <ID>MaxLineLength:StateTInstances.kt$kategory.StateTInstances.kt</ID>
-    <ID>MaxLineLength:StateTInstances.kt$kategory.StateTInstances.kt</ID>
-    <ID>MaxLineLength:StateTInstances.kt$kategory.StateTInstances.kt</ID>
-    <ID>MaxLineLength:StateTInstances.kt$kategory.StateTInstances.kt</ID>
-    <ID>MaxLineLength:TryInstances.kt$kategory.TryInstances.kt</ID>
     <ID>MaxLineLength:TryInstances.kt$kategory.TryInstances.kt</ID>
     <ID>MaxLineLength:ValidatedInstances.kt$kategory.ValidatedInstances.kt</ID>
     <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:ApplicativeError.kt$kategory.ApplicativeError.kt</ID>
     <ID>MaxLineLength:ApplicativeError.kt$kategory.ApplicativeError.kt</ID>
     <ID>MaxLineLength:Foldable.kt$kategory.Foldable.kt</ID>
-    <ID>MaxLineLength:Foldable.kt$kategory.Foldable.kt</ID>
-    <ID>MaxLineLength:Foldable.kt$kategory.Foldable.kt</ID>
-    <ID>MaxLineLength:Foldable.kt$kategory.Foldable.kt</ID>
-    <ID>MaxLineLength:Foldable.kt$kategory.Foldable.kt</ID>
-    <ID>MaxLineLength:Monad.kt$kategory.Monad.kt</ID>
     <ID>MaxLineLength:Monad.kt$kategory.Monad.kt</ID>
     <ID>MaxLineLength:MonadError.kt$kategory.MonadError.kt</ID>
     <ID>MaxLineLength:MonadReader.kt$kategory.MonadReader.kt</ID>
     <ID>MaxLineLength:MonadState.kt$kategory.MonadState.kt</ID>
     <ID>MaxLineLength:Traverse.kt$kategory.Traverse.kt</ID>
     <ID>MaxLineLength:IO.kt$kategory.IO.kt</ID>
-    <ID>MaxLineLength:IO.kt$kategory.IO.kt</ID>
     <ID>MaxLineLength:IOInstances.kt$kategory.IOInstances.kt</ID>
-    <ID>MaxLineLength:Async.kt$kategory.Async.kt</ID>
-    <ID>MaxLineLength:Async.kt$kategory.Async.kt</ID>
-    <ID>MaxLineLength:Async.kt$kategory.Async.kt</ID>
     <ID>MaxLineLength:Async.kt$kategory.Async.kt</ID>
   </Whitelist>
 </SmellBaseline>


### PR DESCRIPTION
This PR adds support for passing a CoroutineContext to both `binding` and `bindInContext`, which would then execute the block in that specific Context.

I've added a law to test it, along with some helpers to run resources-bound tests.  

Closes #197