### PR TITLE
MonadWriter

### DIFF
--- a/kategory-test/src/main/kotlin/kategory/generators/Generators.kt
+++ b/kategory-test/src/main/kotlin/kategory/generators/Generators.kt
@@ -30,6 +30,11 @@ inline fun <F, A> genConstructor(valueGen: Gen<A>, crossinline cf: (A) -> HK<F, 
 fun genIntSmall(): Gen<Int> =
         Gen.oneOf(Gen.negativeIntegers(), Gen.choose(0, Int.MAX_VALUE / 10000))
 
+fun <A, B> genTuple(genA : Gen<A>, genB: Gen<B>): Gen<Tuple2<A, B>> =
+        object : Gen<Tuple2<A, B>> {
+            override fun generate(): Tuple2<A, B> = Tuple2(genA.generate(), genB.generate())
+        }
+
 fun genIntPredicate(): Gen<(Int) -> Boolean> =
         Gen.int().let { gen ->
             /* If you ever see two zeros in a row please contact the maintainers for a pat in the back */

--- a/kategory/src/main/kotlin/kategory/data/WriterT.kt
+++ b/kategory/src/main/kotlin/kategory/data/WriterT.kt
@@ -2,7 +2,7 @@ package kategory
 
 @higherkind data class WriterT<F, W, A>(val MF: Monad<F>, val value: HK<F, Tuple2<W, A>>) : WriterTKind<F, W, A> {
 
-    companion object : WriterTFunctions {
+    companion object {
         inline fun <reified F, reified W, A> pure(a: A, MM: Monoid<W> = monoid(), MF: Monad<F> = kategory.monad()) = WriterT(MF.pure(MM.empty() toT a), MF)
 
         inline fun <reified F, W, A> both(w: W, a: A, MF: Monad<F> = kategory.monad()) = WriterT(MF.pure(w toT a), MF)
@@ -34,6 +34,21 @@ package kategory
 
             override fun F0(): MonoidK<F> = MKF
         }
+
+        inline fun <reified F, W, A> putT(vf: HK<F, A>, w: W, MF: Monad<F> = kategory.monad()): WriterT<F, W, A> =
+                WriterT(MF, MF.map(vf, { v -> Tuple2(w, v) }))
+
+        inline fun <reified F, W, A> put(a: A, w: W, applicativeF: Applicative<F> = kategory.applicative()): WriterT<F, W, A> =
+                WriterT.putT(applicativeF.pure(a), w)
+
+        inline fun <reified F, W> tell(l: W, applicativeF: Applicative<F> = kategory.applicative()): WriterT<F, W, Unit> =
+                WriterT.put(Unit, l)
+
+        inline fun <reified F, reified W, A> value(v: A, applicativeF: Applicative<F> = kategory.applicative(), monoidW: Monoid<W> = monoid()): WriterT<F, W, A> =
+                WriterT.put(v, monoidW.empty())
+
+        inline fun <reified F, reified W, A> valueT(vf: HK<F, A>, functorF: Functor<F> = kategory.functor(), monoidW: Monoid<W> = monoid()): WriterT<F, W, A> =
+                WriterT.putT(vf, monoidW.empty())
     }
 
     fun tell(w: W, SG: Semigroup<W>): WriterT<F, W, A> = mapAcc { SG.combine(it, w) }
@@ -61,22 +76,4 @@ package kategory
     inline fun <C> semiflatMap(crossinline f: (A) -> HK<F, C>, SG: Semigroup<W>): WriterT<F, W, C> = flatMap({ liftF(f(it)) }, SG)
 
     inline fun <B> subflatMap(crossinline f: (A) -> Tuple2<W, B>): WriterT<F, W, B> = transform({ f(it.b) })
-}
-
-object WriterTFunctions {
-
-    inline fun <reified F, W, A> putT(vf: HK<F, A>, w: W, MF: Monad<F> = monad()): WriterT<F, W, A> =
-            WriterT(MF, MF.map(vf, { v -> Tuple2(w, v) }))
-
-    inline fun <reified F, W, A> put(a: A, w: W, applicativeF: Applicative<F> = applicative()): WriterT<F, W, A> =
-            WriterT.putT(applicativeF.pure(a), w)
-
-    inline fun <reified F, W> tell(l: W, applicativeF: Applicative<F> = applicative()): WriterT<F, W, Unit> =
-            WriterT.put(Unit, l)
-
-    inline fun <reified F, reified W, A> value(v: A, applicativeF: Applicative<F> = applicative(), monoidW: Monoid<W> = monoid()): WriterT<F, W, A> =
-            WriterT.put(v, monoidW.empty())
-
-    inline fun <reified F, reified W, A> valueT(vf: HK<F, A>, functorF: Functor<F> = functor(), monoidW: Monoid<W> = monoid()): WriterT<F, W, A> =
-            WriterT.putT(vf, monoidW.empty())
 }

--- a/kategory/src/main/kotlin/kategory/data/WriterT.kt
+++ b/kategory/src/main/kotlin/kategory/data/WriterT.kt
@@ -48,20 +48,15 @@ package kategory
 
         inline fun <reified F, reified W> monadWriter(MM: Monad<F> = kategory.monad(), SG: Monoid<W> = kategory.monoid()): MonadWriter<WriterTKindPartial<F, W>, W> = instances(MM, SG)
 
-        inline fun <reified F, W, A> putT(vf: HK<F, A>, w: W, MF: Monad<F> = kategory.monad()): WriterT<F, W, A> =
-                WriterT(MF, MF.map(vf, { v -> Tuple2(w, v) }))
+        inline fun <reified F, W, A> putT(vf: HK<F, A>, w: W, MF: Monad<F> = kategory.monad()): WriterT<F, W, A> = WriterT(MF, MF.map(vf, { v -> Tuple2(w, v) }))
 
-        inline fun <reified F, W, A> put(a: A, w: W, applicativeF: Applicative<F> = kategory.applicative()): WriterT<F, W, A> =
-                WriterT.putT(applicativeF.pure(a), w)
+        inline fun <reified F, W, A> put(a: A, w: W, applicativeF: Applicative<F> = kategory.applicative()): WriterT<F, W, A> = WriterT.putT(applicativeF.pure(a), w)
 
-        inline fun <reified F, W> tell(l: W, applicativeF: Applicative<F> = kategory.applicative()): WriterT<F, W, Unit> =
-                WriterT.put(Unit, l)
+        inline fun <reified F, W> tell(l: W, applicativeF: Applicative<F> = kategory.applicative()): WriterT<F, W, Unit> = WriterT.put(Unit, l)
 
-        inline fun <reified F, reified W, A> value(v: A, applicativeF: Applicative<F> = kategory.applicative(), monoidW: Monoid<W> = monoid()): WriterT<F, W, A> =
-                WriterT.put(v, monoidW.empty())
+        inline fun <reified F, reified W, A> value(v: A, applicativeF: Applicative<F> = kategory.applicative(), monoidW: Monoid<W> = monoid()): WriterT<F, W, A> = WriterT.put(v, monoidW.empty())
 
-        inline fun <reified F, reified W, A> valueT(vf: HK<F, A>, functorF: Functor<F> = kategory.functor(), monoidW: Monoid<W> = monoid()): WriterT<F, W, A> =
-                WriterT.putT(vf, monoidW.empty())
+        inline fun <reified F, reified W, A> valueT(vf: HK<F, A>, functorF: Functor<F> = kategory.functor(), monoidW: Monoid<W> = monoid()): WriterT<F, W, A> = WriterT.putT(vf, monoidW.empty())
     }
 
     fun tell(w: W, SG: Semigroup<W>): WriterT<F, W, A> = mapAcc { SG.combine(it, w) }

--- a/kategory/src/main/kotlin/kategory/data/WriterT.kt
+++ b/kategory/src/main/kotlin/kategory/data/WriterT.kt
@@ -11,7 +11,18 @@ package kategory
 
         inline operator fun <reified F, W, A> invoke(value: HK<F, Tuple2<W, A>>, MF: Monad<F> = kategory.monad()) = WriterT(MF, value)
 
-        inline fun <reified F, reified W> instances(MM: Monad<F> = kategory.monad<F>(), SG: Monoid<W> = kategory.monoid<W>()): WriterTInstances<F, W> = object : WriterTInstances<F, W> {
+        inline fun <reified F, reified W> instances(MM: Monad<F> = kategory.monad(), SG: Monoid<W> = kategory.monoid<W>()): WriterTInstances<F, W> = object : WriterTInstances<F, W> {
+
+            override fun <A> writer(aw: Tuple2<W, A>): WriterT<F, W, A> = WriterT.put(aw.b, aw.a)
+
+            override fun <A> listen(fa: HK<WriterTKindPartial<F, W>, A>): HK<WriterTKindPartial<F, W>, Tuple2<W, A>> =
+                    WriterT(MM, MM.flatMap(fa.ev().content(), { a -> MM.map(fa.ev().write(), { l -> Tuple2(l, Tuple2(l, a)) }) }))
+
+            override fun <A> pass(fa: HK<WriterTKindPartial<F, W>, Tuple2<(W) -> W, A>>): HK<WriterTKindPartial<F, W>, A> =
+                    WriterT(MM, MM.flatMap(fa.ev().content(), { tuple2FA -> MM.map(fa.ev().write(), { l -> Tuple2(tuple2FA.a(l), tuple2FA.b) }) }))
+
+            override fun tell(w: W): HK<WriterTKindPartial<F, W>, Unit> = WriterT.tell(w)
+
             override fun MM(): Monad<F> = MM
 
             override fun SG(): Monoid<W> = SG
@@ -34,6 +45,8 @@ package kategory
 
             override fun F0(): MonoidK<F> = MKF
         }
+
+        inline fun <reified F, reified W> monadWriter(MM: Monad<F> = kategory.monad(), SG: Monoid<W> = kategory.monoid()): MonadWriter<WriterTKindPartial<F, W>, W> = instances(MM, SG)
 
         inline fun <reified F, W, A> putT(vf: HK<F, A>, w: W, MF: Monad<F> = kategory.monad()): WriterT<F, W, A> =
                 WriterT(MF, MF.map(vf, { v -> Tuple2(w, v) }))

--- a/kategory/src/main/kotlin/kategory/instances/WriterTInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/WriterTInstances.kt
@@ -27,6 +27,21 @@ interface WriterTInstances<F, W> :
 
 }
 
+interface WriterTMonadWriter<F, W> : MonadWriter<WriterTKindPartial<F, W>, W> {
+
+    fun MF(): Monad<F>
+
+    override fun <A> writer(aw: Tuple2<W, A>): WriterT<F, W, A> = WriterT.put(aw.b, aw.a)
+
+    override fun <A> listen(fa: HK<WriterTKindPartial<F, W>, A>): HK<WriterTKindPartial<F, W>, Tuple2<W, A>> =
+            WriterT(MF(), MF().flatMap(fa.ev().content(), { a -> MF().map(fa.ev().write(), { l -> Tuple2(l, Tuple2(l, a)) }) }))
+
+    override fun <A> pass(fa: HK<WriterTKindPartial<F, W>, Tuple2<(W) -> W, A>>): HK<WriterTKindPartial<F, W>, A> =
+            WriterT(MF(), MF().flatMap(fa.ev().content(), { tuple2FA -> MF().map(fa.ev().write(), { l -> Tuple2(tuple2FA.a(l), tuple2FA.b) }) }))
+
+    override fun tell(w: W): HK<WriterTKindPartial<F, W>, Unit> = WriterT.tell(w)
+}
+
 interface WriterTSemigroupK<F, W> : SemigroupK<WriterTKindPartial<F, W>> {
 
     fun MF(): Monad<F>

--- a/kategory/src/main/kotlin/kategory/instances/WriterTInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/WriterTInstances.kt
@@ -3,7 +3,8 @@ package kategory
 interface WriterTInstances<F, W> :
         Functor<WriterTKindPartial<F, W>>,
         Applicative<WriterTKindPartial<F, W>>,
-        Monad<WriterTKindPartial<F, W>>, WriterTMonadWriter<F, W> {
+        Monad<WriterTKindPartial<F, W>>,
+        MonadWriter<WriterTKindPartial<F, W>, W> {
 
     fun MM(): Monad<F>
 
@@ -26,8 +27,6 @@ interface WriterTInstances<F, W> :
             }))
 
 }
-
-interface WriterTMonadWriter<F, W> : MonadWriter<WriterTKindPartial<F, W>, W>
 
 interface WriterTSemigroupK<F, W> : SemigroupK<WriterTKindPartial<F, W>> {
 

--- a/kategory/src/main/kotlin/kategory/instances/WriterTInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/WriterTInstances.kt
@@ -3,7 +3,7 @@ package kategory
 interface WriterTInstances<F, W> :
         Functor<WriterTKindPartial<F, W>>,
         Applicative<WriterTKindPartial<F, W>>,
-        Monad<WriterTKindPartial<F, W>> {
+        Monad<WriterTKindPartial<F, W>>, WriterTMonadWriter<F, W> {
 
     fun MM(): Monad<F>
 
@@ -27,21 +27,7 @@ interface WriterTInstances<F, W> :
 
 }
 
-abstract class WriterTMonadWriter<F, W> : MonadWriter<WriterTKindPartial<F, W>, W> {
-
-    companion object {
-
-        inline fun <reified F, W, A> writer(aw: Tuple2<W, A>): WriterT<F, W, A> = WriterT.put(aw.b, aw.a)
-
-        inline fun <reified F, W, A> listen(fa: HK<WriterTKindPartial<F, W>, A>, MF: Monad<F> = monad()): HK<WriterTKindPartial<F, W>, Tuple2<W, A>> =
-                WriterT(MF, MF.flatMap(fa.ev().content(), { a -> MF.map(fa.ev().write(), { l -> Tuple2(l, Tuple2(l, a)) }) }))
-
-        inline fun <reified F, W, A> pass(fa: HK<WriterTKindPartial<F, W>, Tuple2<(W) -> W, A>>, MF: Monad<F> = monad()): HK<WriterTKindPartial<F, W>, A> =
-                WriterT(MF, MF.flatMap(fa.ev().content(), { tuple2FA -> MF.map(fa.ev().write(), { l -> Tuple2(tuple2FA.a(l), tuple2FA.b) }) }))
-
-        inline fun <reified F, W> tell(w: W): HK<WriterTKindPartial<F, W>, Unit> = WriterT.tell(w)
-    }
-}
+interface WriterTMonadWriter<F, W> : MonadWriter<WriterTKindPartial<F, W>, W>
 
 interface WriterTSemigroupK<F, W> : SemigroupK<WriterTKindPartial<F, W>> {
 

--- a/kategory/src/main/kotlin/kategory/instances/WriterTInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/WriterTInstances.kt
@@ -39,7 +39,7 @@ abstract class WriterTMonadWriter<F, W> : MonadWriter<WriterTKindPartial<F, W>, 
         inline fun <reified F, W, A> pass(fa: HK<WriterTKindPartial<F, W>, Tuple2<(W) -> W, A>>, MF: Monad<F> = monad()): HK<WriterTKindPartial<F, W>, A> =
                 WriterT(MF, MF.flatMap(fa.ev().content(), { tuple2FA -> MF.map(fa.ev().write(), { l -> Tuple2(tuple2FA.a(l), tuple2FA.b) }) }))
 
-        inline fun <reified F, W, A> tell(w: W): HK<WriterTKindPartial<F, W>, Unit> = WriterT.tell(w)
+        inline fun <reified F, W> tell(w: W): HK<WriterTKindPartial<F, W>, Unit> = WriterT.tell(w)
     }
 }
 

--- a/kategory/src/main/kotlin/kategory/instances/WriterTInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/WriterTInstances.kt
@@ -27,19 +27,20 @@ interface WriterTInstances<F, W> :
 
 }
 
-interface WriterTMonadWriter<F, W> : MonadWriter<WriterTKindPartial<F, W>, W> {
+abstract class WriterTMonadWriter<F, W> : MonadWriter<WriterTKindPartial<F, W>, W> {
 
-    fun MF(): Monad<F>
+    companion object {
 
-    override fun <A> writer(aw: Tuple2<W, A>): WriterT<F, W, A> = WriterT.put(aw.b, aw.a)
+        inline fun <reified F, W, A> writer(aw: Tuple2<W, A>): WriterT<F, W, A> = WriterT.put(aw.b, aw.a)
 
-    override fun <A> listen(fa: HK<WriterTKindPartial<F, W>, A>): HK<WriterTKindPartial<F, W>, Tuple2<W, A>> =
-            WriterT(MF(), MF().flatMap(fa.ev().content(), { a -> MF().map(fa.ev().write(), { l -> Tuple2(l, Tuple2(l, a)) }) }))
+        inline fun <reified F, W, A> listen(fa: HK<WriterTKindPartial<F, W>, A>, MF: Monad<F> = monad()): HK<WriterTKindPartial<F, W>, Tuple2<W, A>> =
+                WriterT(MF, MF.flatMap(fa.ev().content(), { a -> MF.map(fa.ev().write(), { l -> Tuple2(l, Tuple2(l, a)) }) }))
 
-    override fun <A> pass(fa: HK<WriterTKindPartial<F, W>, Tuple2<(W) -> W, A>>): HK<WriterTKindPartial<F, W>, A> =
-            WriterT(MF(), MF().flatMap(fa.ev().content(), { tuple2FA -> MF().map(fa.ev().write(), { l -> Tuple2(tuple2FA.a(l), tuple2FA.b) }) }))
+        inline fun <reified F, W, A> pass(fa: HK<WriterTKindPartial<F, W>, Tuple2<(W) -> W, A>>, MF: Monad<F> = monad()): HK<WriterTKindPartial<F, W>, A> =
+                WriterT(MF, MF.flatMap(fa.ev().content(), { tuple2FA -> MF.map(fa.ev().write(), { l -> Tuple2(tuple2FA.a(l), tuple2FA.b) }) }))
 
-    override fun tell(w: W): HK<WriterTKindPartial<F, W>, Unit> = WriterT.tell(w)
+        inline fun <reified F, W, A> tell(w: W): HK<WriterTKindPartial<F, W>, Unit> = WriterT.tell(w)
+    }
 }
 
 interface WriterTSemigroupK<F, W> : SemigroupK<WriterTKindPartial<F, W>> {

--- a/kategory/src/main/kotlin/kategory/typeclasses/MonadWriter.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/MonadWriter.kt
@@ -1,0 +1,32 @@
+package kategory
+
+interface MonadWriter<F, W> : Monad<F> {
+
+    /** Lift a writer action into the effect */
+    fun <A> writer(aw: Tuple2<W, A>): HK<F, A>
+
+    /** Run the effect and pair the accumulator with the result */
+    fun <A> listen(fa: HK<F, A>): HK<F, Tuple2<W, A>>
+
+    /** Apply the effectful function to the accumulator */
+    fun <A> pass(fa: HK<F, Tuple2<(W) -> W, A>>): HK<F, A>
+
+    /** Lift the log into the effect */
+    fun tell(w: W): HK<F, Unit> = writer(Tuple2(w, Unit))
+
+    /** Pair the value with an inspection of the accumulator */
+    fun <A, B> listens(fa: HK<F, A>, f: (W) -> B): HK<F, Tuple2<B, A>> =
+            map(listen(fa)) { Tuple2(f(it.a), it.b) }
+
+    /** Modify the accumulator */
+    fun <A> censor(fa: HK<F, A>, f: (W) -> W): HK<F, A> =
+            flatMap(listen(fa)) { writer(Tuple2(f(it.a), it.b)) }
+
+    companion object {
+
+        inline fun <reified F, reified W> invoke(MWF: MonadWriter<F, W> = monadWriter<F, W>()) = MWF
+    }
+}
+
+inline fun <reified F, reified W> monadWriter(): MonadWriter<F, W> =
+        instance(InstanceParametrizedType(MonadWriter::class.java, listOf(F::class.java, W::class.java)))

--- a/kategory/src/main/kotlin/kategory/typeclasses/MonadWriter.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/MonadWriter.kt
@@ -1,5 +1,6 @@
 package kategory
 
+/** A monad that support monoidal accumulation (e.g. logging List<String>) */
 interface MonadWriter<F, W> : Monad<F> {
 
     /** Lift a writer action into the effect */

--- a/kategory/src/main/kotlin/kategory/typeclasses/MonadWriter.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/MonadWriter.kt
@@ -16,18 +16,16 @@ interface MonadWriter<F, W> : Monad<F> {
     fun tell(w: W): HK<F, Unit> = writer(Tuple2(w, Unit))
 
     /** Pair the value with an inspection of the accumulator */
-    fun <A, B> listens(fa: HK<F, A>, f: (W) -> B): HK<F, Tuple2<B, A>> =
-            map(listen(fa)) { Tuple2(f(it.a), it.b) }
+    fun <A, B> listens(fa: HK<F, A>, f: (W) -> B): HK<F, Tuple2<B, A>> = map(listen(fa)) { Tuple2(f(it.a), it.b) }
 
     /** Modify the accumulator */
-    fun <A> censor(fa: HK<F, A>, f: (W) -> W): HK<F, A> =
-            flatMap(listen(fa)) { writer(Tuple2(f(it.a), it.b)) }
+    fun <A> censor(fa: HK<F, A>, f: (W) -> W): HK<F, A> = flatMap(listen(fa)) { writer(Tuple2(f(it.a), it.b)) }
 
     companion object {
 
-        inline fun <reified F, reified W> invoke(MWF: MonadWriter<F, W> = monadWriter<F, W>()) = MWF
+        inline fun <reified F, reified W> invoke(MWF: MonadWriter<F, W> = monadWriter()) = MWF
     }
 }
 
-inline fun <reified F, reified W> monadWriter(): MonadWriter<F, W> =
-        instance(InstanceParametrizedType(MonadWriter::class.java, listOf(F::class.java, W::class.java)))
+inline fun <reified F, reified W> monadWriter(): MonadWriter<F, W> = instance(
+        InstanceParametrizedType(MonadWriter::class.java, listOf(F::class.java, W::class.java)))

--- a/kategory/src/test/kotlin/kategory/data/WriterTTest.kt
+++ b/kategory/src/test/kotlin/kategory/data/WriterTTest.kt
@@ -2,6 +2,7 @@ package kategory
 
 import io.kotlintest.KTestJUnitRunner
 import io.kotlintest.matchers.shouldBe
+import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
 import org.junit.runner.RunWith
 
@@ -16,6 +17,17 @@ class WriterTTest : UnitSpec() {
                 WriterT.invoke(Option(Tuple2(1, 2)), Option.monad()),
                 Eq.any(),
                 Eq.any()))
+
+        testLaws(MonadWriterLaws.laws(WriterT.monad(Option, IntMonoid),
+                WriterT.monadWriter(Option, IntMonoid),
+                IntMonoid,
+                Gen.string(),
+                genIntSmall(),
+                genTuple(genIntSmall(), Gen.string()),
+                Eq.any(),
+                Eq.any(),
+                Eq.any()
+        ))
 
         "tell should accumulate write" {
             forAll { a: Int ->

--- a/kategory/src/test/kotlin/kategory/laws/MonadWriterLaws.kt
+++ b/kategory/src/test/kotlin/kategory/laws/MonadWriterLaws.kt
@@ -1,0 +1,38 @@
+package kategory
+
+import io.kotlintest.properties.Gen
+import io.kotlintest.properties.forAll
+
+object MonadWriterLaws {
+
+    inline fun <reified F, reified W, A> laws(MF: Monad<F>,
+                                              MW: MonadWriter<F, W>,
+                                              MOW: Monoid<W> = monoid<W>(),
+                                              genA: Gen<A>,
+                                              genW: Gen<W>,
+                                              EqA: Eq<HK<F, A>>,
+                                              EqInt: Eq<HK<F, Int>>,
+                                              EqUnit: Eq<HK<F, Unit>>): List<Law> =
+
+            MonadLaws.laws(MF, EqInt) + listOf(
+                    Law("Monad Writer Laws: writer pure", { monadWriterWriterPure(genA, MW, MOW, EqA) }),
+                    Law("Monad Writer Laws: tell fusion", { monadWriterTellFusion(genW, MW, MOW, EqUnit)}))
+
+    inline fun <reified F, reified W, A> monadWriterWriterPure(genA: Gen<A>,
+                                                               MW: MonadWriter<F, W>,
+                                                               MOW: Monoid<W> = monoid<W>(),
+                                                               EQ: Eq<HK<F, A>>): Unit {
+        forAll(genA, { a: A ->
+            MW.writer(Tuple2(MOW.empty(), a)).equalUnderTheLaw(MW.pure(a), EQ)
+        })
+    }
+
+    inline fun <reified F, reified W> monadWriterTellFusion(genW: Gen<W>,
+                                                               MW: MonadWriter<F, W>,
+                                                               MOW: Monoid<W> = monoid<W>(),
+                                                               EQ: Eq<HK<F, Unit>>): Unit {
+        forAll(genW, genW, { x: W, y: W ->
+            MW.flatMap(MW.tell(x), { MW.tell(y) }).equalUnderTheLaw(MOW.combine(x, y), EQ)
+        })
+    }
+}

--- a/kategory/src/test/kotlin/kategory/laws/MonadWriterLaws.kt
+++ b/kategory/src/test/kotlin/kategory/laws/MonadWriterLaws.kt
@@ -34,7 +34,7 @@ object MonadWriterLaws {
                                                             MW: MonadWriter<F, W>,
                                                             MOW: Monoid<W> = monoid<W>()): Unit {
         forAll(genW, genW, { x: W, y: W ->
-            MW.flatMap(MW.tell(x), { MW.tell(y) }).equalUnderTheLaw(MOW.combine(x, y), Eq.any())
+            MW.flatMap(MW.tell(x), { MW.tell(y) }).equalUnderTheLaw(MW.tell(MOW.combine(x, y)), Eq.any())
         })
     }
 


### PR DESCRIPTION
Fixes #163

**Disclaimer:** `MonadWriter` was moved to `FunctorListen` inside `cats-mtl` module. The reason to keep implementing `MonadWriter` here is that I think we should definitely keep "old" constructs (the one valids until cats `pre-1.0.0`) for the time being, until we have a first release. I would iterate towards `kategory-mtl` module with the same renaming / refactor iterations applied to cats probably after release, to avoid more noise.