### PR TITLE
Update kotlin-metadata library from 1.1.0 to 1.2.0

### DIFF
--- a/kategory-annotations-processor/build.gradle
+++ b/kategory-annotations-processor/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlinVersion"
     compile project(':kategory-annotations')
     compile 'com.squareup:kotlinpoet:0.4.0'
-    compile 'me.eugeniomarletti:kotlin-metadata:1.1.0'
+    compile 'me.eugeniomarletti:kotlin-metadata:1.2.0'
     compileOnly 'com.google.auto.service:auto-service:1.0-rc3'
     kapt 'com.google.auto.service:auto-service:1.0-rc3'
 

--- a/kategory-annotations-processor/src/main/java/kategory/common/messager/MessagerExtensions.kt
+++ b/kategory-annotations-processor/src/main/java/kategory/common/messager/MessagerExtensions.kt
@@ -1,6 +1,6 @@
 package kategory.common.messager
 
-import me.eugeniomarletti.kotlin.processing.KotlinProcessingUtils
+import me.eugeniomarletti.kotlin.processing.KotlinProcessingEnvironment
 import javax.lang.model.element.AnnotationMirror
 import javax.lang.model.element.AnnotationValue
 import javax.lang.model.element.Element
@@ -9,25 +9,25 @@ import javax.tools.Diagnostic.Kind.MANDATORY_WARNING
 import javax.tools.Diagnostic.Kind.NOTE
 import javax.tools.Diagnostic.Kind.WARNING
 
-fun KotlinProcessingUtils.log(message: CharSequence,
+fun KotlinProcessingEnvironment.log(message: CharSequence,
     element: Element? = null,
     annotationMirror: AnnotationMirror? = null,
     annotationValue: AnnotationValue? = null
 ) = messager.printMessage(NOTE, message, element, annotationMirror, annotationValue)
 
-fun KotlinProcessingUtils.logW(message: CharSequence,
+fun KotlinProcessingEnvironment.logW(message: CharSequence,
     element: Element? = null,
     annotationMirror: AnnotationMirror? = null,
     annotationValue: AnnotationValue? = null
 ) = messager.printMessage(WARNING, message, element, annotationMirror, annotationValue)
 
-fun KotlinProcessingUtils.logMW(message: CharSequence,
+fun KotlinProcessingEnvironment.logMW(message: CharSequence,
     element: Element? = null,
     annotationMirror: AnnotationMirror? = null,
     annotationValue: AnnotationValue? = null
 ) = messager.printMessage(MANDATORY_WARNING, message, element, annotationMirror, annotationValue)
 
-fun KotlinProcessingUtils.logE(message: CharSequence,
+fun KotlinProcessingEnvironment.logE(message: CharSequence,
     element: Element? = null,
     annotationMirror: AnnotationMirror? = null,
     annotationValue: AnnotationValue? = null

--- a/kategory-annotations-processor/src/main/java/kategory/common/utils/AbstractProcessor.kt
+++ b/kategory-annotations-processor/src/main/java/kategory/common/utils/AbstractProcessor.kt
@@ -5,8 +5,6 @@ import me.eugeniomarletti.kotlin.processing.KotlinAbstractProcessor
 import javax.annotation.processing.RoundEnvironment
 import javax.lang.model.element.Element
 import javax.lang.model.element.TypeElement
-import me.eugeniomarletti.kotlin.metadata.kaptGeneratedOption
-import java.io.File
 
 class KnownException(message: String, val element: Element?) : RuntimeException(message) {
     override val message: String get() = super.message as String
@@ -15,8 +13,6 @@ class KnownException(message: String, val element: Element?) : RuntimeException(
 }
 
 abstract class AbstractProcessor : KotlinAbstractProcessor(), ProcessorUtils {
-
-    val generatedDir: File? get() = options[kaptGeneratedOption]?.let(::File)
 
     override final fun process(annotations: Set<TypeElement>, roundEnv: RoundEnvironment): Boolean {
         if (!roundEnv.errorRaised()) {

--- a/kategory-annotations-processor/src/main/java/kategory/common/utils/ProcessorUtils.kt
+++ b/kategory-annotations-processor/src/main/java/kategory/common/utils/ProcessorUtils.kt
@@ -5,9 +5,11 @@ import me.eugeniomarletti.kotlin.metadata.KotlinClassMetadata
 import me.eugeniomarletti.kotlin.metadata.KotlinMetadata
 import me.eugeniomarletti.kotlin.metadata.KotlinMetadataUtils
 import me.eugeniomarletti.kotlin.metadata.KotlinPackageMetadata
-import me.eugeniomarletti.kotlin.metadata.getJvmMethodSignature
+import me.eugeniomarletti.kotlin.metadata.extractFullName
+import me.eugeniomarletti.kotlin.metadata.getPropertyOrNull
+import me.eugeniomarletti.kotlin.metadata.getValueParameterOrNull
+import me.eugeniomarletti.kotlin.metadata.jvm.getJvmMethodSignature
 import me.eugeniomarletti.kotlin.metadata.kotlinMetadata
-import me.eugeniomarletti.kotlin.metadata.kotlinPropertyAnnotationsFunPostfix
 import org.jetbrains.kotlin.serialization.ProtoBuf
 import javax.lang.model.element.Element
 import javax.lang.model.element.ExecutableElement
@@ -31,22 +33,11 @@ interface ProcessorUtils : KotlinMetadataUtils {
     }
 
     fun ClassOrPackageDataWrapper.getFunction(methodElement: ExecutableElement) =
-        methodElement.jvmMethodSignature.let { methodSignature ->
-            functionList
-                .firstOrNull { methodSignature == it.getJvmMethodSignature(nameResolver) }
-                ?: knownError("Can't find annotated method $methodSignature")
-        }
+        getFunctionOrNull(methodElement, nameResolver, functionList)
+            ?: knownError("Can't find annotated method ${methodElement.jvmMethodSignature}")
 }
 
 fun knownError(message: String, element: Element? = null): Nothing = throw KnownException(message, element)
-
-fun String.plusIfNotBlank(
-    postfix: String = "",
-    prefix: String = ""
-) = if (this.isNotBlank()) prefix + this + postfix else this
-
-val String.escapedClassName
-    get() = split('/', '.').joinToString("`.`").plusIfNotBlank(prefix = "`", postfix = "`")
 
 val ProtoBuf.Class.Kind.isCompanionOrObject get() = when (this) {
     ProtoBuf.Class.Kind.OBJECT,
@@ -55,47 +46,20 @@ val ProtoBuf.Class.Kind.isCompanionOrObject get() = when (this) {
 }
 
 fun ClassOrPackageDataWrapper.getParameter(function: ProtoBuf.Function, parameterElement: VariableElement) =
-    parameterElement.simpleName.toString().let { parameterName ->
-        function.valueParameterList
-            .firstOrNull { parameterName == nameResolver.getString(it.name) }
-            ?: knownError("Can't find annotated parameter $parameterName in ${function.getJvmMethodSignature(nameResolver)}")
-    }
+    getValueParameterOrNull(nameResolver, function, parameterElement)
+        ?: knownError("Can't find annotated parameter ${parameterElement.simpleName} in ${function.getJvmMethodSignature(nameResolver)}")
 
 fun ClassOrPackageDataWrapper.getPropertyOrNull(methodElement: ExecutableElement) =
-    methodElement.simpleName.toString()
-        .takeIf { it.endsWith(kotlinPropertyAnnotationsFunPostfix) }
-        ?.substringBefore(kotlinPropertyAnnotationsFunPostfix)
-        ?.let { propertyName -> propertyList.firstOrNull { propertyName == nameResolver.getString(it.name) } }
+    getPropertyOrNull(methodElement, nameResolver, this::propertyList)
 
 fun ProtoBuf.Type.extractFullName(
     classData: ClassOrPackageDataWrapper,
     outputTypeAlias: Boolean = true,
     failOnGeneric: Boolean = true
-): String {
-    val nameResolver = classData.nameResolver
-
-    if (failOnGeneric && !hasClassName()) knownError("Generic $implicitAnnotationName types are not yet supported")
-
-    val name = when {
-        hasTypeParameter() -> classData.getTypeParameter(typeParameter)!!.name
-        hasTypeParameterName() -> typeParameterName
-        outputTypeAlias && hasAbbreviatedType() -> abbreviatedType.typeAliasName
-        else -> className
-    }.let { nameResolver.getString(it).escapedClassName }
-
-    val argumentList = if (outputTypeAlias && hasAbbreviatedType()) abbreviatedType.argumentList else argumentList
-    val arguments = argumentList
-        .takeIf { it.isNotEmpty() }
-        ?.joinToString(prefix = "<", postfix = ">") {
-            when {
-                it.hasType() -> it.type.extractFullName(classData, outputTypeAlias, failOnGeneric)
-                !failOnGeneric -> "*"
-                else -> knownError("Wildcard $implicitAnnotationName types are not yet supported")
-            }
-        }
-        ?: ""
-
-    val nullability = if (nullable) "?" else ""
-
-    return name + arguments + nullability
-}
+): String =
+    extractFullName(
+        nameResolver = classData.nameResolver,
+        getTypeParameter = { classData.getTypeParameter(it)!! },
+        outputTypeAlias = outputTypeAlias,
+        throwOnGeneric = if (!failOnGeneric) null else KnownException("Generic $implicitAnnotationName types are not yet supported", null)
+    )

--- a/kategory-annotations-processor/src/main/java/kategory/implicits/ImplicitsFileGenerator.kt
+++ b/kategory-annotations-processor/src/main/java/kategory/implicits/ImplicitsFileGenerator.kt
@@ -8,11 +8,11 @@ import kategory.implicits.AnnotatedImplicits.Provider
 import kategory.implicits.AnnotatedImplicits.Provider.Function
 import kategory.implicits.AnnotatedImplicits.Provider.Property
 import kategory.common.utils.ClassOrPackageDataWrapper
-import kategory.common.utils.escapedClassName
 import kategory.common.utils.extractFullName
 import kategory.common.utils.knownError
-import kategory.common.utils.plusIfNotBlank
-import me.eugeniomarletti.kotlin.metadata.getJvmMethodSignature
+import me.eugeniomarletti.kotlin.metadata.escapedClassName
+import me.eugeniomarletti.kotlin.metadata.jvm.getJvmMethodSignature
+import me.eugeniomarletti.kotlin.metadata.plusIfNotBlank
 import org.jetbrains.kotlin.serialization.ProtoBuf
 import org.jetbrains.kotlin.serialization.deserialization.NameResolver
 import java.io.File


### PR DESCRIPTION
I'm preparing to finally release the `kotlin-metadata` library so I renamed a few things and moved some utils form kategory to the library, which simplifies the code a bit.

I hope I didn't break anything!