### PR TITLE
Remove `ListKW` boilerplate

### DIFF
--- a/kategory/src/main/kotlin/kategory/data/ListKW.kt
+++ b/kategory/src/main/kotlin/kategory/data/ListKW.kt
@@ -1,27 +1,8 @@
 package kategory
 
-@higherkind data class ListKW<A> constructor(val list: List<A>) : ListKWKind<A> {
-
-    fun <B> map(f: (A) -> B): ListKW<B> = ListKW(list.map(f))
-
-    fun <B> flatMap(f: (A) -> ListKW<B>): ListKW<B> = ListKW(list.flatMap { f(it).list })
-
-    operator fun plus(list: List<A>): ListKW<A> = ListKW(this.list + list)
-
-    operator fun plus(listKW: ListKW<A>): ListKW<A> = ListKW(this.list + listKW.list)
-
-    operator fun get(position: Int): Option<A> = if (list.isEmpty() || position < 0 || position > list.size) Option.None else Option.Some(list[position])
-
-    fun <B> fold(b: B, f: (B, A) -> B): B = list.fold(b, f)
-
-    fun drop(n: Int): ListKW<A> = ListKW(this.list.drop(n))
-
-    fun first(): A = this.list.first()
+@higherkind data class ListKW<A> constructor(val list: List<A>) : ListKWKind<A>, List<A> by list {
 
     companion object : ListKWInstances, GlobalInstance<Monad<ListKWHK>>() {
-
-        @JvmStatic fun <A> listOfK(vararg a: A): ListKW<A> = ListKW(a.asList())
-        @JvmStatic fun <A> listOfK(list: List<A>): ListKW<A> = ListKW(list)
 
         fun functor(): Functor<ListKWHK> = this
 
@@ -43,4 +24,4 @@ package kategory
 
 }
 
-fun <A> List<A>.k(): ListKW<A> = ListKW.listOfK(this)
+fun <A> List<A>.k(): ListKW<A> = ListKW(this)

--- a/kategory/src/main/kotlin/kategory/instances/ListKWInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/ListKWInstances.kt
@@ -6,18 +6,18 @@ interface ListKWInstances :
         Monad<ListKWHK>,
         Traverse<ListKWHK> {
 
-    override fun <A> pure(a: A): ListKW<A> = ListKW.listOfK(a)
+    override fun <A> pure(a: A): ListKW<A> = listOf(a).k()
 
-    override fun <A, B> flatMap(fa: HK<ListKWHK, A>, f: (A) -> HK<ListKWHK, B>): ListKW<B> = fa.ev().flatMap { f(it).ev() }
+    override fun <A, B> flatMap(fa: HK<ListKWHK, A>, f: (A) -> HK<ListKWHK, B>): ListKW<B> = fa.ev().list.flatMap { f(it).ev().list }.k()
 
-    override fun <A, B> map(fa: HK<ListKWHK, A>, f: (A) -> B): HK<ListKWHK, B> = fa.ev().map(f)
+    override fun <A, B> map(fa: HK<ListKWHK, A>, f: (A) -> B): ListKW<B> = fa.ev().map(f).k()
 
-    override fun <A, B, Z> map2(fa: HK<ListKWHK, A>, fb: HK<ListKWHK, B>, f: (Tuple2<A, B>) -> Z): HK<ListKWHK, Z> =
+    override fun <A, B, Z> map2(fa: HK<ListKWHK, A>, fb: HK<ListKWHK, B>, f: (Tuple2<A, B>) -> Z): ListKW<Z> =
         fa.ev().flatMap { a ->
             fb.ev().map { b ->
                 f(Tuple2(a, b))
             }
-        }
+        }.ev()
 
     override fun <A, B> foldL(fa: HK<ListKWHK, A>, b: B, f: (B, A) -> B): B = fa.ev().fold(b, f)
 
@@ -30,8 +30,8 @@ interface ListKWInstances :
     }
 
     override fun <G, A, B> traverse(fa: HK<ListKWHK, A>, f: (A) -> HK<G, B>, GA: Applicative<G>): HK<G, HK<ListKWHK, B>> =
-            foldR(fa, Eval.always { GA.pure(ListKW.listOfK<B>()) }) { a, eval ->
-                GA.map2Eval(f(a), eval) { ListKW.listOfK(it.a) + it.b }
+            foldR(fa, Eval.always { GA.pure(emptyList<B>().k()) }) { a, eval ->
+                GA.map2Eval(f(a), eval) { (listOf(it.a) + it.b).k() }
             }.value()
 
     @Suppress("UNCHECKED_CAST")
@@ -44,9 +44,9 @@ interface ListKWInstances :
             when (head) {
                 is Either.Right<A, B> -> {
                     buf += head.b
-                    go(buf, f, v.drop(1))
+                    go(buf, f, v.drop(1).k())
                 }
-                is Either.Left<A, B> -> go(buf, f, f(head.a).ev() + v.drop(1))
+                is Either.Left<A, B> -> go(buf, f, (f(head.a).ev() + v.drop(1)).k())
             }
         }
     }
@@ -54,18 +54,18 @@ interface ListKWInstances :
     override fun <A, B> tailRecM(a: A, f: (A) -> HK<ListKWHK, Either<A, B>>): ListKW<B> {
         val buf = ArrayList<B>()
         go(buf, f, f(a).ev())
-        return ListKW.listOfK(buf)
+        return ListKW(buf)
     }
 }
 
 interface ListKWMonoid<A> : Monoid<ListKW<A>> {
-    override fun combine(a: ListKW<A>, b: ListKW<A>): ListKW<A> = a + b
+    override fun combine(a: ListKW<A>, b: ListKW<A>): ListKW<A> = (a + b).k()
 
-    override fun empty(): ListKW<A> = ListKW.listOfK()
+    override fun empty(): ListKW<A> = emptyList<A>().k()
 }
 
 interface ListKWMonoidK : MonoidK<ListKWHK> {
-    override fun <A> combineK(x: HK<ListKWHK, A>, y: HK<ListKWHK, A>): ListKW<A> = x.ev() + y.ev()
+    override fun <A> combineK(x: HK<ListKWHK, A>, y: HK<ListKWHK, A>): ListKW<A> = (x.ev() + y.ev()).k()
 
-    override fun <A> empty(): HK<ListKWHK, A> = ListKW.listOfK()
+    override fun <A> empty(): ListKW<A> = emptyList<A>().k()
 }


### PR DESCRIPTION
Removes `ListKW` method delegation boilerplate using Kotlin's class delegation machinery.
This technique can be used for other datatypes in the std lib to avoid manually implementing all combinators.
`@higherkind data class ListKW<A> constructor(val list: List<A>) : ListKWKind<A>, List<A> by list { .. }`
This means that `ListKW<A>` is now a `List<A>` and inherits all public methods as well making them visible. Whenever a concrete `ListKW<A>` is required one can just invoke `list.k()` to rewrap the instance.

This technique may be used when implementing `Set` wrappers and others.