### PR TITLE
Disable ExpressionBodySyntaxLineBreaks and fix maxline errors

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -84,8 +84,8 @@ formatting:
     active: true
     autoCorrect: true
   ExpressionBodySyntaxLineBreaks:
-      active: true
-      autoCorrect: true
+      active: false
+      autoCorrect: false
 
 style:
   active: true

--- a/kategory-effects/src/main/kotlin/kategory/effects/data/IO.kt
+++ b/kategory-effects/src/main/kotlin/kategory/effects/data/IO.kt
@@ -149,7 +149,8 @@ internal data class Suspend<out A>(val cont: AndThen<Unit, IO<A>>) : IO<A>() {
 internal data class BindSuspend<E, out A>(val cont: AndThen<Unit, IO<E>>, val f: AndThen<E, IO<A>>) : IO<A>() {
     override fun <B> map(f: (A) -> B): IO<B> = mapDefault(this, f)
 
-    override fun <B> flatMapTotal(ff: AndThen<A, IO<B>>): IO<B> = BindSuspend(cont, f.andThen(AndThen({ it.flatMapTotal(ff) }, { ff.error(it, { RaiseError(it) }) })))
+    override fun <B> flatMapTotal(ff: AndThen<A, IO<B>>): IO<B> =
+            BindSuspend(cont, f.andThen(AndThen({ it.flatMapTotal(ff) }, { ff.error(it, { RaiseError(it) }) })))
 
     override fun attempt(): IO<Either<Throwable, A>> = BindSuspend(AndThen { _ -> this }, attemptValue())
 
@@ -173,7 +174,8 @@ internal data class Async<out A>(val cont: ((Either<Throwable, A>) -> Unit) -> U
 internal data class BindAsync<E, out A>(val cont: ((Either<Throwable, E>) -> Unit) -> Unit, val f: AndThen<E, IO<A>>) : IO<A>() {
     override fun <B> map(f: (A) -> B): IO<B> = mapDefault(this, f)
 
-    override fun <B> flatMapTotal(ff: AndThen<A, IO<B>>): IO<B> = BindAsync(cont, f.andThen(AndThen({ it.flatMapTotal(ff) }, { ff.error(it, { RaiseError(it) }) })))
+    override fun <B> flatMapTotal(ff: AndThen<A, IO<B>>): IO<B> =
+            BindAsync(cont, f.andThen(AndThen({ it.flatMapTotal(ff) }, { ff.error(it, { RaiseError(it) }) })))
 
     override fun attempt(): IO<Either<Throwable, A>> = BindSuspend(AndThen { _ -> this }, attemptValue())
 

--- a/kategory-effects/src/main/kotlin/kategory/effects/instances/IOInstances.kt
+++ b/kategory-effects/src/main/kotlin/kategory/effects/instances/IOInstances.kt
@@ -15,7 +15,8 @@ interface IOInstances :
 
     override fun <A> raiseError(e: Throwable): IO<A> = RaiseError(e)
 
-    override fun <A> handleErrorWith(fa: HK<IOHK, A>, f: (Throwable) -> HK<IOHK, A>): HK<IOHK, A> = fa.ev().attempt().flatMap { it.fold(f, { IO.pure(it) }).ev() }
+    override fun <A> handleErrorWith(fa: HK<IOHK, A>, f: (Throwable) -> HK<IOHK, A>): HK<IOHK, A> =
+            fa.ev().attempt().flatMap { it.fold(f, { IO.pure(it) }).ev() }
 
     override fun <A> runAsync(fa: Proc<A>): IO<A> = IO.async(fa)
 

--- a/kategory-effects/src/main/kotlin/kategory/effects/typeclass/Async.kt
+++ b/kategory-effects/src/main/kotlin/kategory/effects/typeclass/Async.kt
@@ -23,17 +23,24 @@ inline fun <F, A> runAsync(AC: AsyncContext<F>, crossinline f: () -> A): HK<F, A
 
 suspend inline fun <reified F, A> (() -> A).runAsync(AC: AsyncContext<F> = asyncContext()): HK<F, A> = runAsync(AC, this)
 
-suspend inline fun <reified F, A, B> MonadContinuation<F, A>.bindAsync(AC: AsyncContext<F> = asyncContext(), crossinline f: () -> B): B = runAsync(AC, f).bind()
+suspend inline fun <reified F, A, B> MonadContinuation<F, A>.bindAsync(AC: AsyncContext<F> = asyncContext(), crossinline f: () -> B): B =
+        runAsync(AC, f).bind()
 
-suspend inline fun <reified F, A, B> StackSafeMonadContinuation<F, A>.bindAsync(AC: AsyncContext<F> = asyncContext(), crossinline f: () -> B): B = runAsync(AC, f).bind()
+suspend inline fun <reified F, A, B> StackSafeMonadContinuation<F, A>.bindAsync(AC: AsyncContext<F> = asyncContext(), crossinline f: () -> B): B =
+        runAsync(AC, f).bind()
 
-inline fun <F, A> runAsyncUnsafe(AC: AsyncContext<F>, crossinline f: () -> Either<Throwable, A>): HK<F, A> = AC.runAsync { ff: (Either<Throwable, A>) -> Unit -> ff(f()) }
+inline fun <F, A> runAsyncUnsafe(AC: AsyncContext<F>, crossinline f: () -> Either<Throwable, A>): HK<F, A> =
+        AC.runAsync { ff: (Either<Throwable, A>) -> Unit -> ff(f()) }
 
-suspend inline fun <reified F, A> (() -> Either<Throwable, A>).runAsyncUnsafe(AC: AsyncContext<F> = asyncContext()): HK<F, A> = runAsyncUnsafe(AC, this)
+suspend inline fun <reified F, A> (() -> Either<Throwable, A>).runAsyncUnsafe(AC: AsyncContext<F> = asyncContext()): HK<F, A> =
+        runAsyncUnsafe(AC, this)
 
-suspend inline fun <reified F, A, B> MonadContinuation<F, A>.bindAsyncUnsafe(AC: AsyncContext<F> = asyncContext(), crossinline f: () -> Either<Throwable, B>): B = runAsyncUnsafe(AC, f).bind()
+suspend inline fun <reified F, A, B> MonadContinuation<F, A>.bindAsyncUnsafe(AC: AsyncContext<F> = asyncContext(), crossinline f: () -> Either<Throwable, B>):
+        B = runAsyncUnsafe(AC, f).bind()
 
-suspend inline fun <reified F, A, B> StackSafeMonadContinuation<F, A>.bindAsyncUnsafe(AC: AsyncContext<F> = asyncContext(), crossinline f: () -> Either<Throwable, B>): B = runAsyncUnsafe(AC, f).bind()
+suspend inline fun <reified F, A, B> StackSafeMonadContinuation<F, A>.bindAsyncUnsafe(AC: AsyncContext<F> = asyncContext(),
+                                                                                      crossinline f: () -> Either<Throwable, B>): B =
+        runAsyncUnsafe(AC, f).bind()
 
 open class AsyncMonadContinuation<F, A>(M: Monad<F>, val AC: AsyncContext<F>) : MonadContinuation<F, A>(M) {
 

--- a/kategory/src/main/kotlin/kategory/arrow/Kleisli.kt
+++ b/kategory/src/main/kotlin/kategory/arrow/Kleisli.kt
@@ -3,7 +3,8 @@ package kategory
 typealias KleisliFun<F, D, A> = (D) -> HK<F, A>
 typealias ReaderT<F, D, A> = Kleisli<F, D, A>
 
-@higherkind class Kleisli<F, D, A>(val MF: Monad<F>, val run: KleisliFun<F, D, A>) : KleisliKind<F, D, A> {
+@higherkind
+class Kleisli<F, D, A>(val MF: Monad<F>, val run: KleisliFun<F, D, A>) : KleisliKind<F, D, A> {
 
     fun <B> map(f: (A) -> B): Kleisli<F, D, B> = Kleisli(MF, { a -> MF.map(run(a), f) })
 
@@ -33,21 +34,22 @@ typealias ReaderT<F, D, A> = Kleisli<F, D, A>
 
         @JvmStatic inline fun <reified F, D> ask(MF: Monad<F> = monad<F>()): Kleisli<F, D, D> = Kleisli(MF, { MF.pure(it) })
 
-        fun <F, D> instances(MF : Monad<F>): KleisliInstances<F, D> = object : KleisliInstances<F, D> {
+        fun <F, D> instances(MF: Monad<F>): KleisliInstances<F, D> = object : KleisliInstances<F, D> {
             override fun MF(): Monad<F> = MF
         }
 
-        inline fun <reified F, D> functor(MF : Monad<F> = monad<F>()): Functor<KleisliKindPartial<F, D>> = instances(MF)
+        inline fun <reified F, D> functor(MF: Monad<F> = monad<F>()): Functor<KleisliKindPartial<F, D>> = instances(MF)
 
-        inline fun <reified F, D> applicative(MF : Monad<F> = monad<F>()): Applicative<KleisliKindPartial<F, D>> = instances(MF)
+        inline fun <reified F, D> applicative(MF: Monad<F> = monad<F>()): Applicative<KleisliKindPartial<F, D>> = instances(MF)
 
-        inline fun <reified F, D> monad(MF : Monad<F> = monad<F>()): Monad<KleisliKindPartial<F, D>> = instances(MF)
+        inline fun <reified F, D> monad(MF: Monad<F> = monad<F>()): Monad<KleisliKindPartial<F, D>> = instances(MF)
 
-        inline fun <reified F, D, reified E> monadError(MFE : MonadError<F, E> = monadError<F, E>()): MonadError<KleisliKindPartial<F, D>, E> = object : KleisliMonadError<F, D, E> {
-            override fun MF(): Monad<F> = MFE
+        inline fun <reified F, D, reified E> monadError(MFE: MonadError<F, E> = monadError<F, E>()): MonadError<KleisliKindPartial<F, D>, E> =
+                object : KleisliMonadError<F, D, E> {
+                    override fun MF(): Monad<F> = MFE
 
-            override fun MFE(): MonadError<F, E> = MFE
-        }
+                    override fun MFE(): MonadError<F, E> = MFE
+                }
     }
 
 }

--- a/kategory/src/main/kotlin/kategory/data/Composed.kt
+++ b/kategory/src/main/kotlin/kategory/data/Composed.kt
@@ -16,12 +16,14 @@ data class ComposedFoldable<in F, in G>(val FF: Foldable<F>, val GF: Foldable<G>
 
     fun <A, B> foldLC(fa: HK<F, HK<G, A>>, b: B, f: (B, A) -> B): B = foldL(fa.lift(), b, f)
 
-    override fun <A, B> foldR(fa: HK<ComposedType<F, G>, A>, lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> = FF.foldR(fa.lower(), lb, { laa, lbb -> GF.foldR(laa, lbb, f) })
+    override fun <A, B> foldR(fa: HK<ComposedType<F, G>, A>, lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> =
+            FF.foldR(fa.lower(), lb, { laa, lbb -> GF.foldR(laa, lbb, f) })
 
     fun <A, B> foldRC(fa: HK<F, HK<G, A>>, lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> = foldR(fa.lift(), lb, f)
 
     companion object {
-        inline operator fun <reified F, reified G> invoke(FF: Foldable<F> = foldable<F>(), GF: Foldable<G> = foldable<G>()): ComposedFoldable<F, G> = ComposedFoldable(FF, GF)
+        inline operator fun <reified F, reified G> invoke(FF: Foldable<F> = foldable<F>(), GF: Foldable<G> = foldable<G>()): ComposedFoldable<F, G> =
+                ComposedFoldable(FF, GF)
     }
 }
 
@@ -30,18 +32,23 @@ inline fun <F, reified G> Foldable<F>.compose(GT: Foldable<G> = foldable<G>()): 
 data class ComposedTraverse<F, G>(val FT: Traverse<F>, val GT: Traverse<G>, val GA: Applicative<G>, val CF: ComposedFoldable<F, G> = ComposedFoldable(FT, GT))
     : Traverse<ComposedType<F, G>>, Foldable<ComposedType<F, G>> by CF {
 
-    override fun <H, A, B> traverse(fa: HK<ComposedType<F, G>, A>, f: (A) -> HK<H, B>, HA: Applicative<H>): HK<H, HK<ComposedType<F, G>, B>> = HA.map(FT.traverse(fa.lower(), { ga -> GT.traverse(ga, f, HA) }, HA), { it.lift() })
+    override fun <H, A, B> traverse(fa: HK<ComposedType<F, G>, A>, f: (A) -> HK<H, B>, HA: Applicative<H>): HK<H, HK<ComposedType<F, G>, B>> =
+            HA.map(FT.traverse(fa.lower(), { ga -> GT.traverse(ga, f, HA) }, HA), { it.lift() })
 
     fun <H, A, B> traverseC(fa: HK<F, HK<G, A>>, f: (A) -> HK<H, B>, HA: Applicative<H>): HK<H, HK<ComposedType<F, G>, B>> = traverse(fa.lift(), f, HA)
 
     companion object {
-        inline operator fun <reified F, reified G> invoke(FF: Traverse<F> = traverse<F>(), GF: Traverse<G> = traverse<G>(), GA: Applicative<G> = applicative<G>()): ComposedTraverse<F, G> = ComposedTraverse(FF, GF, GA)
+        inline operator fun <reified F, reified G> invoke(FF: Traverse<F> = traverse<F>(),
+                                                          GF: Traverse<G> = traverse<G>(),
+                                                          GA: Applicative<G> = applicative<G>()): ComposedTraverse<F, G> = ComposedTraverse(FF, GF, GA)
     }
 }
 
-inline fun <F, reified G> Traverse<F>.compose(GT: Traverse<G> = traverse<G>(), GA: Applicative<G> = applicative<G>()): Traverse<ComposedType<F, G>> = ComposedTraverse(this, GT, GA)
+inline fun <F, reified G> Traverse<F>.compose(GT: Traverse<G> = traverse<G>(), GA: Applicative<G> = applicative<G>()): Traverse<ComposedType<F, G>> =
+        ComposedTraverse(this, GT, GA)
 
-data class ComposedReducible<F, G>(val RF: Reducible<F>, val RG: Reducible<G>, val FT: Traverse<F>, val GT: Traverse<G>, val CF: ComposedFoldable<F, G> = ComposedFoldable(FT, GT))
+data class ComposedReducible<F, G>(val RF: Reducible<F>, val RG: Reducible<G>, val FT: Traverse<F>, val GT: Traverse<G>, val CF: ComposedFoldable<F, G> =
+ComposedFoldable(FT, GT))
     : Reducible<ComposedType<F, G>>, Foldable<ComposedType<F, G>> by CF {
 
     override fun <A, B> reduceLeftTo(fa: HK<ComposedType<F, G>, A>, f: (A) -> B, g: (B, A) -> B): B =
@@ -55,8 +62,10 @@ data class ComposedReducible<F, G>(val RF: Reducible<F>, val RG: Reducible<G>, v
             }
 }
 
-inline fun <reified F, reified G> Reducible<F>.compose(RG: Reducible<G> = reducible<G>(), FT: Traverse<F> = traverse<F>(), GT: Traverse<G> = traverse<G>(), GA: Applicative<G> = applicative<G>())
-        : Reducible<ComposedType<F, G>> = ComposedReducible(this, RG, FT, GT)
+inline fun <reified F, reified G> Reducible<F>.compose(RG: Reducible<G> = reducible<G>(),
+                                                       FT: Traverse<F> = traverse<F>(), GT: Traverse<G> = traverse<G>(),
+                                                       GA: Applicative<G> = applicative<G>()): Reducible<ComposedType<F, G>> =
+        ComposedReducible(this, RG, FT, GT)
 
 interface ComposedSemigroupK<F, G> : SemigroupK<ComposedType<F, G>> {
 
@@ -100,11 +109,12 @@ interface ComposedFunctor<F, G> : Functor<ComposedType<F, G>> {
     fun <A, B> mapC(fa: HK<F, HK<G, A>>, f: (A) -> B): HK<F, HK<G, B>> = map(fa.lift(), f).lower()
 
     companion object {
-        inline operator fun <reified F, reified G> invoke(FF: Functor<F> = functor<F>(), GF: Functor<G> = functor<G>()): Functor<ComposedType<F, G>> = object : ComposedFunctor<F, G> {
-            override fun F(): Functor<F> = FF
+        inline operator fun <reified F, reified G> invoke(FF: Functor<F> = functor<F>(), GF: Functor<G> = functor<G>()): Functor<ComposedType<F, G>> =
+                object : ComposedFunctor<F, G> {
+                    override fun F(): Functor<F> = FF
 
-            override fun G(): Functor<G> = GF
-        }
+                    override fun G(): Functor<G> = GF
+                }
     }
 }
 
@@ -119,16 +129,19 @@ interface ComposedApplicative<F, G> : Applicative<ComposedType<F, G>>, ComposedF
 
     override fun <A> pure(a: A): HK<ComposedType<F, G>, A> = F().pure(G().pure(a)).lift()
 
-    override fun <A, B> ap(fa: HK<ComposedType<F, G>, A>, ff: HK<ComposedType<F, G>, (A) -> B>): HK<ComposedType<F, G>, B> = F().ap(fa.lower(), F().map(ff.lower(), { gfa: HK<G, (A) -> B> -> { ga: HK<G, A> -> G().ap(ga, gfa) } })).lift()
+    override fun <A, B> ap(fa: HK<ComposedType<F, G>, A>, ff: HK<ComposedType<F, G>, (A) -> B>):
+            HK<ComposedType<F, G>, B> = F().ap(fa.lower(), F().map(ff.lower(), { gfa: HK<G, (A) -> B> -> { ga: HK<G, A> -> G().ap(ga, gfa) } })).lift()
 
     fun <A, B> apC(fa: HK<F, HK<G, A>>, ff: HK<F, HK<G, (A) -> B>>): HK<F, HK<G, B>> = ap(fa.lift(), ff.lift()).lower()
 
     companion object {
-        inline operator fun <reified F, reified G> invoke(FF: Applicative<F> = applicative<F>(), GF: Applicative<G> = applicative<G>()): Applicative<ComposedType<F, G>> = object : ComposedApplicative<F, G> {
-            override fun F(): Applicative<F> = FF
+        inline operator fun <reified F, reified G> invoke(FF: Applicative<F> = applicative<F>(), GF: Applicative<G> = applicative<G>())
+                : Applicative<ComposedType<F, G>> =
+                object : ComposedApplicative<F, G> {
+                    override fun F(): Applicative<F> = FF
 
-            override fun G(): Applicative<G> = GF
-        }
+                    override fun G(): Applicative<G> = GF
+                }
     }
 }
 

--- a/kategory/src/main/kotlin/kategory/data/Coproduct.kt
+++ b/kategory/src/main/kotlin/kategory/data/Coproduct.kt
@@ -16,7 +16,8 @@ package kategory
 
     fun <B> foldL(b: B, f: (B, A) -> B, FF: Foldable<F>, FG: Foldable<G>): B = run.fold({ FF.foldL(it, b, f) }, { FG.foldL(it, b, f) })
 
-    fun <B> foldR(lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>, FF: Foldable<F>, FG: Foldable<G>): Eval<B> = run.fold({ FF.foldR(it, lb, f) }, { FG.foldR(it, lb, f) })
+    fun <B> foldR(lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>, FF: Foldable<F>, FG: Foldable<G>): Eval<B> =
+            run.fold({ FF.foldR(it, lb, f) }, { FG.foldR(it, lb, f) })
 
     fun <H, B> traverse(f: (A) -> HK<H, B>, GA: Applicative<H>, FT: Traverse<F>, GT: Traverse<G>): HK<H, Coproduct<F, G, B>> =
             run.fold({
@@ -26,19 +27,23 @@ package kategory
             })
 
     companion object {
-        inline operator fun <reified F, reified G, A> invoke(run: Either<HK<F, A>, HK<G, A>>, CF: Comonad<F> = comonad<F>(), CG: Comonad<G> = comonad<G>()): Coproduct<F, G, A> = Coproduct(CF, CG, run)
+        inline operator fun <reified F, reified G, A> invoke(run: Either<HK<F, A>, HK<G, A>>,
+                                                             CF: Comonad<F> = comonad<F>(),
+                                                             CG: Comonad<G> = comonad<G>()): Coproduct<F, G, A> = Coproduct(CF, CG, run)
 
         fun <F, G> comonad(): CoproductComonad<F, G> = object : CoproductComonad<F, G> {}
 
         fun <F, G> functor(): CoproductComonad<F, G> = object : CoproductComonad<F, G> {}
 
-        inline fun <reified F, reified G> traverse(FF: Traverse<F> = traverse<F>(), FG: Traverse<G> = traverse<G>()): CoproductTraverse<F, G> = object : CoproductTraverse<F, G> {
-            override fun FF(): Traverse<F> = FF
+        inline fun <reified F, reified G> traverse(FF: Traverse<F> = traverse<F>(), FG: Traverse<G> = traverse<G>()): CoproductTraverse<F, G> =
+                object : CoproductTraverse<F, G> {
+                    override fun FF(): Traverse<F> = FF
 
-            override fun FG(): Traverse<G> = FG
-        }
+                    override fun FG(): Traverse<G> = FG
+                }
     }
 
 }
 
-inline fun <reified F, reified G, A> Either<HK<F, A>, HK<G, A>>.coproduct(CF: Comonad<F> = comonad(), CG: Comonad<G> = comonad()): Coproduct<F, G, A> = Coproduct(CF, CG, this)
+inline fun <reified F, reified G, A> Either<HK<F, A>, HK<G, A>>.coproduct(CF: Comonad<F> = comonad(), CG: Comonad<G> = comonad()): Coproduct<F, G, A> =
+        Coproduct(CF, CG, this)

--- a/kategory/src/main/kotlin/kategory/data/Either.kt
+++ b/kategory/src/main/kotlin/kategory/data/Either.kt
@@ -179,7 +179,8 @@ inline fun <B> Either<*, B>.getOrElse(crossinline default: () -> B): B = fold({ 
  * left.filterOrElse({ it > 10 }, { -1 })      // Result: Left(12)
  * ```
  */
-inline fun <A, B> Either<A, B>.filterOrElse(crossinline predicate: (B) -> Boolean, crossinline default: () -> A): Either<A, B> = fold({ Either.Left(it) }, { if (predicate(it)) Either.Right(it) else Either.Left(default()) })
+inline fun <A, B> Either<A, B>.filterOrElse(crossinline predicate: (B) -> Boolean, crossinline default: () -> A): Either<A, B> =
+        fold({ Either.Left(it) }, { if (predicate(it)) Either.Right(it) else Either.Left(default()) })
 
 /**
  * Returns `true` if this is a [Either.Right] and its value is equal to `elem` (as determined by `==`),

--- a/kategory/src/main/kotlin/kategory/data/EitherT.kt
+++ b/kategory/src/main/kotlin/kategory/data/EitherT.kt
@@ -32,11 +32,12 @@ package kategory
 
         inline fun <reified F, L> monadError(MF: Monad<F> = monad<F>()): MonadError<EitherTKindPartial<F, L>, L> = instances(MF)
 
-        inline fun <reified F, A> traverse(FF: Traverse<F> = traverse<F>(), MF: Monad<F> = monad<F>()): Traverse<EitherTKindPartial<F, A>> = object : EitherTTraverse<F, A> {
-            override fun FF(): Traverse<F> = FF
+        inline fun <reified F, A> traverse(FF: Traverse<F> = traverse<F>(), MF: Monad<F> = monad<F>()): Traverse<EitherTKindPartial<F, A>> =
+                object : EitherTTraverse<F, A> {
+                    override fun FF(): Traverse<F> = FF
 
-            override fun MF(): Monad<F> = MF
-        }
+                    override fun MF(): Monad<F> = MF
+                }
 
         inline fun <reified F, A> foldable(FF: Traverse<F> = traverse<F>(), MF: Monad<F> = monad<F>()): Foldable<EitherTKindPartial<F, A>> = traverse(FF, MF)
 
@@ -49,7 +50,8 @@ package kategory
 
     inline fun <C> flatMap(crossinline f: (B) -> EitherT<F, A, C>): EitherT<F, A, C> = flatMapF({ it -> f(it).value })
 
-    inline fun <C> flatMapF(crossinline f: (B) -> HK<F, Either<A, C>>): EitherT<F, A, C> = EitherT(MF, MF.flatMap(value, { either -> either.fold({ MF.pure(Either.Left(it)) }, { f(it) }) }))
+    inline fun <C> flatMapF(crossinline f: (B) -> HK<F, Either<A, C>>): EitherT<F, A, C> =
+            EitherT(MF, MF.flatMap(value, { either -> either.fold({ MF.pure(Either.Left(it)) }, { f(it) }) }))
 
     inline fun <C> cata(crossinline l: (A) -> C, crossinline r: (B) -> C): HK<F, C> = fold(l, r)
 

--- a/kategory/src/main/kotlin/kategory/data/OptionT.kt
+++ b/kategory/src/main/kotlin/kategory/data/OptionT.kt
@@ -28,13 +28,15 @@ package kategory
 
         inline fun <reified F> monad(MF: Monad<F> = kategory.monad<F>()): Monad<OptionTKindPartial<F>> = instances(MF)
 
-        inline fun <reified F> traverse(FF: Traverse<F> = kategory.traverse<F>(), MF: Monad<F> = kategory.monad<F>()): Traverse<OptionTKindPartial<F>> = object : OptionTTraverse<F> {
-            override fun FF(): Traverse<F> = FF
+        inline fun <reified F> traverse(FF: Traverse<F> = kategory.traverse<F>(), MF: Monad<F> = kategory.monad<F>()): Traverse<OptionTKindPartial<F>> =
+                object : OptionTTraverse<F> {
+                    override fun FF(): Traverse<F> = FF
 
-            override fun MF(): Monad<F> = MF
-        }
+                    override fun MF(): Monad<F> = MF
+                }
 
-        inline fun <reified F> foldable(FF: Traverse<F> = kategory.traverse<F>(), MF: Monad<F> = kategory.monad<F>()): Foldable<OptionTKindPartial<F>> = traverse(FF, MF)
+        inline fun <reified F> foldable(FF: Traverse<F> = kategory.traverse<F>(), MF: Monad<F> = kategory.monad<F>()): Foldable<OptionTKindPartial<F>> =
+                traverse(FF, MF)
 
         inline fun <reified F> semigroupK(MF: Monad<F> = kategory.monad<F>()): SemigroupK<OptionTKindPartial<F>> = object : OptionTSemigroupK<F> {
             override fun F(): Monad<F> = MF
@@ -51,7 +53,8 @@ package kategory
 
     inline fun <B> flatMap(crossinline f: (A) -> OptionT<F, B>): OptionT<F, B> = flatMapF({ it -> f(it).value })
 
-    inline fun <B> flatMapF(crossinline f: (A) -> HK<F, Option<B>>): OptionT<F, B> = OptionT(MF, MF.flatMap(value, { option -> option.fold({ MF.pure(Option.None) }, f) }))
+    inline fun <B> flatMapF(crossinline f: (A) -> HK<F, Option<B>>): OptionT<F, B> =
+            OptionT(MF, MF.flatMap(value, { option -> option.fold({ MF.pure(Option.None) }, f) }))
 
     fun <B> liftF(fa: HK<F, B>): OptionT<F, B> = OptionT(MF, MF.map(fa, { Option.Some(it) }))
 

--- a/kategory/src/main/kotlin/kategory/data/WriterT.kt
+++ b/kategory/src/main/kotlin/kategory/data/WriterT.kt
@@ -11,52 +11,63 @@ package kategory
 
         inline operator fun <reified F, W, A> invoke(value: HK<F, Tuple2<W, A>>, MF: Monad<F> = kategory.monad()) = WriterT(MF, value)
 
-        inline fun <reified F, reified W> instances(MM: Monad<F> = kategory.monad(), SG: Monoid<W> = kategory.monoid<W>()): WriterTInstances<F, W> = object : WriterTInstances<F, W> {
+        inline fun <reified F, reified W> instances(MM: Monad<F> = kategory.monad(), SG: Monoid<W> = kategory.monoid<W>()): WriterTInstances<F, W> =
+                object : WriterTInstances<F, W> {
 
-            override fun <A> writer(aw: Tuple2<W, A>): WriterT<F, W, A> = WriterT.put(aw.b, aw.a)
+                    override fun <A> writer(aw: Tuple2<W, A>): WriterT<F, W, A> = WriterT.put(aw.b, aw.a)
 
-            override fun <A> listen(fa: HK<WriterTKindPartial<F, W>, A>): HK<WriterTKindPartial<F, W>, Tuple2<W, A>> =
-                    WriterT(MM, MM.flatMap(fa.ev().content(), { a -> MM.map(fa.ev().write(), { l -> Tuple2(l, Tuple2(l, a)) }) }))
+                    override fun <A> listen(fa: HK<WriterTKindPartial<F, W>, A>): HK<WriterTKindPartial<F, W>, Tuple2<W, A>> =
+                            WriterT(MM, MM.flatMap(fa.ev().content(), { a -> MM.map(fa.ev().write(), { l -> Tuple2(l, Tuple2(l, a)) }) }))
 
-            override fun <A> pass(fa: HK<WriterTKindPartial<F, W>, Tuple2<(W) -> W, A>>): HK<WriterTKindPartial<F, W>, A> =
-                    WriterT(MM, MM.flatMap(fa.ev().content(), { tuple2FA -> MM.map(fa.ev().write(), { l -> Tuple2(tuple2FA.a(l), tuple2FA.b) }) }))
+                    override fun <A> pass(fa: HK<WriterTKindPartial<F, W>, Tuple2<(W) -> W, A>>): HK<WriterTKindPartial<F, W>, A> =
+                            WriterT(MM, MM.flatMap(fa.ev().content(), { tuple2FA -> MM.map(fa.ev().write(), { l -> Tuple2(tuple2FA.a(l), tuple2FA.b) }) }))
 
-            override fun tell(w: W): HK<WriterTKindPartial<F, W>, Unit> = WriterT.tell(w)
+                    override fun tell(w: W): HK<WriterTKindPartial<F, W>, Unit> = WriterT.tell(w)
 
-            override fun MM(): Monad<F> = MM
+                    override fun MM(): Monad<F> = MM
 
-            override fun SG(): Monoid<W> = SG
-        }
+                    override fun SG(): Monoid<W> = SG
+                }
 
-        inline fun <reified F, reified W> functor(MM: Monad<F> = kategory.monad<F>(), SG: Monoid<W> = kategory.monoid<W>()): Functor<WriterTKindPartial<F, W>> = instances(MM, SG)
+        inline fun <reified F, reified W> functor(MM: Monad<F> = kategory.monad<F>(), SG: Monoid<W> = kategory.monoid<W>()): Functor<WriterTKindPartial<F, W>> =
+                instances(MM, SG)
 
-        inline fun <reified F, reified W> applicative(MM: Monad<F> = kategory.monad<F>(), SG: Monoid<W> = kategory.monoid<W>()): Applicative<WriterTKindPartial<F, W>> = instances(MM, SG)
+        inline fun <reified F, reified W> applicative(MM: Monad<F> = kategory.monad<F>(), SG: Monoid<W> = kategory.monoid<W>()):
+                Applicative<WriterTKindPartial<F, W>> = instances(MM, SG)
 
-        inline fun <reified F, reified W> monad(MM: Monad<F> = kategory.monad<F>(), SG: Monoid<W> = kategory.monoid<W>()): Monad<WriterTKindPartial<F, W>> = instances(MM, SG)
+        inline fun <reified F, reified W> monad(MM: Monad<F> = kategory.monad<F>(), SG: Monoid<W> = kategory.monoid<W>()): Monad<WriterTKindPartial<F, W>> =
+                instances(MM, SG)
 
-        inline fun <reified F, reified W> semigroupK(MF: Monad<F> = monad<F>(), SGK: SemigroupK<F> = semigroupK<F>()): SemigroupK<WriterTKindPartial<F, W>> = object : WriterTSemigroupK<F, W> {
-            override fun MF(): Monad<F> = MF
+        inline fun <reified F, reified W> semigroupK(MF: Monad<F> = monad<F>(), SGK: SemigroupK<F> = semigroupK<F>()): SemigroupK<WriterTKindPartial<F, W>> =
+                object : WriterTSemigroupK<F, W> {
+                    override fun MF(): Monad<F> = MF
 
-            override fun F0(): SemigroupK<F> = SGK
-        }
+                    override fun F0(): SemigroupK<F> = SGK
+                }
 
-        inline fun <reified F, reified W> monoidK(MF: Monad<F> = monad<F>(), MKF: MonoidK<F> = monoidK<F>()): MonoidK<WriterTKindPartial<F, W>> = object : WriterTMonoidK<F, W> {
-            override fun MF(): Monad<F> = MF
+        inline fun <reified F, reified W> monoidK(MF: Monad<F> = monad<F>(), MKF: MonoidK<F> = monoidK<F>()): MonoidK<WriterTKindPartial<F, W>> =
+                object : WriterTMonoidK<F, W> {
+                    override fun MF(): Monad<F> = MF
 
-            override fun F0(): MonoidK<F> = MKF
-        }
+                    override fun F0(): MonoidK<F> = MKF
+                }
 
-        inline fun <reified F, reified W> monadWriter(MM: Monad<F> = kategory.monad(), SG: Monoid<W> = kategory.monoid()): MonadWriter<WriterTKindPartial<F, W>, W> = instances(MM, SG)
+        inline fun <reified F, reified W> monadWriter(MM: Monad<F> = kategory.monad(), SG: Monoid<W> = kategory.monoid()):
+                MonadWriter<WriterTKindPartial<F, W>, W> = instances(MM, SG)
 
-        inline fun <reified F, W, A> putT(vf: HK<F, A>, w: W, MF: Monad<F> = kategory.monad()): WriterT<F, W, A> = WriterT(MF, MF.map(vf, { v -> Tuple2(w, v) }))
+        inline fun <reified F, W, A> putT(vf: HK<F, A>, w: W, MF: Monad<F> = kategory.monad()): WriterT<F, W, A> =
+                WriterT(MF, MF.map(vf, { v -> Tuple2(w, v) }))
 
-        inline fun <reified F, W, A> put(a: A, w: W, applicativeF: Applicative<F> = kategory.applicative()): WriterT<F, W, A> = WriterT.putT(applicativeF.pure(a), w)
+        inline fun <reified F, W, A> put(a: A, w: W, applicativeF: Applicative<F> = kategory.applicative()): WriterT<F, W, A> =
+                WriterT.putT(applicativeF.pure(a), w)
 
         inline fun <reified F, W> tell(l: W, applicativeF: Applicative<F> = kategory.applicative()): WriterT<F, W, Unit> = WriterT.put(Unit, l)
 
-        inline fun <reified F, reified W, A> value(v: A, applicativeF: Applicative<F> = kategory.applicative(), monoidW: Monoid<W> = monoid()): WriterT<F, W, A> = WriterT.put(v, monoidW.empty())
+        inline fun <reified F, reified W, A> value(v: A, applicativeF: Applicative<F> = kategory.applicative(), monoidW: Monoid<W> = monoid()):
+                WriterT<F, W, A> = WriterT.put(v, monoidW.empty())
 
-        inline fun <reified F, reified W, A> valueT(vf: HK<F, A>, functorF: Functor<F> = kategory.functor(), monoidW: Monoid<W> = monoid()): WriterT<F, W, A> = WriterT.putT(vf, monoidW.empty())
+        inline fun <reified F, reified W, A> valueT(vf: HK<F, A>, functorF: Functor<F> = kategory.functor(), monoidW: Monoid<W> = monoid()): WriterT<F, W, A> =
+                WriterT.putT(vf, monoidW.empty())
     }
 
     fun tell(w: W, SG: Semigroup<W>): WriterT<F, W, A> = mapAcc { SG.combine(it, w) }
@@ -75,7 +86,8 @@ package kategory
 
     fun swap(): WriterT<F, A, W> = transform { it.b toT it.a }
 
-    inline fun <B> flatMap(crossinline f: (A) -> WriterT<F, W, B>, SG: Semigroup<W>): WriterT<F, W, B> = WriterT(MF, MF.flatMap(value, { value -> MF.map(f(value.b).value, { SG.combine(it.a, value.a) toT it.b }) }))
+    inline fun <B> flatMap(crossinline f: (A) -> WriterT<F, W, B>, SG: Semigroup<W>): WriterT<F, W, B> =
+            WriterT(MF, MF.flatMap(value, { value -> MF.map(f(value.b).value, { SG.combine(it.a, value.a) toT it.b }) }))
 
     inline fun <B, U> transform(crossinline f: (Tuple2<W, A>) -> Tuple2<U, B>): WriterT<F, U, B> = WriterT(MF, MF.flatMap(value, { MF.pure(f(it)) }))
 

--- a/kategory/src/main/kotlin/kategory/free/Free.kt
+++ b/kategory/src/main/kotlin/kategory/free/Free.kt
@@ -48,7 +48,8 @@ inline fun <reified M, S, A> FreeKind<S, A>.foldMapK(f: FunctionK<S, M>, MM: Mon
     }
 
     data class FlatMapped<out S, out A, C>(val c: Free<S, C>, val f: (C) -> Free<S, A>) : Free<S, A>() {
-        override fun <O, B> transform(fm: (A) -> B, fs: FunctionK<S, O>): Free<O, B> = Free.FlatMapped(c.transform({ it }, fs), { c.flatMap { f(it) }.transform(fm, fs) })
+        override fun <O, B> transform(fm: (A) -> B, fs: FunctionK<S, O>): Free<O, B> =
+                Free.FlatMapped(c.transform({ it }, fs), { c.flatMap { f(it) }.transform(fm, fs) })
     }
 
     override fun toString(): String = "Free(...) : toString is not stack-safe"

--- a/kategory/src/main/kotlin/kategory/free/FreeApplicative.kt
+++ b/kategory/src/main/kotlin/kategory/free/FreeApplicative.kt
@@ -1,6 +1,7 @@
 package kategory
 
-inline fun <F, reified G, A> FreeApplicativeKind<F, A>.foldMapK(f: FunctionK<F, G>, GA: Applicative<G> = applicative<G>()): HK<G, A> = (this as FreeApplicative<F, A>).foldMap(f, GA)
+inline fun <F, reified G, A> FreeApplicativeKind<F, A>.foldMapK(f: FunctionK<F, G>, GA: Applicative<G> = applicative<G>()): HK<G, A> =
+        (this as FreeApplicative<F, A>).foldMap(f, GA)
 
 inline fun <reified F, A> FreeApplicativeKind<F, A>.foldK(FA: Applicative<F> = applicative<F>()): HK<F, A> = (this as FreeApplicative<F, A>).fold(FA)
 
@@ -52,7 +53,8 @@ inline fun <reified F, A> FreeApplicativeKind<F, A>.foldK(FA: Applicative<F> = a
 
     fun <G> compile(f: FunctionK<F, G>): FreeApplicative<G, A> = foldMap(functionKF(f), applicativeF()).ev()
 
-    fun <G> flatCompile(f: FunctionK<F, FreeApplicativeKindPartial<G>>, GFA: Applicative<FreeApplicativeKindPartial<G>>): FreeApplicative<G, A> = foldMap(f, GFA).ev()
+    fun <G> flatCompile(f: FunctionK<F, FreeApplicativeKindPartial<G>>, GFA: Applicative<FreeApplicativeKindPartial<G>>): FreeApplicative<G, A> =
+            foldMap(f, GFA).ev()
 
     fun <M> analyze(f: FunctionK<F, ConstKindPartial<M>>, MM: Monoid<M>): M =
             foldMap(object : FunctionK<F, ConstKindPartial<M>> {

--- a/kategory/src/main/kotlin/kategory/instances/CoproductInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/CoproductInstances.kt
@@ -21,7 +21,8 @@ interface CoproductTraverse<F, G> : Traverse<CoproductKindPartial<F, G>> {
 
     fun FG(): Traverse<G>
 
-    override fun <H, A, B> traverse(fa: HK<CoproductKindPartial<F, G>, A>, f: (A) -> HK<H, B>, GA: Applicative<H>): HK<H, HK<CoproductKindPartial<F, G>, B>> = fa.ev().traverse(f, GA, FF(), FG())
+    override fun <H, A, B> traverse(fa: HK<CoproductKindPartial<F, G>, A>, f: (A) -> HK<H, B>, GA: Applicative<H>): HK<H, HK<CoproductKindPartial<F, G>, B>> =
+            fa.ev().traverse(f, GA, FF(), FG())
 
     override fun <A, B> foldL(fa: HK<CoproductKindPartial<F, G>, A>, b: B, f: (B, A) -> B): B = fa.ev().foldL(b, f, FF(), FG())
 

--- a/kategory/src/main/kotlin/kategory/instances/EitherInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/EitherInstances.kt
@@ -38,7 +38,8 @@ interface EitherInstances<L> :
         }
     }
 
-    override fun <G, A, B> traverse(fa: HK<EitherKindPartial<L>, A>, f: (A) -> HK<G, B>, GA: Applicative<G>): HK<G, HK<EitherKindPartial<L>, B>> = fa.ev().fold({ GA.pure(it.left()) }, { GA.map(f(it), { Either.Right(it) }) })
+    override fun <G, A, B> traverse(fa: HK<EitherKindPartial<L>, A>, f: (A) -> HK<G, B>, GA: Applicative<G>): HK<G, HK<EitherKindPartial<L>, B>> =
+            fa.ev().fold({ GA.pure(it.left()) }, { GA.map(f(it), { Either.Right(it) }) })
 
     override fun <A, B> foldL(fa: HK<EitherKindPartial<L>, A>, b: B, f: (B, A) -> B): B =
             fa.ev().let { either ->

--- a/kategory/src/main/kotlin/kategory/instances/EitherTInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/EitherTInstances.kt
@@ -50,7 +50,8 @@ interface EitherTTraverse<F, A> :
 
     fun MF(): Monad<F>
 
-    override fun <G, B, C> traverse(fa: HK<EitherTKindPartial<F, A>, B>, f: (B) -> HK<G, C>, GA: Applicative<G>): HK<G, HK<EitherTKindPartial<F, A>, C>> = fa.ev().traverse(f, GA, FF(), MF())
+    override fun <G, B, C> traverse(fa: HK<EitherTKindPartial<F, A>, B>, f: (B) -> HK<G, C>, GA: Applicative<G>): HK<G, HK<EitherTKindPartial<F, A>, C>> =
+            fa.ev().traverse(f, GA, FF(), MF())
 
     override fun <B, C> foldL(fa: HK<EitherTKindPartial<F, A>, B>, b: C, f: (C, B) -> C): C = fa.ev().foldL(b, f, FF())
 

--- a/kategory/src/main/kotlin/kategory/instances/FreeApplicativeInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/FreeApplicativeInstances.kt
@@ -8,13 +8,16 @@ interface FreeApplicativeInstances<S> :
 
     override fun <A, B> map(fa: FreeApplicativeKind<S, A>, f: (A) -> B): FreeApplicative<S, B> = fa.ev().map(f)
 
-    override fun <A, B> ap(fa: HK<FreeApplicativeKindPartial<S>, A>, ff: HK<FreeApplicativeKindPartial<S>, (A) -> B>): FreeApplicative<S, B> = fa.ev().ap(ff.ev())
+    override fun <A, B> ap(fa: HK<FreeApplicativeKindPartial<S>, A>, ff: HK<FreeApplicativeKindPartial<S>, (A) -> B>): FreeApplicative<S, B> =
+            fa.ev().ap(ff.ev())
 }
 
 data class FreeApplicativeEq<in F, in G, in A>(private val interpreter: FunctionK<F, G>, private val MG: Monad<G>) : Eq<HK<FreeApplicativeKindPartial<F>, A>> {
-    override fun eqv(a: HK<FreeApplicativeKindPartial<F>, A>, b: HK<FreeApplicativeKindPartial<F>, A>): Boolean = a.ev().foldMap(interpreter, MG) == b.ev().foldMap(interpreter, MG)
+    override fun eqv(a: HK<FreeApplicativeKindPartial<F>, A>, b: HK<FreeApplicativeKindPartial<F>, A>): Boolean =
+            a.ev().foldMap(interpreter, MG) == b.ev().foldMap(interpreter, MG)
 
     companion object {
-        inline operator fun <F, reified G, A> invoke(interpreter: FunctionK<F, G>, MG: Monad<G> = monad(), dummy: Unit = Unit): FreeApplicativeEq<F, G, A> = FreeApplicativeEq(interpreter, MG)
+        inline operator fun <F, reified G, A> invoke(interpreter: FunctionK<F, G>, MG: Monad<G> = monad(), dummy: Unit = Unit): FreeApplicativeEq<F, G, A> =
+                FreeApplicativeEq(interpreter, MG)
     }
 }

--- a/kategory/src/main/kotlin/kategory/instances/FreeInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/FreeInstances.kt
@@ -23,6 +23,7 @@ data class FreeEq<in F, in G, in A>(private val interpreter: FunctionK<F, G>, pr
     override fun eqv(a: HK<FreeKindPartial<F>, A>, b: HK<FreeKindPartial<F>, A>): Boolean = a.ev().foldMap(interpreter, MG) == b.ev().foldMap(interpreter, MG)
 
     companion object {
-        inline operator fun <F, reified G, A> invoke(interpreter: FunctionK<F, G>, MG: Monad<G> = monad(), dummy: Unit = Unit): FreeEq<F, G, A> = FreeEq(interpreter, MG)
+        inline operator fun <F, reified G, A> invoke(interpreter: FunctionK<F, G>, MG: Monad<G> = monad(), dummy: Unit = Unit): FreeEq<F, G, A> =
+                FreeEq(interpreter, MG)
     }
 }

--- a/kategory/src/main/kotlin/kategory/instances/IorInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/IorInstances.kt
@@ -38,9 +38,11 @@ interface IorInstances<L> :
 interface IorTraverse<A> :
         Foldable<HK<IorHK, A>>,
         Traverse<HK<IorHK, A>> {
-    override fun <G, B, C> traverse(fa: HK<HK<IorHK, A>, B>, f: (B) -> HK<G, C>, GA: Applicative<G>): HK<G, HK<HK<IorHK, A>, C>> = fa.ev().fold({ GA.pure(Ior.Left(it)) }, { GA.map(f(it), { Ior.Right(it) }) }, { _, b -> GA.map(f(b), { Ior.Right(it) }) })
+    override fun <G, B, C> traverse(fa: HK<HK<IorHK, A>, B>, f: (B) -> HK<G, C>, GA: Applicative<G>): HK<G, HK<HK<IorHK, A>, C>> =
+            fa.ev().fold({ GA.pure(Ior.Left(it)) }, { GA.map(f(it), { Ior.Right(it) }) }, { _, b -> GA.map(f(b), { Ior.Right(it) }) })
 
     override fun <B, C> foldL(fa: HK<HK<IorHK, A>, B>, c: C, f: (C, B) -> C): C = fa.ev().fold({ c }, { f(c, it) }, { _, b -> f(c, b) })
 
-    override fun <B, C> foldR(fa: HK<HK<IorHK, A>, B>, lc: Eval<C>, f: (B, Eval<C>) -> Eval<C>): Eval<C> = fa.ev().fold({ lc }, { f(it, lc) }, { _, b -> f(b, lc) })
+    override fun <B, C> foldR(fa: HK<HK<IorHK, A>, B>, lc: Eval<C>, f: (B, Eval<C>) -> Eval<C>): Eval<C> =
+            fa.ev().fold({ lc }, { f(it, lc) }, { _, b -> f(b, lc) })
 }

--- a/kategory/src/main/kotlin/kategory/instances/KleisliInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/KleisliInstances.kt
@@ -12,13 +12,16 @@ interface KleisliInstances<F, D> :
 
     override fun <A> local(f: (D) -> D, fa: HK<KleisliKindPartial<F, D>, A>): Kleisli<F, D, A> = fa.ev().local(f)
 
-    override fun <A, B> flatMap(fa: HK<KleisliKindPartial<F, D>, A>, f: (A) -> HK<KleisliKindPartial<F, D>, B>): Kleisli<F, D, B> = fa.ev().flatMap(f.andThen { it.ev() })
+    override fun <A, B> flatMap(fa: HK<KleisliKindPartial<F, D>, A>, f: (A) -> HK<KleisliKindPartial<F, D>, B>): Kleisli<F, D, B> =
+            fa.ev().flatMap(f.andThen { it.ev() })
 
     override fun <A, B> map(fa: HK<KleisliKindPartial<F, D>, A>, f: (A) -> B): Kleisli<F, D, B> = fa.ev().map(f)
 
-    override fun <A, B> product(fa: HK<KleisliKindPartial<F, D>, A>, fb: HK<KleisliKindPartial<F, D>, B>): Kleisli<F, D, Tuple2<A, B>> = Kleisli(MF(), { MF().product(fa.ev().run(it), fb.ev().run(it)) })
+    override fun <A, B> product(fa: HK<KleisliKindPartial<F, D>, A>, fb: HK<KleisliKindPartial<F, D>, B>): Kleisli<F, D, Tuple2<A, B>> =
+            Kleisli(MF(), { MF().product(fa.ev().run(it), fb.ev().run(it)) })
 
-    override fun <A, B> tailRecM(a: A, f: (A) -> HK<KleisliKindPartial<F, D>, Either<A, B>>): Kleisli<F, D, B> = Kleisli(MF(), { b -> MF().tailRecM(a, { f(it).ev().run(b) }) })
+    override fun <A, B> tailRecM(a: A, f: (A) -> HK<KleisliKindPartial<F, D>, Either<A, B>>): Kleisli<F, D, B> =
+            Kleisli(MF(), { b -> MF().tailRecM(a, { f(it).ev().run(b) }) })
 
     override fun <A> pure(a: A): Kleisli<F, D, A> = Kleisli(MF(), { MF().pure(a) })
 }

--- a/kategory/src/main/kotlin/kategory/instances/OptionTInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/OptionTInstances.kt
@@ -34,7 +34,8 @@ interface OptionTTraverse<F> :
 
     fun MF(): Monad<F>
 
-    override fun <G, A, B> traverse(fa: HK<OptionTKindPartial<F>, A>, f: (A) -> HK<G, B>, GA: Applicative<G>): HK<G, HK<OptionTKindPartial<F>, B>> = fa.ev().traverse(f, GA, FF(), MF())
+    override fun <G, A, B> traverse(fa: HK<OptionTKindPartial<F>, A>, f: (A) -> HK<G, B>, GA: Applicative<G>): HK<G, HK<OptionTKindPartial<F>, B>> =
+            fa.ev().traverse(f, GA, FF(), MF())
 
     override fun <A, B> foldL(fa: HK<OptionTKindPartial<F>, A>, b: B, f: (B, A) -> B): B = fa.ev().foldL(b, f, FF())
 

--- a/kategory/src/main/kotlin/kategory/instances/StateTInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/StateTInstances.kt
@@ -14,14 +14,18 @@ interface StateTInstances<F, S> :
 
     override fun <A> pure(a: A): StateT<F, S, A> = StateT(MF(), MF().pure({ s: S -> MF().pure(Tuple2(s, a)) }))
 
-    override fun <A, B> ap(fa: HK<StateTKindPartial<F, S>, A>, ff: HK<StateTKindPartial<F, S>, (A) -> B>): StateT<F, S, B> = ff.ev().map2(fa.ev()) { f, a -> f(a) }
+    override fun <A, B> ap(fa: HK<StateTKindPartial<F, S>, A>, ff: HK<StateTKindPartial<F, S>, (A) -> B>): StateT<F, S, B> =
+            ff.ev().map2(fa.ev()) { f, a -> f(a) }
 
-    override fun <A, B, Z> map2(fa: HK<StateTKindPartial<F, S>, A>, fb: HK<StateTKindPartial<F, S>, B>, f: (Tuple2<A, B>) -> Z): StateT<F, S, Z> = fa.ev().map2(fb.ev(), { a, b -> f(Tuple2(a, b)) })
+    override fun <A, B, Z> map2(fa: HK<StateTKindPartial<F, S>, A>, fb: HK<StateTKindPartial<F, S>, B>, f: (Tuple2<A, B>) -> Z): StateT<F, S, Z> =
+            fa.ev().map2(fb.ev(), { a, b -> f(Tuple2(a, b)) })
 
     @Suppress("UNCHECKED_CAST")
-    override fun <A, B, Z> map2Eval(fa: HK<StateTKindPartial<F, S>, A>, fb: Eval<HK<StateTKindPartial<F, S>, B>>, f: (Tuple2<A, B>) -> Z): Eval<StateT<F, S, Z>> = fa.ev().map2Eval(fb as Eval<StateT<F, S, B>>) { a, b -> f(Tuple2(a, b)) }
+    override fun <A, B, Z> map2Eval(fa: HK<StateTKindPartial<F, S>, A>, fb: Eval<HK<StateTKindPartial<F, S>, B>>, f: (Tuple2<A, B>) -> Z):
+            Eval<StateT<F, S, Z>> = fa.ev().map2Eval(fb as Eval<StateT<F, S, B>>) { a, b -> f(Tuple2(a, b)) }
 
-    override fun <A, B> product(fa: HK<StateTKindPartial<F, S>, A>, fb: HK<StateTKindPartial<F, S>, B>): HK<StateTKindPartial<F, S>, Tuple2<A, B>> = fa.ev().product(fb.ev())
+    override fun <A, B> product(fa: HK<StateTKindPartial<F, S>, A>, fb: HK<StateTKindPartial<F, S>, B>): HK<StateTKindPartial<F, S>, Tuple2<A, B>> =
+            fa.ev().product(fb.ev())
 
     override fun <A, B> tailRecM(a: A, f: (A) -> HK<StateTKindPartial<F, S>, Either<A, B>>): StateT<F, S, B> =
             StateT(MF(), MF().pure({ s: S ->
@@ -43,5 +47,6 @@ interface StateTSemigroupK<F, S> : SemigroupK<StateTKindPartial<F, S>> {
     fun F(): Monad<F>
     fun G(): SemigroupK<F>
 
-    override fun <A> combineK(x: HK<HK2<StateTHK, F, S>, A>, y: HK<HK2<StateTHK, F, S>, A>): StateT<F, S, A> = StateT(F(), F().pure({ s -> G().combineK(x.ev().run(s), y.ev().run(s)) }))
+    override fun <A> combineK(x: HK<HK2<StateTHK, F, S>, A>, y: HK<HK2<StateTHK, F, S>, A>): StateT<F, S, A> =
+            StateT(F(), F().pure({ s -> G().combineK(x.ev().run(s), y.ev().run(s)) }))
 }

--- a/kategory/src/main/kotlin/kategory/instances/TryInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/TryInstances.kt
@@ -18,9 +18,11 @@ interface TryInstances :
 
     override fun <A> handleErrorWith(fa: TryKind<A>, f: (Throwable) -> TryKind<A>): Try<A> = fa.ev().recoverWith { f(it).ev() }
 
-    override fun <A, B> tailRecM(a: A, f: (A) -> TryKind<Either<A, B>>): Try<B> = f(a).ev().fold({ Try.raiseError(it) }, { either -> either.fold({ tailRecM(it, f) }, { Try.Success(it) }) })
+    override fun <A, B> tailRecM(a: A, f: (A) -> TryKind<Either<A, B>>): Try<B> =
+            f(a).ev().fold({ Try.raiseError(it) }, { either -> either.fold({ tailRecM(it, f) }, { Try.Success(it) }) })
 
-    override fun <G, A, B> traverse(fa: HK<TryHK, A>, f: (A) -> HK<G, B>, GA: Applicative<G>): HK<G, HK<TryHK, B>> = fa.ev().fold({ GA.pure(Try.raise(IllegalStateException())) }, { GA.map(f(it), { Try { it } }) })
+    override fun <G, A, B> traverse(fa: HK<TryHK, A>, f: (A) -> HK<G, B>, GA: Applicative<G>): HK<G, HK<TryHK, B>> =
+            fa.ev().fold({ GA.pure(Try.raise(IllegalStateException())) }, { GA.map(f(it), { Try { it } }) })
 
     override fun <A, B> foldL(fa: HK<TryHK, A>, b: B, f: (B, A) -> B): B = fa.ev().fold({ b }, { f(b, it) })
 

--- a/kategory/src/main/kotlin/kategory/instances/ValidatedInstances.kt
+++ b/kategory/src/main/kotlin/kategory/instances/ValidatedInstances.kt
@@ -18,7 +18,8 @@ interface ValidatedInstances<E> :
 
     override fun <A> raiseError(e: E): Validated<E, A> = Validated.Invalid(e)
 
-    override fun <A> handleErrorWith(fa: ValidatedKind<E, A>, f: (E) -> ValidatedKind<E, A>): Validated<E, A> = fa.ev().fold({ f(it).ev() }, { Validated.Valid(it) })
+    override fun <A> handleErrorWith(fa: ValidatedKind<E, A>, f: (E) -> ValidatedKind<E, A>): Validated<E, A> =
+            fa.ev().fold({ f(it).ev() }, { Validated.Valid(it) })
 
     override fun <A, B> ap(fa: ValidatedKind<E, A>, ff: HK<ValidatedKindPartial<E>, (A) -> B>): Validated<E, B> = fa.ev().ap(ff.ev(), SE())
 

--- a/kategory/src/main/kotlin/kategory/typeclasses/Applicative.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/Applicative.kt
@@ -19,48 +19,68 @@ interface Applicative<F> : Functor<F>, Typeclass {
 
 // Syntax
 
-inline fun <reified F, A> A.pure(FT : Applicative<F> = applicative()): HK<F, A> = FT.pure(this)
+inline fun <reified F, A> A.pure(FT: Applicative<F> = applicative()): HK<F, A> = FT.pure(this)
 
-inline fun <reified F, A, B> HK<F, A>.ap(FT : Applicative<F> = applicative(), ff: HK<F, (A) -> B>): HK<F, B> = FT.ap(this, ff)
+inline fun <reified F, A, B> HK<F, A>.ap(FT: Applicative<F> = applicative(), ff: HK<F, (A) -> B>): HK<F, B> = FT.ap(this, ff)
 
-inline fun <reified F, A, B, Z> HK<F, A>.map2(FT : Applicative<F> = applicative(), fb: HK<F, B>, noinline f: (Tuple2<A, B>) -> Z): HK<F, Z> = FT.map2(this, fb, f)
+inline fun <reified F, A, B, Z> HK<F, A>.map2(FT: Applicative<F> = applicative(), fb: HK<F, B>, noinline f: (Tuple2<A, B>) -> Z): HK<F, Z> =
+        FT.map2(this, fb, f)
 
-inline fun <reified F, A, B, Z> HK<F, A>.map2Eval(FT : Applicative<F> = applicative(), fb: Eval<HK<F, B>>, noinline f: (Tuple2<A, B>) -> Z): Eval<HK<F, Z>> = FT.map2Eval(this, fb, f)
+inline fun <reified F, A, B, Z> HK<F, A>.map2Eval(FT: Applicative<F> = applicative(), fb: Eval<HK<F, B>>, noinline f: (Tuple2<A, B>) -> Z): Eval<HK<F, Z>> =
+        FT.map2Eval(this, fb, f)
 
 //Applicative Builder
 
 data class Tuple2<out A, out B>(val a: A, val b: B) {
     fun reverse(): Tuple2<B, A> = Tuple2(b, a)
 }
+
 data class Tuple3<out A, out B, out C>(val a: A, val b: B, val c: C) {
     fun reverse(): Tuple3<C, B, A> = Tuple3(c, b, a)
 }
+
 data class Tuple4<out A, out B, out C, out D>(val a: A, val b: B, val c: C, val d: D) {
     fun reverse(): Tuple4<D, C, B, A> = Tuple4(d, c, b, a)
 }
+
 data class Tuple5<out A, out B, out C, out D, out E>(val a: A, val b: B, val c: C, val d: D, val e: E) {
     fun reverse(): Tuple5<E, D, C, B, A> = Tuple5(e, d, c, b, a)
 }
+
 data class Tuple6<out A, out B, out C, out D, out E, out F>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F) {
     fun reverse(): Tuple6<F, E, D, C, B, A> = Tuple6(f, e, d, c, b, a)
 }
+
 data class Tuple7<out A, out B, out C, out D, out E, out F, out G>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F, val g: G) {
     fun reverse(): Tuple7<G, F, E, D, C, B, A> = Tuple7(g, f, e, d, c, b, a)
 }
+
 data class Tuple8<out A, out B, out C, out D, out E, out F, out G, out H>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F, val g: G, val h: H) {
     fun reverse(): Tuple8<H, G, F, E, D, C, B, A> = Tuple8(h, g, f, e, d, c, b, a)
 }
-data class Tuple9<out A, out B, out C, out D, out E, out F, out G, out H, out I>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F, val g: G, val h: H, val i: I) {
+
+data class Tuple9<out A, out B, out C, out D, out E, out F, out G, out H, out I>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F, val g: G,
+                                                                                 val h: H, val i: I) {
     fun reverse(): Tuple9<I, H, G, F, E, D, C, B, A> = Tuple9(i, h, g, f, e, d, c, b, a)
 }
-data class Tuple10<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F, val g: G, val h: H, val i: I, val j: J) {
+
+data class Tuple10<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J>(val a: A, val b: B, val c: C, val d: D, val e: E, val f: F, val g: G,
+                                                                                         val h: H, val i: I, val j: J) {
     fun reverse(): Tuple10<J, I, H, G, F, E, D, C, B, A> = Tuple10(j, i, h, g, f, e, d, c, b, a)
 }
 
-infix operator fun <A, B, C, D, E, F, G, H, I, J> Tuple9<A, B, C, D, E, F, G, H, I>.plus(j: J): Tuple10<A, B, C, D, E, F, G, H, I, J> = Tuple10(this.a, this.b, this.c, this.d, this.e, this.f, this.g, this.h, this.i, j)
-infix operator fun <A, B, C, D, E, F, G, H, I> Tuple8<A, B, C, D, E, F, G, H>.plus(i: I): Tuple9<A, B, C, D, E, F, G, H, I> = Tuple9(this.a, this.b, this.c, this.d, this.e, this.f, this.g, this.h, i)
-infix operator fun <A, B, C, D, E, F, G, H> Tuple7<A, B, C, D, E, F, G>.plus(h: H): Tuple8<A, B, C, D, E, F, G, H> = Tuple8(this.a, this.b, this.c, this.d, this.e, this.f, this.g, h)
-infix operator fun <A, B, C, D, E, F, G> Tuple6<A, B, C, D, E, F>.plus(g: G): Tuple7<A, B, C, D, E, F, G> = Tuple7(this.a, this.b, this.c, this.d, this.e, this.f, g)
+infix operator fun <A, B, C, D, E, F, G, H, I, J> Tuple9<A, B, C, D, E, F, G, H, I>.plus(j: J): Tuple10<A, B, C, D, E, F, G, H, I, J> =
+        Tuple10(this.a, this.b, this.c, this.d, this.e, this.f, this.g, this.h, this.i, j)
+
+infix operator fun <A, B, C, D, E, F, G, H, I> Tuple8<A, B, C, D, E, F, G, H>.plus(i: I): Tuple9<A, B, C, D, E, F, G, H, I> =
+        Tuple9(this.a, this.b, this.c, this.d, this.e, this.f, this.g, this.h, i)
+
+infix operator fun <A, B, C, D, E, F, G, H> Tuple7<A, B, C, D, E, F, G>.plus(h: H): Tuple8<A, B, C, D, E, F, G, H> =
+        Tuple8(this.a, this.b, this.c, this.d, this.e, this.f, this.g, h)
+
+infix operator fun <A, B, C, D, E, F, G> Tuple6<A, B, C, D, E, F>.plus(g: G): Tuple7<A, B, C, D, E, F, G> =
+        Tuple7(this.a, this.b, this.c, this.d, this.e, this.f, g)
+
 infix operator fun <A, B, C, D, E, F> Tuple5<A, B, C, D, E>.plus(f: F): Tuple6<A, B, C, D, E, F> = Tuple6(this.a, this.b, this.c, this.d, this.e, f)
 infix operator fun <A, B, C, D, E> Tuple4<A, B, C, D>.plus(e: E): Tuple5<A, B, C, D, E> = Tuple5(this.a, this.b, this.c, this.d, e)
 infix operator fun <A, B, C, D> Tuple3<A, B, C>.plus(d: D): Tuple4<A, B, C, D> = Tuple4(this.a, this.b, this.c, d)
@@ -93,7 +113,8 @@ fun <HKF, A, B, C, D, E, Z> HK<HKF, Tuple5<A, B, C, D, E>>.product(
         dummyImplicit: Any? = null,
         dummyImplicit2: Any? = null,
         dummyImplicit3: Any? = null,
-        dummyImplicit4: Any? = null): HK<HKF, Tuple6<A, B, C, D, E, Z>> = AP.map(AP.product(this, other), { Tuple6(it.a.a, it.a.b, it.a.c, it.a.d, it.a.e, it.b) })
+        dummyImplicit4: Any? = null): HK<HKF, Tuple6<A, B, C, D, E, Z>> =
+        AP.map(AP.product(this, other), { Tuple6(it.a.a, it.a.b, it.a.c, it.a.d, it.a.e, it.b) })
 
 fun <HKF, A, B, C, D, E, F, Z> HK<HKF, Tuple6<A, B, C, D, E, F>>.product(
         AP: Applicative<HKF>,
@@ -102,7 +123,8 @@ fun <HKF, A, B, C, D, E, F, Z> HK<HKF, Tuple6<A, B, C, D, E, F>>.product(
         dummyImplicit2: Any? = null,
         dummyImplicit3: Any? = null,
         dummyImplicit4: Any? = null,
-        dummyImplicit5: Any? = null): HK<HKF, Tuple7<A, B, C, D, E, F, Z>> = AP.map(AP.product(this, other), { Tuple7(it.a.a, it.a.b, it.a.c, it.a.d, it.a.e, it.a.f, it.b) })
+        dummyImplicit5: Any? = null): HK<HKF, Tuple7<A, B, C, D, E, F, Z>> =
+        AP.map(AP.product(this, other), { Tuple7(it.a.a, it.a.b, it.a.c, it.a.d, it.a.e, it.a.f, it.b) })
 
 fun <HKF, A, B, C, D, E, F, G, Z> HK<HKF, Tuple7<A, B, C, D, E, F, G>>.product(
         AP: Applicative<HKF>,
@@ -112,7 +134,8 @@ fun <HKF, A, B, C, D, E, F, G, Z> HK<HKF, Tuple7<A, B, C, D, E, F, G>>.product(
         dummyImplicit3: Any? = null,
         dummyImplicit4: Any? = null,
         dummyImplicit5: Any? = null,
-        dummyImplicit6: Any? = null): HK<HKF, Tuple8<A, B, C, D, E, F, G, Z>> = AP.map(AP.product(this, other), { Tuple8(it.a.a, it.a.b, it.a.c, it.a.d, it.a.e, it.a.f, it.a.g, it.b) })
+        dummyImplicit6: Any? = null): HK<HKF, Tuple8<A, B, C, D, E, F, G, Z>> =
+        AP.map(AP.product(this, other), { Tuple8(it.a.a, it.a.b, it.a.c, it.a.d, it.a.e, it.a.f, it.a.g, it.b) })
 
 fun <HKF, A, B, C, D, E, F, G, H, Z> HK<HKF, Tuple8<A, B, C, D, E, F, G, H>>.product(
         AP: Applicative<HKF>,
@@ -123,7 +146,8 @@ fun <HKF, A, B, C, D, E, F, G, H, Z> HK<HKF, Tuple8<A, B, C, D, E, F, G, H>>.pro
         dummyImplicit4: Any? = null,
         dummyImplicit5: Any? = null,
         dummyImplicit6: Any? = null,
-        dummyImplicit7: Any? = null): HK<HKF, Tuple9<A, B, C, D, E, F, G, H, Z>> = AP.map(AP.product(this, other), { Tuple9(it.a.a, it.a.b, it.a.c, it.a.d, it.a.e, it.a.f, it.a.g, it.a.h, it.b) })
+        dummyImplicit7: Any? = null): HK<HKF, Tuple9<A, B, C, D, E, F, G, H, Z>> =
+        AP.map(AP.product(this, other), { Tuple9(it.a.a, it.a.b, it.a.c, it.a.d, it.a.e, it.a.f, it.a.g, it.a.h, it.b) })
 
 fun <HKF, A, B, C, D, E, F, G, H, I, Z> HK<HKF, Tuple9<A, B, C, D, E, F, G, H, I>>.product(
         AP: Applicative<HKF>,
@@ -135,7 +159,8 @@ fun <HKF, A, B, C, D, E, F, G, H, I, Z> HK<HKF, Tuple9<A, B, C, D, E, F, G, H, I
         dummyImplicit5: Any? = null,
         dummyImplicit6: Any? = null,
         dummyImplicit7: Any? = null,
-        dummyImplicit9: Any? = null): HK<HKF, Tuple10<A, B, C, D, E, F, G, H, I, Z>> = AP.map(AP.product(this, other), { Tuple10(it.a.a, it.a.b, it.a.c, it.a.d, it.a.e, it.a.f, it.a.g, it.a.h, it.a.i, it.b) })
+        dummyImplicit9: Any? = null): HK<HKF, Tuple10<A, B, C, D, E, F, G, H, I, Z>> =
+        AP.map(AP.product(this, other), { Tuple10(it.a.a, it.a.b, it.a.c, it.a.d, it.a.e, it.a.f, it.a.g, it.a.h, it.a.i, it.b) })
 
 fun <HKF, A, B> Applicative<HKF>.tupled(
         a: HK<HKF, A>,
@@ -165,7 +190,8 @@ fun <HKF, A, B, C, D, E, F> Applicative<HKF>.tupled(
         c: HK<HKF, C>,
         d: HK<HKF, D>,
         e: HK<HKF, E>,
-        f: HK<HKF, F>): HK<HKF, Tuple6<A, B, C, D, E, F>> = a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f)
+        f: HK<HKF, F>): HK<HKF, Tuple6<A, B, C, D, E, F>> =
+        a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f)
 
 fun <HKF, A, B, C, D, E, F, G> Applicative<HKF>.tupled(
         a: HK<HKF, A>,
@@ -174,7 +200,8 @@ fun <HKF, A, B, C, D, E, F, G> Applicative<HKF>.tupled(
         d: HK<HKF, D>,
         e: HK<HKF, E>,
         f: HK<HKF, F>,
-        g: HK<HKF, G>): HK<HKF, Tuple7<A, B, C, D, E, F, G>> = a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g)
+        g: HK<HKF, G>): HK<HKF, Tuple7<A, B, C, D, E, F, G>> =
+        a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g)
 
 fun <HKF, A, B, C, D, E, F, G, H> Applicative<HKF>.tupled(
         a: HK<HKF, A>,
@@ -184,7 +211,8 @@ fun <HKF, A, B, C, D, E, F, G, H> Applicative<HKF>.tupled(
         e: HK<HKF, E>,
         f: HK<HKF, F>,
         g: HK<HKF, G>,
-        h: HK<HKF, H>): HK<HKF, Tuple8<A, B, C, D, E, F, G, H>> = a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g).product(this, h)
+        h: HK<HKF, H>): HK<HKF, Tuple8<A, B, C, D, E, F, G, H>> =
+        a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g).product(this, h)
 
 fun <HKF, A, B, C, D, E, F, G, H, I> Applicative<HKF>.tupled(
         a: HK<HKF, A>,
@@ -195,7 +223,8 @@ fun <HKF, A, B, C, D, E, F, G, H, I> Applicative<HKF>.tupled(
         f: HK<HKF, F>,
         g: HK<HKF, G>,
         h: HK<HKF, H>,
-        i: HK<HKF, I>): HK<HKF, Tuple9<A, B, C, D, E, F, G, H, I>> = a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g).product(this, h).product(this, i)
+        i: HK<HKF, I>): HK<HKF, Tuple9<A, B, C, D, E, F, G, H, I>> =
+        a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g).product(this, h).product(this, i)
 
 fun <HKF, A, B, C, D, E, F, G, H, I, J> Applicative<HKF>.tupled(
         a: HK<HKF, A>,
@@ -207,7 +236,9 @@ fun <HKF, A, B, C, D, E, F, G, H, I, J> Applicative<HKF>.tupled(
         g: HK<HKF, G>,
         h: HK<HKF, H>,
         i: HK<HKF, I>,
-        j: HK<HKF, J>): HK<HKF, Tuple10<A, B, C, D, E, F, G, H, I, J>> = a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g).product(this, h).product(this, i).product(this, j)
+        j: HK<HKF, J>): HK<HKF, Tuple10<A, B, C, D, E, F, G, H, I, J>> =
+        a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g)
+                .product(this, h).product(this, i).product(this, j)
 
 fun <HKF, A, B, Z> Applicative<HKF>.map(
         a: HK<HKF, A>,
@@ -242,7 +273,8 @@ fun <HKF, A, B, C, D, E, F, Z> Applicative<HKF>.map(
         d: HK<HKF, D>,
         e: HK<HKF, E>,
         f: HK<HKF, F>,
-        lbd: (Tuple6<A, B, C, D, E, F>) -> Z): HK<HKF, Z> = this.map(a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f), lbd)
+        lbd: (Tuple6<A, B, C, D, E, F>) -> Z): HK<HKF, Z> =
+        this.map(a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f), lbd)
 
 fun <HKF, A, B, C, D, E, F, G, Z> Applicative<HKF>.map(
         a: HK<HKF, A>,
@@ -252,7 +284,8 @@ fun <HKF, A, B, C, D, E, F, G, Z> Applicative<HKF>.map(
         e: HK<HKF, E>,
         f: HK<HKF, F>,
         g: HK<HKF, G>,
-        lbd: (Tuple7<A, B, C, D, E, F, G>) -> Z): HK<HKF, Z> = this.map(a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g), lbd)
+        lbd: (Tuple7<A, B, C, D, E, F, G>) -> Z): HK<HKF, Z> =
+        this.map(a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g), lbd)
 
 fun <HKF, A, B, C, D, E, F, G, H, Z> Applicative<HKF>.map(
         a: HK<HKF, A>,
@@ -263,7 +296,9 @@ fun <HKF, A, B, C, D, E, F, G, H, Z> Applicative<HKF>.map(
         f: HK<HKF, F>,
         g: HK<HKF, G>,
         h: HK<HKF, H>,
-        lbd: (Tuple8<A, B, C, D, E, F, G, H>) -> Z): HK<HKF, Z> = this.map(a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g).product(this, h), lbd)
+        lbd: (Tuple8<A, B, C, D, E, F, G, H>) -> Z): HK<HKF, Z> =
+        this.map(a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f)
+                .product(this, g).product(this, h), lbd)
 
 fun <HKF, A, B, C, D, E, F, G, H, I, Z> Applicative<HKF>.map(
         a: HK<HKF, A>,
@@ -275,7 +310,9 @@ fun <HKF, A, B, C, D, E, F, G, H, I, Z> Applicative<HKF>.map(
         g: HK<HKF, G>,
         h: HK<HKF, H>,
         i: HK<HKF, I>,
-        lbd: (Tuple9<A, B, C, D, E, F, G, H, I>) -> Z): HK<HKF, Z> = this.map(a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g).product(this, h).product(this, i), lbd)
+        lbd: (Tuple9<A, B, C, D, E, F, G, H, I>) -> Z): HK<HKF, Z> =
+        this.map(a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f)
+                .product(this, g).product(this, h).product(this, i), lbd)
 
 fun <HKF, A, B, C, D, E, F, G, H, I, J, Z> Applicative<HKF>.map(
         a: HK<HKF, A>,
@@ -288,6 +325,7 @@ fun <HKF, A, B, C, D, E, F, G, H, I, J, Z> Applicative<HKF>.map(
         h: HK<HKF, H>,
         i: HK<HKF, I>,
         j: HK<HKF, J>,
-        lbd: (Tuple10<A, B, C, D, E, F, G, H, I, J>) -> Z): HK<HKF, Z> = this.map(a.product(this, b).product(this, c).product(this, d).product(this, e).product(this, f).product(this, g).product(this, h).product(this, i).product(this, j), lbd)
+        lbd: (Tuple10<A, B, C, D, E, F, G, H, I, J>) -> Z): HK<HKF, Z> = this.map(a.product(this, b).product(this, c).product(this, d)
+        .product(this, e).product(this, f).product(this, g).product(this, h).product(this, i).product(this, j), lbd)
 
 inline fun <reified F> applicative(): Applicative<F> = instance(InstanceParametrizedType(Applicative::class.java, listOf(F::class.java)))

--- a/kategory/src/main/kotlin/kategory/typeclasses/ApplicativeError.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/ApplicativeError.kt
@@ -25,7 +25,8 @@ interface ApplicativeError<F, E> : Applicative<F>, Typeclass {
 
 inline fun <reified F, reified E, A> A.raiseError(FT: ApplicativeError<F, E> = applicativeError(), e: E): HK<F, A> = FT.raiseError<A>(e)
 
-inline fun <reified F, reified E, A> HK<F, A>.handlerErrorWith(FT: ApplicativeError<F, E> = applicativeError(), noinline f: (E) -> HK<F, A>): HK<F, A> = FT.handleErrorWith(this, f)
+inline fun <reified F, reified E, A> HK<F, A>.handlerErrorWith(FT: ApplicativeError<F, E> = applicativeError(), noinline f: (E) -> HK<F, A>): HK<F, A> =
+        FT.handleErrorWith(this, f)
 
 inline fun <reified F, reified E, A> HK<F, A>.attempt(FT: ApplicativeError<F, E> = applicativeError()): HK<F, Either<E, A>> = FT.attempt(this)
 
@@ -41,4 +42,5 @@ fun <F, A> ApplicativeError<F, Throwable>.catch(f: () -> A): HK<F, A> =
             raiseError(e)
         }
 
-inline fun <reified F, reified E> applicativeError(): ApplicativeError<F, E> = instance(InstanceParametrizedType(ApplicativeError::class.java, listOf(F::class.java, E::class.java)))
+inline fun <reified F, reified E> applicativeError(): ApplicativeError<F, E> =
+        instance(InstanceParametrizedType(ApplicativeError::class.java, listOf(F::class.java, E::class.java)))

--- a/kategory/src/main/kotlin/kategory/typeclasses/Foldable.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/Foldable.kt
@@ -89,7 +89,8 @@ interface Foldable<in F> : Typeclass {
      * This method is primarily useful when G<_> represents an action or effect, and the specific A aspect of G<A> is
      * not otherwise needed.
      */
-    fun <G, A, B> traverse_(ag: Applicative<G>, fa: HK<F, A>, f: (A) -> HK<G, B>): HK<G, Unit> = foldR(fa, always { ag.pure(Unit) }, { a, acc -> ag.map2Eval(f(a), acc) { Unit } }).value()
+    fun <G, A, B> traverse_(ag: Applicative<G>, fa: HK<F, A>, f: (A) -> HK<G, B>): HK<G, Unit> =
+            foldR(fa, always { ag.pure(Unit) }, { a, acc -> ag.map2Eval(f(a), acc) { Unit } }).value()
 
     /**
      * Sequence F<G<A>> using Applicative<G>.
@@ -141,7 +142,8 @@ interface Foldable<in F> : Typeclass {
  *
  * Similar to foldM, but using a Monoid<B>.
  */
-inline fun <F, reified G, A, reified B> Foldable<F>.foldMapM(fa: HK<F, A>, noinline f: (A) -> HK<G, B>, MG: Monad<G> = monad(), bb: Monoid<B> = monoid()): HK<G, B> = foldM(fa, bb.empty(), { b, a -> MG.map(f(a)) { bb.combine(b, it) } }, MG)
+inline fun <F, reified G, A, reified B> Foldable<F>.foldMapM(fa: HK<F, A>, noinline f: (A) -> HK<G, B>, MG: Monad<G> = monad(), bb: Monoid<B> = monoid()):
+        HK<G, B> = foldM(fa, bb.empty(), { b, a -> MG.map(f(a)) { bb.combine(b, it) } }, MG)
 
 /**
  * Get the element at the index of the Foldable.
@@ -167,7 +169,8 @@ inline fun <F, A> Foldable<F>.get(fa: HK<F, A>, idx: Long): Option<A> {
  * Certain structures are able to implement this in such a way that folds can be short-circuited (not traverse the
  * entirety of the structure), depending on the G result produced at a given step.
  */
-inline fun <F, reified G, A, B> Foldable<F>.foldM(fa: HK<F, A>, z: B, crossinline f: (B, A) -> HK<G, B>, MG: Monad<G> = monad()): HK<G, B> = foldL(fa, MG.pure(z), { gb, a -> MG.flatMap(gb) { f(it, a) } })
+inline fun <F, reified G, A, B> Foldable<F>.foldM(fa: HK<F, A>, z: B, crossinline f: (B, A) -> HK<G, B>, MG: Monad<G> = monad()): HK<G, B> =
+        foldL(fa, MG.pure(z), { gb, a -> MG.flatMap(gb) { f(it, a) } })
 
 inline fun <reified F> foldable(): Foldable<F> = instance(InstanceParametrizedType(Foldable::class.java, listOf(F::class.java)))
 
@@ -189,11 +192,14 @@ inline fun <reified F, reified A> HK<F, A>.fold(FT: Foldable<F> = foldable(), MA
 
 inline fun <reified F, reified A> HK<F, A>.combineAll(FT: Foldable<F> = foldable(), MA: Monoid<A> = monoid()): A = FT.combineAll(MA, this)
 
-inline fun <reified F, A, reified B> HK<F, A>.foldMap(FT: Foldable<F> = foldable(), MB: Monoid<B> = monoid(), noinline f: (A) -> B): B = FT.foldMap(MB, this, f)
+inline fun <reified F, A, reified B> HK<F, A>.foldMap(FT: Foldable<F> = foldable(), MB: Monoid<B> = monoid(), noinline f: (A) -> B): B =
+        FT.foldMap(MB, this, f)
 
-inline fun <reified F, reified G, A, B> HK<F, A>.traverse_(FT: Foldable<F> = foldable(), AG: Applicative<G> = applicative(), noinline f: (A) -> HK<G, B>): HK<G, Unit> = FT.traverse_(AG, this, f)
+inline fun <reified F, reified G, A, B> HK<F, A>.traverse_(FT: Foldable<F> = foldable(), AG: Applicative<G> = applicative(), noinline f: (A) -> HK<G, B>):
+        HK<G, Unit> = FT.traverse_(AG, this, f)
 
-inline fun <reified F, reified G, A> HK<F, HK<G, A>>.sequence_(FT: Foldable<F> = foldable(), AG: Applicative<G> = applicative()): HK<G, Unit> = FT.sequence_(AG, this)
+inline fun <reified F, reified G, A> HK<F, HK<G, A>>.sequence_(FT: Foldable<F> = foldable(), AG: Applicative<G> = applicative()):
+        HK<G, Unit> = FT.sequence_(AG, this)
 
 inline fun <reified F, A> HK<F, A>.find(FT: Foldable<F> = foldable(), noinline f: (A) -> Boolean): Option<A> = FT.find(this, f)
 

--- a/kategory/src/main/kotlin/kategory/typeclasses/MonadError.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/MonadError.kt
@@ -42,4 +42,5 @@ fun <F, B> MonadError<F, Throwable>.bindingE(c: suspend MonadErrorContinuation<F
     return continuation.returnedMonad()
 }
 
-inline fun <reified F, reified E> monadError(): MonadError<F, E> = instance(InstanceParametrizedType(MonadError::class.java, listOf(F::class.java, E::class.java)))
+inline fun <reified F, reified E> monadError(): MonadError<F, E> =
+        instance(InstanceParametrizedType(MonadError::class.java, listOf(F::class.java, E::class.java)))

--- a/kategory/src/main/kotlin/kategory/typeclasses/MonadReader.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/MonadReader.kt
@@ -15,4 +15,5 @@ inline fun <reified F, A, reified D> HK<F, A>.local(FT: MonadReader<F, D> = mona
 
 inline fun <reified F, A, reified D> ((D) -> A).reader(FT: MonadReader<F, D> = monadReader()): HK<F, A> = FT.reader(this)
 
-inline fun <reified F, reified D> monadReader(): MonadReader<F, D> = instance(InstanceParametrizedType(MonadReader::class.java, listOf(F::class.java, D::class.java)))
+inline fun <reified F, reified D> monadReader(): MonadReader<F, D> =
+        instance(InstanceParametrizedType(MonadReader::class.java, listOf(F::class.java, D::class.java)))

--- a/kategory/src/main/kotlin/kategory/typeclasses/MonadState.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/MonadState.kt
@@ -13,4 +13,5 @@ interface MonadState<F, S> : Monad<F>, Typeclass {
     fun <A> inspect(f: (S) -> A): HK<F, A> = map(get(), f)
 }
 
-inline fun <reified F, reified S> monadState(): MonadState<F, S> = instance(InstanceParametrizedType(MonadState::class.java, listOf(F::class.java, S::class.java)))
+inline fun <reified F, reified S> monadState(): MonadState<F, S> =
+        instance(InstanceParametrizedType(MonadState::class.java, listOf(F::class.java, S::class.java)))

--- a/kategory/src/main/kotlin/kategory/typeclasses/Reducible.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/Reducible.kt
@@ -39,7 +39,8 @@ interface Reducible<in F> : Foldable<F>, Typeclass {
      */
     fun <A, B> reduceRightTo(fa: HK<F, A>, f: (A) -> B, g: (A, Eval<B>) -> Eval<B>): Eval<B>
 
-    override fun <A, B> reduceRightToOption(fa: HK<F, A>, f: (A) -> B, g: (A, Eval<B>) -> Eval<B>): Eval<Option<B>> = reduceRightTo(fa, f, g).map({ Option.Some(it) })
+    override fun <A, B> reduceRightToOption(fa: HK<F, A>, f: (A) -> B, g: (A, Eval<B>) -> Eval<B>): Eval<Option<B>> =
+            reduceRightTo(fa, f, g).map({ Option.Some(it) })
 
     fun <A> toNonEmptyList(fa: HK<F, A>): NonEmptyList<A> =
             reduceRightTo(fa, { a -> NonEmptyList.of(a) }, { a, lnel ->
@@ -66,7 +67,8 @@ inline fun <F, reified G, A> Reducible<F>.reduceK(fga: HK<F, HK<G, A>>, SGKG: Se
 /**
  * Apply f to each element of fa and combine them using the given Semigroup<B>.
  */
-inline fun <F, A, reified B> Reducible<F>.reduceMap(fa: HK<F, A>, noinline f: (A) -> B, SB: Semigroup<B> = semigroup()): B = reduceLeftTo(fa, f, { b, a -> SB.combine(b, f(a)) })
+inline fun <F, A, reified B> Reducible<F>.reduceMap(fa: HK<F, A>, noinline f: (A) -> B, SB: Semigroup<B> = semigroup()): B =
+        reduceLeftTo(fa, f, { b, a -> SB.combine(b, f(a)) })
 
 inline fun <reified F> reducible(): Reducible<F> = instance(InstanceParametrizedType(Reducible::class.java, listOf(F::class.java)))
 
@@ -86,7 +88,8 @@ abstract class NonEmptyReducible<F, G> : Reducible<F> {
         return FG().foldL(ga, f(b, a), f)
     }
 
-    override fun <A, B> foldR(fa: HK<F, A>, lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> = Eval.Always({ split(fa) }).flatMap { (a, ga) -> f(a, FG().foldR(ga, lb, f)) }
+    override fun <A, B> foldR(fa: HK<F, A>, lb: Eval<B>, f: (A, Eval<B>) -> Eval<B>): Eval<B> =
+            Eval.Always({ split(fa) }).flatMap { (a, ga) -> f(a, FG().foldR(ga, lb, f)) }
 
     override fun <A, B> reduceLeftTo(fa: HK<F, A>, f: (A) -> B, g: (B, A) -> B): B {
         val (a, ga) = split(fa)

--- a/kategory/src/main/kotlin/kategory/typeclasses/Traverse.kt
+++ b/kategory/src/main/kotlin/kategory/typeclasses/Traverse.kt
@@ -24,7 +24,8 @@ inline fun <reified F, reified G, A, B> HK<F, A>.flatTraverse(
         GA: Applicative<G> = applicative(),
         FM: Monad<F> = monad(), noinline f: (A) -> HK<G, HK<F, B>>): HK<G, HK<F, B>> = GA.map(FT.traverse(this, f, GA), { FM.flatten(it) })
 
-inline fun <reified F, reified G, A, B> Traverse<F>.flatTraverse(fa: HK<F, A>, noinline f: (A) -> HK<G, HK<F, B>>, GA: Applicative<G> = applicative(), FM: Monad<F> = monad()): HK<G, HK<F, B>> = GA.map(traverse(fa, f, GA), { FM.flatten(it) })
+inline fun <reified F, reified G, A, B> Traverse<F>.flatTraverse(fa: HK<F, A>, noinline f: (A) -> HK<G, HK<F, B>>, GA: Applicative<G> =
+applicative(), FM: Monad<F> = monad()): HK<G, HK<F, B>> = GA.map(traverse(fa, f, GA), { FM.flatten(it) })
 
 /**
  * Thread all the G effects through the F structure to invert the structure from F<G<A>> to G<F<A>>.

--- a/reports/baseline.xml
+++ b/reports/baseline.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <SmellBaseline>
-  <Blacklist timestamp="1490879306930"></Blacklist>
-  <Whitelist timestamp="1503248886832">
+  <Blacklist timestamp="1503308049178"></Blacklist>
+  <Whitelist timestamp="1503308097846">
     <ID>LabeledExpression:FunctionK.kt$&lt;no name provided&gt;$this@or</ID>
     <ID>LabeledExpression:PartialFunction.kt$&lt;no name provided&gt;$this@orElse</ID>
     <ID>LabeledExpression:PartialFunction.kt$&lt;no name provided&gt;$this@orElse</ID>
@@ -31,108 +31,5 @@
     <ID>LateinitUsage:Monad.kt$StackSafeMonadContinuation$protected lateinit var returnedMonad: Free&lt;F, A&gt;</ID>
     <ID>UnsafeCallOnNullableType:AndThen.kt$AndThen$failure!!</ID>
     <ID>UnsafeCallOnNullableType:AndThen.kt$AndThen$failure!!</ID>
-    <ID>MaxLineLength:Kleisli.kt$kategory.Kleisli.kt</ID>
-    <ID>MaxLineLength:Composed.kt$kategory.Composed.kt</ID>
-    <ID>MaxLineLength:Composed.kt$kategory.Composed.kt</ID>
-    <ID>MaxLineLength:Composed.kt$kategory.Composed.kt</ID>
-    <ID>MaxLineLength:Composed.kt$kategory.Composed.kt</ID>
-    <ID>MaxLineLength:Composed.kt$kategory.Composed.kt</ID>
-    <ID>MaxLineLength:Composed.kt$kategory.Composed.kt</ID>
-    <ID>MaxLineLength:Composed.kt$kategory.Composed.kt</ID>
-    <ID>MaxLineLength:Composed.kt$kategory.Composed.kt</ID>
-    <ID>MaxLineLength:Composed.kt$kategory.Composed.kt</ID>
-    <ID>MaxLineLength:Composed.kt$kategory.Composed.kt</ID>
-    <ID>MaxLineLength:Coproduct.kt$kategory.Coproduct.kt</ID>
-    <ID>MaxLineLength:Coproduct.kt$kategory.Coproduct.kt</ID>
-    <ID>MaxLineLength:Coproduct.kt$kategory.Coproduct.kt</ID>
-    <ID>MaxLineLength:Coproduct.kt$kategory.Coproduct.kt</ID>
-    <ID>MaxLineLength:Either.kt$kategory.Either.kt</ID>
-    <ID>MaxLineLength:EitherT.kt$kategory.EitherT.kt</ID>
-    <ID>MaxLineLength:EitherT.kt$kategory.EitherT.kt</ID>
-    <ID>MaxLineLength:OptionT.kt$kategory.OptionT.kt</ID>
-    <ID>MaxLineLength:OptionT.kt$kategory.OptionT.kt</ID>
-    <ID>MaxLineLength:OptionT.kt$kategory.OptionT.kt</ID>
-    <ID>MaxLineLength:WriterT.kt$kategory.WriterT.kt</ID>
-    <ID>MaxLineLength:WriterT.kt$kategory.WriterT.kt</ID>
-    <ID>MaxLineLength:WriterT.kt$kategory.WriterT.kt</ID>
-    <ID>MaxLineLength:WriterT.kt$kategory.WriterT.kt</ID>
-    <ID>MaxLineLength:WriterT.kt$kategory.WriterT.kt</ID>
-    <ID>MaxLineLength:WriterT.kt$kategory.WriterT.kt</ID>
-    <ID>MaxLineLength:WriterT.kt$kategory.WriterT.kt</ID>
-    <ID>MaxLineLength:WriterT.kt$kategory.WriterT.kt</ID>
-    <ID>MaxLineLength:WriterT.kt$kategory.WriterT.kt</ID>
-    <ID>MaxLineLength:WriterT.kt$kategory.WriterT.kt</ID>
-    <ID>MaxLineLength:WriterT.kt$kategory.WriterT.kt</ID>
-    <ID>MaxLineLength:WriterT.kt$kategory.WriterT.kt</ID>
-    <ID>MaxLineLength:Free.kt$kategory.Free.kt</ID>
-    <ID>MaxLineLength:FreeApplicative.kt$kategory.FreeApplicative.kt</ID>
-    <ID>MaxLineLength:FreeApplicative.kt$kategory.FreeApplicative.kt</ID>
-    <ID>MaxLineLength:CoproductInstances.kt$kategory.CoproductInstances.kt</ID>
-    <ID>MaxLineLength:EitherInstances.kt$kategory.EitherInstances.kt</ID>
-    <ID>MaxLineLength:EitherTInstances.kt$kategory.EitherTInstances.kt</ID>
-    <ID>MaxLineLength:FreeApplicativeInstances.kt$kategory.FreeApplicativeInstances.kt</ID>
-    <ID>MaxLineLength:FreeApplicativeInstances.kt$kategory.FreeApplicativeInstances.kt</ID>
-    <ID>MaxLineLength:FreeApplicativeInstances.kt$kategory.FreeApplicativeInstances.kt</ID>
-    <ID>MaxLineLength:FreeInstances.kt$kategory.FreeInstances.kt</ID>
-    <ID>MaxLineLength:IorInstances.kt$kategory.IorInstances.kt</ID>
-    <ID>MaxLineLength:IorInstances.kt$kategory.IorInstances.kt</ID>
-    <ID>MaxLineLength:KleisliInstances.kt$kategory.KleisliInstances.kt</ID>
-    <ID>MaxLineLength:KleisliInstances.kt$kategory.KleisliInstances.kt</ID>
-    <ID>MaxLineLength:KleisliInstances.kt$kategory.KleisliInstances.kt</ID>
-    <ID>MaxLineLength:OptionTInstances.kt$kategory.OptionTInstances.kt</ID>
-    <ID>MaxLineLength:StateTInstances.kt$kategory.StateTInstances.kt</ID>
-    <ID>MaxLineLength:StateTInstances.kt$kategory.StateTInstances.kt</ID>
-    <ID>MaxLineLength:StateTInstances.kt$kategory.StateTInstances.kt</ID>
-    <ID>MaxLineLength:StateTInstances.kt$kategory.StateTInstances.kt</ID>
-    <ID>MaxLineLength:StateTInstances.kt$kategory.StateTInstances.kt</ID>
-    <ID>MaxLineLength:TryInstances.kt$kategory.TryInstances.kt</ID>
-    <ID>MaxLineLength:TryInstances.kt$kategory.TryInstances.kt</ID>
-    <ID>MaxLineLength:ValidatedInstances.kt$kategory.ValidatedInstances.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:Applicative.kt$kategory.Applicative.kt</ID>
-    <ID>MaxLineLength:ApplicativeError.kt$kategory.ApplicativeError.kt</ID>
-    <ID>MaxLineLength:ApplicativeError.kt$kategory.ApplicativeError.kt</ID>
-    <ID>MaxLineLength:Foldable.kt$kategory.Foldable.kt</ID>
-    <ID>MaxLineLength:Foldable.kt$kategory.Foldable.kt</ID>
-    <ID>MaxLineLength:Foldable.kt$kategory.Foldable.kt</ID>
-    <ID>MaxLineLength:Foldable.kt$kategory.Foldable.kt</ID>
-    <ID>MaxLineLength:Foldable.kt$kategory.Foldable.kt</ID>
-    <ID>MaxLineLength:Monad.kt$kategory.Monad.kt</ID>
-    <ID>MaxLineLength:Monad.kt$kategory.Monad.kt</ID>
-    <ID>MaxLineLength:Monad.kt$kategory.Monad.kt</ID>
-    <ID>MaxLineLength:MonadError.kt$kategory.MonadError.kt</ID>
-    <ID>MaxLineLength:MonadReader.kt$kategory.MonadReader.kt</ID>
-    <ID>MaxLineLength:MonadState.kt$kategory.MonadState.kt</ID>
-    <ID>MaxLineLength:Reducible.kt$kategory.Reducible.kt</ID>
-    <ID>MaxLineLength:Reducible.kt$kategory.Reducible.kt</ID>
-    <ID>MaxLineLength:Reducible.kt$kategory.Reducible.kt</ID>
-    <ID>MaxLineLength:Traverse.kt$kategory.Traverse.kt</ID>
-    <ID>MaxLineLength:IO.kt$kategory.IO.kt</ID>
-    <ID>MaxLineLength:IO.kt$kategory.IO.kt</ID>
-    <ID>MaxLineLength:IOInstances.kt$kategory.IOInstances.kt</ID>
-    <ID>MaxLineLength:Async.kt$kategory.Async.kt</ID>
-    <ID>MaxLineLength:Async.kt$kategory.Async.kt</ID>
-    <ID>MaxLineLength:Async.kt$kategory.Async.kt</ID>
-    <ID>MaxLineLength:Async.kt$kategory.Async.kt</ID>
   </Whitelist>
 </SmellBaseline>


### PR DESCRIPTION
Fixes #217

* Cleared baseline.
* Disabled  `ExpressionBodySyntaxLineBreaks#active` and `ExpressionBodySyntaxLineBreaks#autoCorrect`.
* Fixed all the `MaxLineLength` errors arised.
* Re-generated baseline.