### PR TITLE
Optional optic

### DIFF
--- a/kategory-optics/src/main/kotlin/kategory/optics/Iso.kt
+++ b/kategory-optics/src/main/kotlin/kategory/optics/Iso.kt
@@ -157,4 +157,12 @@ abstract class Iso<A, B> {
      * View a [Iso] as a [Lens]
      */
     fun asLens(): Lens<A, B> = Lens(this::get, this::set)
+
+    /**
+     * View a [Iso] as a [Optional]
+     */
+    fun asOptional(): Optional<A, B> = Optional(
+            { a -> Option.Some(get(a)) },
+            this::set
+    )
 }

--- a/kategory-optics/src/main/kotlin/kategory/optics/Lens.kt
+++ b/kategory-optics/src/main/kotlin/kategory/optics/Lens.kt
@@ -105,6 +105,10 @@ abstract class Lens<A, B> {
             { c -> { a -> set(l.set(c)(get(a)))(a) } }
     )
 
+    /** compose a [Lens] with a [Optional] */
+    infix fun <C> composeOptional(other: Optional<B, C>): Optional<A, C> =
+            asOptional() composeOptional other
+
     /** compose an [Iso] as an [Prism] */
     fun <C> composeIso(other: Iso<B, C>): Lens<A, C> =
             composeLens(other.asLens())
@@ -115,5 +119,13 @@ abstract class Lens<A, B> {
     operator fun <C> plus(other: Lens<B, C>): Lens<A, C> = composeLens(other)
 
     operator fun <C> plus(other: Iso<B, C>): Lens<A, C> = composeIso(other)
+
+    /**
+     * View a [Lens] as an [Optional]
+     */
+    fun asOptional(): Optional<A, B> = Optional(
+            { a -> Option.Some(get(a)) },
+            this::set
+    )
 
 }

--- a/kategory-optics/src/main/kotlin/kategory/optics/Lens.kt
+++ b/kategory-optics/src/main/kotlin/kategory/optics/Lens.kt
@@ -29,6 +29,9 @@ abstract class Lens<A, B> {
 
         fun <A> id() = Iso.id<A>().asLens()
 
+        /**
+         * [Lens] that takes either A or A and strips the choice of A.
+         */
         fun <A> codiagonal() = Lens<Either<A, A>, A>(
                 get = { it.fold(::identity, ::identity) },
                 set = { a -> { it.bimap({ a }, { a }) } }
@@ -117,6 +120,8 @@ abstract class Lens<A, B> {
      * plus operator overload to compose lenses
      */
     operator fun <C> plus(other: Lens<B, C>): Lens<A, C> = composeLens(other)
+
+    operator fun <C> plus(other: Optional<B, C>): Optional<A, C> = composeOptional(other)
 
     operator fun <C> plus(other: Iso<B, C>): Lens<A, C> = composeIso(other)
 

--- a/kategory-optics/src/main/kotlin/kategory/optics/Optional.kt
+++ b/kategory-optics/src/main/kotlin/kategory/optics/Optional.kt
@@ -1,0 +1,129 @@
+package kategory.optics
+
+import kategory.Applicative
+import kategory.Either
+import kategory.HK
+import kategory.Option
+import kategory.Tuple2
+import kategory.compose
+import kategory.identity
+import kategory.none
+import kategory.some
+import kategory.toT
+
+/**
+ * A [Optional] can be seen as a pair of functions `getOption: (A) -> Option<B>` and `set: (B) -> (A) -> A`
+ *
+ * An [Optional] can also be defined as a weaker [Lens] and [Prism]
+ *
+ * @param A the source of a [Optional]
+ * @param B the target of a [Optional]
+ * @property getOption from an `A` we can extract a `Option<B?`
+ * @property set replace the target value by `B` in an `A` so we obtain another modified `A`
+ * @constructor Creates a Lens of type `A` with target `B`.
+ */
+abstract class Optional<A, B> {
+
+    /** get the target of a [Optional] or nothing if there is no target */
+    abstract fun getOption(a: A): Option<B>
+
+    /** get the modified source of a [Optional] */
+    abstract fun set(b: B): (A) -> (A)
+
+    companion object {
+        operator fun <A, B> invoke(getOption: (A) -> Option<B>, set: (B) -> (A) -> (A)) = object : Optional<A, B>() {
+            override fun getOption(a: A): Option<B> = getOption(a)
+
+            override fun set(b: B): (A) -> A = set(b)
+        }
+
+        fun <A, B> void() = Optional<A, B>(
+                { none() },
+                { _ -> { b -> identity(b) } }
+        )
+
+    }
+
+    /** get the target of a [Optional] or return the original value while allowing the type to change if it does not match */
+    fun getOrModify(a: A): Either<A, B> = getOption(a).fold({ Either.Left(a) }, { Either.Right(it) })
+
+    /** check if there is no target */
+    fun isEmpty(a: A): Boolean = !getOption(a).nonEmpty
+
+    /** check if there is a target */
+    fun nonEmpty(a: A): Boolean = getOption(a).nonEmpty
+
+    /** find if the target satisfies the predicate */
+    fun find(p: (B) -> Boolean): (A) -> Option<B> =
+            { a -> getOption(a).flatMap { b -> if (p(b)) b.some() else none() } }
+
+    /** check if there is a target and it satisfies the predicate */
+    fun exists(p: (B) -> Boolean): (A) -> Boolean =
+            { a -> getOption(a).fold({ false }, p) }
+
+    /** check if there is no target or the target satisfies the predicate */
+    fun all(p: (B) -> Boolean): (A) -> Boolean =
+            { a -> getOption(a).fold({ true }, p) }
+
+    /** join two [Optional] with the same target */
+    fun <C> choice(other: Optional<C, B>): Optional<Either<A, C>, B> =
+            Optional(
+                    { a -> a.fold(this::getOption, other::getOption) },
+                    { b -> { it.bimap(this.set(b), other.set(b)) } }
+            )
+
+    fun <C> first(): Optional<Tuple2<A, C>, Tuple2<B, C>> =
+            Optional(
+                    { (a, c) -> getOption(a).map { it toT c } },
+                    { (b, c) -> { (a, c2) -> setOption(b)(a).fold({ set(b)(a) toT c2 }, { it toT c }) } }
+            )
+
+    fun <C> second(): Optional<Tuple2<C, A>, Tuple2<C, B>> =
+            Optional(
+                    { (c, a) -> getOption(a).map { c toT it } },
+                    { (c, b) -> { (c2, a) -> setOption(b)(a).fold({ c2 toT set(b)(a) }, { c toT it }) } }
+            )
+
+    /** modify polymorphically the target of a [Optional] with a function */
+    inline fun modify(crossinline f: (B) -> B): (A) -> A = { a -> getOption(a).fold({ a }, { set(f(it))(a) }) }
+
+    /** modify polymorphically the target of a [Optional] with an Applicative function */
+    inline fun <reified F> modifyF(FA: Applicative<F> = kategory.applicative(), crossinline f: (B) -> HK<F, B>, a: A): HK<F, A> =
+            getOrModify(a).fold(
+                    { FA.pure(it) },
+                    { FA.map(f(it), { set(it)(a) }) }
+            )
+
+    /**
+     * modify polymorphically the target of a [Optional] with a function.
+     * return empty if the [Optional] is not matching
+     */
+    fun modifiyOption(f: (B) -> B): (A) -> Option<A> = { a -> getOption(a).map({ set(f(it))(a) }) }
+
+    /**
+     * set polymorphically the target of a [Optional] with a value.
+     * return empty if the [Optional] is not matching
+     */
+    fun setOption(b: B): (A) -> Option<A> = modifiyOption { b }
+
+    /** compose a [Optional] with a [Optional] */
+    infix fun <C> composeOptional(other: Optional<B, C>): Optional<A, C> = Optional(
+            { a -> getOption(a).flatMap(other::getOption) },
+            this::modify compose other::set
+    )
+
+    /** compose a [Optional] with a [Prism] */
+    infix fun <C> composePrism(other: Prism<B, C>): Optional<A, C> = composeOptional(other.asOptional())
+
+    /** compose a [Optional] with a [Lens] */
+    infix fun <C> composeLens(other: Lens<B, C>): Optional<A, C> = composeOptional(other.asOptional())
+
+    /**
+     * Plus operator overload to compose optionals
+     */
+    operator fun <C> plus(o: Optional<B, C>): Optional<A, C> = composeOptional(o)
+
+    operator fun <C> plus(o: Prism<B, C>): Optional<A, C> = composePrism(o)
+
+    operator fun <C> plus(o: Lens<B, C>): Optional<A, C> = composeLens(o)
+}

--- a/kategory-optics/src/main/kotlin/kategory/optics/Optional.kt
+++ b/kategory-optics/src/main/kotlin/kategory/optics/Optional.kt
@@ -94,12 +94,12 @@ abstract class Optional<A, B> {
     /**
      * Check if there is no target
      */
-    fun isEmpty(a: A): Boolean = !getOption(a).nonEmpty
+    fun isEmpty(a: A): Boolean = !nonEmpty(a)
 
     /**
      * Check if there is a target
      */
-    fun nonEmpty(a: A): Boolean = getOption(a).nonEmpty
+    fun nonEmpty(a: A): Boolean = getOption(a).fold({ false }, { true })
 
     /**
      * Find if the target satisfies the predicate [p]

--- a/kategory-optics/src/main/kotlin/kategory/optics/Optional.kt
+++ b/kategory-optics/src/main/kotlin/kategory/optics/Optional.kt
@@ -8,6 +8,7 @@ import kategory.Tuple2
 import kategory.compose
 import kategory.identity
 import kategory.none
+import kategory.right
 import kategory.some
 import kategory.toT
 
@@ -18,19 +19,34 @@ import kategory.toT
  *
  * @param A the source of a [Optional]
  * @param B the target of a [Optional]
- * @property getOption from an `A` we can extract a `Option<B?`
+ * @property getOption from an `A` we can extract a `Option<B>`
  * @property set replace the target value by `B` in an `A` so we obtain another modified `A`
  * @constructor Creates a Lens of type `A` with target `B`.
  */
 abstract class Optional<A, B> {
 
-    /** get the target of a [Optional] or nothing if there is no target */
+    /**
+     * Get the target of a [Optional] or [Option.None] if there is no target
+     */
     abstract fun getOption(a: A): Option<B>
 
-    /** get the modified source of a [Optional] */
+    /**
+     * Get the modified source of a [Optional]
+     */
     abstract fun set(b: B): (A) -> (A)
 
     companion object {
+
+        fun <A> id() = Iso.id<A>().asOptional()
+
+        /**
+         * [Optional] that takes either A or A and strips the choice of A.
+         */
+        fun <A> codiagonal() = Optional<Either<A, A>, A>(
+                getOption = { aa -> aa.fold({ a -> a.right() }, { a -> a.right() }).toOption() },
+                set = { a -> { aa -> aa.bimap({ a }, { a }) } }
+        )
+
         operator fun <A, B> invoke(getOption: (A) -> Option<B>, set: (B) -> (A) -> (A)) = object : Optional<A, B>() {
             override fun getOption(a: A): Option<B> = getOption(a)
 
@@ -39,72 +55,96 @@ abstract class Optional<A, B> {
 
         fun <A, B> void() = Optional<A, B>(
                 { none() },
-                { _ -> { b -> identity(b) } }
+                { _ -> ::identity }
         )
 
     }
 
-    /** get the target of a [Optional] or return the original value while allowing the type to change if it does not match */
+    /**
+     * Get the target of a [Optional] or return the original value while allowing the type to change if it does not match
+     */
     fun getOrModify(a: A): Either<A, B> = getOption(a).fold({ Either.Left(a) }, { Either.Right(it) })
 
-    /** check if there is no target */
+    /**
+     * Modify polymorphically the target of a [Optional] with a function [f]
+     */
+    inline fun modify(crossinline f: (B) -> B): (A) -> A = { a -> getOption(a).fold({ a }, { set(f(it))(a) }) }
+
+    /**
+     * Modify polymorphically the target of a [Optional] with an Applicative function [f]
+     */
+    inline fun <reified F> modifyF(FA: Applicative<F> = kategory.applicative(), crossinline f: (B) -> HK<F, B>, a: A): HK<F, A> =
+            getOrModify(a).fold(
+                    FA::pure,
+                    { FA.map(f(it), { set(it)(a) }) }
+            )
+
+    /**
+     * Modify polymorphically the target of a [Optional] with a function [f]
+     * @return [Option.None] if the [Optional] is not matching
+     */
+    fun modifiyOption(f: (B) -> B): (A) -> Option<A> = { a -> getOption(a).map({ set(f(it))(a) }) }
+
+    /**
+     * Set polymorphically the target of a [Optional] with a value.
+     * @return [Option.None] if the [Optional] is not matching
+     */
+    fun setOption(b: B): (A) -> Option<A> = modifiyOption { b }
+
+    /**
+     * Check if there is no target
+     */
     fun isEmpty(a: A): Boolean = !getOption(a).nonEmpty
 
-    /** check if there is a target */
+    /**
+     * Check if there is a target
+     */
     fun nonEmpty(a: A): Boolean = getOption(a).nonEmpty
 
-    /** find if the target satisfies the predicate */
+    /**
+     * Find if the target satisfies the predicate [p]
+     */
     fun find(p: (B) -> Boolean): (A) -> Option<B> =
             { a -> getOption(a).flatMap { b -> if (p(b)) b.some() else none() } }
 
-    /** check if there is a target and it satisfies the predicate */
+    /**
+     * Check if there is a target and it satisfies the predicate [p]
+     */
     fun exists(p: (B) -> Boolean): (A) -> Boolean =
             { a -> getOption(a).fold({ false }, p) }
 
-    /** check if there is no target or the target satisfies the predicate */
+    /**
+     * check if there is no target or the target satisfies the predicate [p]
+     */
     fun all(p: (B) -> Boolean): (A) -> Boolean =
             { a -> getOption(a).fold({ true }, p) }
 
-    /** join two [Optional] with the same target */
+    /**
+     * join two [Optional] with the same target [B]
+     */
     fun <C> choice(other: Optional<C, B>): Optional<Either<A, C>, B> =
             Optional(
                     { a -> a.fold(this::getOption, other::getOption) },
                     { b -> { it.bimap(this.set(b), other.set(b)) } }
             )
 
+    /**
+     * Create a product of the target and a type [C]
+     */
     fun <C> first(): Optional<Tuple2<A, C>, Tuple2<B, C>> =
             Optional(
                     { (a, c) -> getOption(a).map { it toT c } },
                     { (b, c) -> { (a, c2) -> setOption(b)(a).fold({ set(b)(a) toT c2 }, { it toT c }) } }
             )
 
+    /**
+     * Create a product of a type [C] and the target
+     */
     fun <C> second(): Optional<Tuple2<C, A>, Tuple2<C, B>> =
             Optional(
                     { (c, a) -> getOption(a).map { c toT it } },
                     { (c, b) -> { (c2, a) -> setOption(b)(a).fold({ c2 toT set(b)(a) }, { c toT it }) } }
             )
-
-    /** modify polymorphically the target of a [Optional] with a function */
-    inline fun modify(crossinline f: (B) -> B): (A) -> A = { a -> getOption(a).fold({ a }, { set(f(it))(a) }) }
-
-    /** modify polymorphically the target of a [Optional] with an Applicative function */
-    inline fun <reified F> modifyF(FA: Applicative<F> = kategory.applicative(), crossinline f: (B) -> HK<F, B>, a: A): HK<F, A> =
-            getOrModify(a).fold(
-                    { FA.pure(it) },
-                    { FA.map(f(it), { set(it)(a) }) }
-            )
-
-    /**
-     * modify polymorphically the target of a [Optional] with a function.
-     * return empty if the [Optional] is not matching
-     */
-    fun modifiyOption(f: (B) -> B): (A) -> Option<A> = { a -> getOption(a).map({ set(f(it))(a) }) }
-
-    /**
-     * set polymorphically the target of a [Optional] with a value.
-     * return empty if the [Optional] is not matching
-     */
-    fun setOption(b: B): (A) -> Option<A> = modifiyOption { b }
 
     /** compose a [Optional] with a [Optional] */
     infix fun <C> composeOptional(other: Optional<B, C>): Optional<A, C> = Optional(
@@ -112,10 +152,14 @@ abstract class Optional<A, B> {
             this::modify compose other::set
     )
 
-    /** compose a [Optional] with a [Prism] */
+    /**
+     * Compose a [Optional] with a [Prism]
+     */
     infix fun <C> composePrism(other: Prism<B, C>): Optional<A, C> = composeOptional(other.asOptional())
 
-    /** compose a [Optional] with a [Lens] */
+    /**
+     * Compose a [Optional] with a [Lens]
+     */
     infix fun <C> composeLens(other: Lens<B, C>): Optional<A, C> = composeOptional(other.asOptional())
 
     /**

--- a/kategory-optics/src/main/kotlin/kategory/optics/Prism.kt
+++ b/kategory-optics/src/main/kotlin/kategory/optics/Prism.kt
@@ -142,6 +142,18 @@ abstract class Prism<A, B> {
             composePrism(other.asPrism())
 
     /**
+     * View a [Prism] as an [Optional]
+     */
+    fun asOptional(): Optional<A, B> = Optional(
+            this::getOption,
+            this::set
+    )
+
+    /** compose a [Prism] with a [Optional] */
+    infix fun <C> composeOptional(other: Optional<B, C>): Optional<A, C> =
+            asOptional() composeOptional other
+
+    /**
      * Plus operator overload to compose lenses
      */
     operator fun <C> plus(other: Prism<B, C>): Prism<A, C> = composePrism(other)

--- a/kategory-optics/src/main/kotlin/kategory/optics/Prism.kt
+++ b/kategory-optics/src/main/kotlin/kategory/optics/Prism.kt
@@ -149,7 +149,9 @@ abstract class Prism<A, B> {
             this::set
     )
 
-    /** compose a [Prism] with a [Optional] */
+    /**
+     * Compose a [Prism] with a [Optional]
+     */
     infix fun <C> composeOptional(other: Optional<B, C>): Optional<A, C> =
             asOptional() composeOptional other
 
@@ -157,6 +159,8 @@ abstract class Prism<A, B> {
      * Plus operator overload to compose lenses
      */
     operator fun <C> plus(other: Prism<B, C>): Prism<A, C> = composePrism(other)
+
+    operator fun <C> plus(other: Optional<B, C>): Optional<A, C> = composeOptional(other)
 
     operator fun <C> plus(other: Iso<B, C>): Prism<A, C> = composeIso(other)
 

--- a/kategory-optics/src/test/kotlin/kategory/optics/IsoTest.kt
+++ b/kategory-optics/src/test/kotlin/kategory/optics/IsoTest.kt
@@ -3,7 +3,18 @@ package kategory.optics
 import io.kotlintest.KTestJUnitRunner
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
-import kategory.*
+import kategory.Either
+import kategory.Eq
+import kategory.IsoLaws
+import kategory.LensLaws
+import kategory.NonEmptyList
+import kategory.Option
+import kategory.PrismLaws
+import kategory.StringMonoidInstance
+import kategory.UnitSpec
+import kategory.applicative
+import kategory.genFunctionAToB
+import kategory.toT
 import org.junit.runner.RunWith
 
 @RunWith(KTestJUnitRunner::class)
@@ -24,7 +35,7 @@ class IsoTest : UnitSpec() {
                         funcGen = genFunctionAToB(Gen.string()),
                         EQA = Eq.any(),
                         EQB = Eq.any(),
-                        FA = Try.applicative()
+                        FA = NonEmptyList.applicative()
                 ) + PrismLaws.laws(
                         prism = aIso.asPrism(),
                         aGen = AGen,

--- a/kategory-optics/src/test/kotlin/kategory/optics/LensTest.kt
+++ b/kategory-optics/src/test/kotlin/kategory/optics/LensTest.kt
@@ -5,13 +5,11 @@ import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
 import kategory.Eq
 import kategory.LensLaws
-import kategory.NonEmptyList
 import kategory.Option
 import kategory.Try
 import kategory.Tuple2
 import kategory.UnitSpec
 import kategory.applicative
-import kategory.genEither
 import kategory.genFunctionAToB
 import kategory.left
 import kategory.right
@@ -39,14 +37,6 @@ class LensTest : UnitSpec() {
                         EQA = Eq.any(),
                         EQB = Eq.any(),
                         FA = Try.applicative()
-                ) + LensLaws.laws(
-                        lens = Lens.codiagonal(),
-                        aGen = genEither(Gen.string(), Gen.string()),
-                        bGen = Gen.string(),
-                        funcGen = genFunctionAToB(Gen.string()),
-                        EQA = Eq.any(),
-                        EQB = Eq.any(),
-                        FA = NonEmptyList.applicative()
                 )
         )
 

--- a/kategory-optics/src/test/kotlin/kategory/optics/LensTest.kt
+++ b/kategory-optics/src/test/kotlin/kategory/optics/LensTest.kt
@@ -5,11 +5,13 @@ import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll
 import kategory.Eq
 import kategory.LensLaws
+import kategory.NonEmptyList
 import kategory.Option
 import kategory.Try
 import kategory.Tuple2
 import kategory.UnitSpec
 import kategory.applicative
+import kategory.genEither
 import kategory.genFunctionAToB
 import kategory.left
 import kategory.right
@@ -37,6 +39,14 @@ class LensTest : UnitSpec() {
                         EQA = Eq.any(),
                         EQB = Eq.any(),
                         FA = Try.applicative()
+                ) + LensLaws.laws(
+                        lens = Lens.codiagonal(),
+                        aGen = genEither(Gen.string(), Gen.string()),
+                        bGen = Gen.string(),
+                        funcGen = genFunctionAToB(Gen.string()),
+                        EQA = Eq.any(),
+                        EQB = Eq.any(),
+                        FA = NonEmptyList.applicative()
                 )
         )
 

--- a/kategory-optics/src/test/kotlin/kategory/optics/OptionalTest.kt
+++ b/kategory-optics/src/test/kotlin/kategory/optics/OptionalTest.kt
@@ -2,11 +2,15 @@ package kategory.optics
 
 import io.kotlintest.KTestJUnitRunner
 import io.kotlintest.properties.Gen
+import io.kotlintest.properties.forAll
 import kategory.Eq
+import kategory.Option
 import kategory.OptionalLaws
 import kategory.UnitSpec
-import kategory.genEither
 import kategory.genFunctionAToB
+import kategory.genTuple
+import kategory.left
+import kategory.right
 import org.junit.runner.RunWith
 
 @RunWith(KTestJUnitRunner::class)
@@ -29,8 +33,72 @@ class OptionalTest : UnitSpec() {
                         funcGen = genFunctionAToB(Gen.int()),
                         EQA = Eq.any(),
                         EQB = Eq.any()
+                ) + OptionalLaws.laws(
+                        optional = optionalHead.first(),
+                        aGen = genTuple(Gen.list(Gen.int()), Gen.bool()),
+                        bGen = genTuple(Gen.int(), Gen.bool()),
+                        funcGen = genFunctionAToB(genTuple(Gen.int(), Gen.bool())),
+                        EQA = Eq.any(),
+                        EQB = Eq.any()
+                ) + OptionalLaws.laws(
+                        optional = optionalHead.second(),
+                        aGen = genTuple(Gen.bool(), Gen.list(Gen.int())),
+                        bGen = genTuple(Gen.bool(), Gen.int()),
+                        funcGen = genFunctionAToB(genTuple(Gen.bool(), Gen.int())),
+                        EQA = Eq.any(),
+                        EQB = Eq.any()
                 )
         )
+
+        "void should always " {
+            forAll({ string: String ->
+                Optional.void<String, Int>().getOption(string) == Option.None
+            })
+        }
+
+        "void should always return source when setting target" {
+            forAll({ int: Int, string: String ->
+                Optional.void<String, Int>().set(int)(string) == string
+            })
+        }
+
+        "Checking if there is no target" {
+            forAll(Gen.list(Gen.int()), { list ->
+                optionalHead.nonEmpty(list) == list.isNotEmpty()
+            })
+        }
+
+        "Checking if a target exists" {
+            forAll(Gen.list(Gen.int()), { list ->
+                optionalHead.isEmpty(list) == list.isEmpty()
+            })
+        }
+
+        "Finding a target using a predicate should be wrapped in the correct option result" {
+            forAll(Gen.list(Gen.int()), Gen.bool(), { list, predicate ->
+                optionalHead.find { predicate }(list).isDefined == predicate
+            })
+        }
+
+        "Checking existence predicate over the target should result in same result as predicate" {
+            forAll(Gen.list(Gen.int()), Gen.bool(), { list, predicate ->
+                optionalHead.exists { predicate }(list) == predicate
+            })
+        }
+
+        "Checking satisfaction of predicate over the target should result in opposite result as predicate" {
+            forAll(Gen.list(Gen.int()), Gen.bool(), { list, predicate ->
+                optionalHead.all { predicate }(list) == predicate
+            })
+        }
+
+        "Joining two optionals together with same target should yield same result" {
+            val joinedOptional = optionalHead.choice(defaultHead)
+
+            forAll(Gen.int(), { int ->
+                joinedOptional.getOption(listOf(int).left()) == joinedOptional.getOption(int.right())
+            })
+        }
 
     }
 

--- a/kategory-optics/src/test/kotlin/kategory/optics/OptionalTest.kt
+++ b/kategory-optics/src/test/kotlin/kategory/optics/OptionalTest.kt
@@ -76,7 +76,7 @@ class OptionalTest : UnitSpec() {
 
         "Finding a target using a predicate should be wrapped in the correct option result" {
             forAll(Gen.list(Gen.int()), Gen.bool(), { list, predicate ->
-                optionalHead.find { predicate }(list).isDefined == predicate
+                optionalHead.find { predicate }(list).fold({ false }, { true }) == predicate
             })
         }
 

--- a/kategory-optics/src/test/kotlin/kategory/optics/OptionalTest.kt
+++ b/kategory-optics/src/test/kotlin/kategory/optics/OptionalTest.kt
@@ -1,0 +1,37 @@
+package kategory.optics
+
+import io.kotlintest.KTestJUnitRunner
+import io.kotlintest.properties.Gen
+import kategory.Eq
+import kategory.OptionalLaws
+import kategory.UnitSpec
+import kategory.genEither
+import kategory.genFunctionAToB
+import org.junit.runner.RunWith
+
+@RunWith(KTestJUnitRunner::class)
+class OptionalTest : UnitSpec() {
+
+    init {
+
+        testLaws(
+                OptionalLaws.laws(
+                        optional = optionalHead,
+                        aGen = Gen.list(Gen.int()),
+                        bGen = Gen.int(),
+                        funcGen = genFunctionAToB(Gen.int()),
+                        EQA = Eq.any(),
+                        EQB = Eq.any()
+                ) + OptionalLaws.laws(
+                        optional = Optional.id(),
+                        aGen = Gen.int(),
+                        bGen = Gen.int(),
+                        funcGen = genFunctionAToB(Gen.int()),
+                        EQA = Eq.any(),
+                        EQB = Eq.any()
+                )
+        )
+
+    }
+
+}

--- a/kategory-optics/src/test/kotlin/kategory/optics/TestDomain.kt
+++ b/kategory-optics/src/test/kotlin/kategory/optics/TestDomain.kt
@@ -1,6 +1,7 @@
 package kategory.optics
 
 import io.kotlintest.properties.Gen
+import kategory.Option
 import kategory.left
 import kategory.right
 
@@ -60,4 +61,9 @@ internal object UserGen : Gen<User> {
 internal val userLens: Lens<User, Token> = Lens(
         { user: User -> user.token },
         { token: Token -> { user: User -> user.copy(token = token) } }
+)
+
+internal val optionalHead = Optional<List<Int>, Int>(
+        { Option.fromNullable(it.firstOrNull()) },
+        { int -> { list -> listOf(int) + if (list.size > 1) list.drop(1) else emptyList() } }
 )

--- a/kategory-optics/src/test/kotlin/kategory/optics/TestDomain.kt
+++ b/kategory-optics/src/test/kotlin/kategory/optics/TestDomain.kt
@@ -2,8 +2,10 @@ package kategory.optics
 
 import io.kotlintest.properties.Gen
 import kategory.Option
+import kategory.identity
 import kategory.left
 import kategory.right
+import kategory.some
 
 sealed class SumType {
     data class A(val string: String) : SumType()
@@ -66,4 +68,9 @@ internal val userLens: Lens<User, Token> = Lens(
 internal val optionalHead = Optional<List<Int>, Int>(
         { Option.fromNullable(it.firstOrNull()) },
         { int -> { list -> listOf(int) + if (list.size > 1) list.drop(1) else emptyList() } }
+)
+
+internal val defaultHead = Optional<Int, Int>(
+        { it.some() },
+        { ::identity }
 )

--- a/kategory-test/src/main/kotlin/kategory/laws/OptionalLaws.kt
+++ b/kategory-test/src/main/kotlin/kategory/laws/OptionalLaws.kt
@@ -1,0 +1,98 @@
+package kategory
+
+import io.kotlintest.properties.Gen
+import io.kotlintest.properties.forAll
+import kategory.optics.Optional
+
+object OptionalLaws {
+
+    inline fun <reified A, reified B> laws(optional: Optional<A, B>, aGen: Gen<A>, bGen: Gen<B>, funcGen: Gen<(B) -> B>, EQA: Eq<A>, EQB: Eq<B>): List<Law> = listOf(
+            Law("Optional Law: set what you get", { getOptionSet(optional, aGen, EQA) }),
+            Law("Optional Law: get what you get", { getGetOption(optional, aGen, bGen, EQB) }),
+            Law("Optional Law: set is idempotent", { setIdempotent(optional, aGen, bGen, EQA) }),
+            Law("Optional Law: modify identity = identity", { modifyIdentity(optional, aGen, EQA) }),
+            Law("Optional Law: compose modify", { composeModify(optional, aGen, funcGen, EQA) }),
+            Law("Optional Law: consistent set with modify", { consistentSetModify(optional, aGen, bGen, EQA) }),
+            Law("Optional Law: consistent modify with modify identity", { consistentModifyModifyId(optional, aGen, funcGen, EQA) }),
+            Law("Optional Law: consistent getOption with modify identity", { consistentGetOptionModifyId(optional, aGen, EQB) })
+    )
+
+    fun <A, B> getOptionSet(optional: Optional<A, B>, aGen: Gen<A>, EQA: Eq<A>): Unit =
+            forAll(aGen, { a ->
+                EQA.eqv(
+                        optional.getOrModify(a).fold(::identity, { optional.set(it)(a) }),
+                        a
+                )
+            })
+
+    fun <A, B> getGetOption(optional: Optional<A, B>, aGen: Gen<A>, bGen: Gen<B>, EQB: Eq<B>): Unit =
+            forAll(aGen, bGen, { a, b ->
+                optional.getOption(optional.set(b)(a)).exists { EQB.eqv(it, b) }
+            })
+
+    fun <A, B> setIdempotent(optional: Optional<A, B>, aGen: Gen<A>, bGen: Gen<B>, EQA: Eq<A>): Unit =
+            forAll(aGen, bGen, { a, b ->
+                EQA.eqv(
+                        optional.set(b)(optional.set(b)(a)),
+                        optional.set(b)(a)
+                )
+            })
+
+    fun <A, B> modifyIdentity(optional: Optional<A, B>, aGen: Gen<A>, EQA: Eq<A>): Unit =
+            forAll(aGen, { a ->
+                EQA.eqv(
+                        optional.modify(::identity)(a),
+                        a
+                )
+            })
+
+
+    fun <A, B> composeModify(optional: Optional<A, B>, aGen: Gen<A>, funcGen: Gen<(B) -> B>, EQA: Eq<A>): Unit =
+            forAll(aGen, funcGen, funcGen, { a, f, g ->
+                EQA.eqv(
+                        optional.modify(g)(optional.modify(f)(a)),
+                        optional.modify(g compose f)(a)
+                )
+            })
+
+    fun <A, B> consistentSetModify(optional: Optional<A, B>, aGen: Gen<A>, bGen: Gen<B>, EQA: Eq<A>): Unit =
+            forAll(aGen, bGen, { a, b ->
+                EQA.eqv(
+                        optional.set(b)(a),
+                        optional.modify { b }(a)
+                )
+            })
+
+    fun <A, B> consistentModifyModifyId(optional: Optional<A, B>, aGen: Gen<A>, funcGen: Gen<(B) -> B>, EQA: Eq<A>): Unit =
+            forAll(aGen, funcGen, { a, f ->
+                EQA.eqv(
+                        optional.modify(f)(a),
+                        optional.modifyF(Id.applicative(), { Id.pure(f(it)) }, a).value()
+                )
+            })
+
+    inline fun <reified A, B> consistentGetOptionModifyId(optional: Optional<A, B>, aGen: Gen<A>, EQB: Eq<B>): Unit =
+            forAll(aGen, { a ->
+                val getOption = optional.getOption(a)
+
+                val modifyFId = optional.modifyF(Const.applicative(firstOptionMonoid<B>()), { b ->
+                    Const(FirstOption(b.some()))
+                }, a).value().option
+
+                getOption.exists { b ->
+                    modifyFId.exists {
+                        EQB.eqv(b, it)
+                    }
+                }
+            })
+
+    @PublishedApi internal data class FirstOption<A>(val option: Option<A>)
+
+    @PublishedApi internal fun <A> firstOptionMonoid() = object : Monoid<FirstOption<A>> {
+        override fun empty(): FirstOption<A> = FirstOption(Option.None)
+
+        override fun combine(a: FirstOption<A>, b: FirstOption<A>): FirstOption<A> =
+                if (a.option.isDefined) a else b
+    }
+
+}

--- a/kategory-test/src/main/kotlin/kategory/laws/OptionalLaws.kt
+++ b/kategory-test/src/main/kotlin/kategory/laws/OptionalLaws.kt
@@ -17,61 +17,45 @@ object OptionalLaws {
             Law("Optional Law: consistent getOption with modify identity", { consistentGetOptionModifyId(optional, aGen, EQB) })
     )
 
-    fun <A, B> getOptionSet(optional: Optional<A, B>, aGen: Gen<A>, EQA: Eq<A>): Unit =
+    inline fun <reified A, reified B> getOptionSet(optional: Optional<A, B>, aGen: Gen<A>, EQA: Eq<A>): Unit =
             forAll(aGen, { a ->
-                EQA.eqv(
-                        optional.getOrModify(a).fold(::identity, { optional.set(it)(a) }),
-                        a
-                )
+                optional.getOrModify(a).fold(::identity, { optional.set(it)(a) }).equalUnderTheLaw(a, EQA)
             })
 
-    fun <A, B> getGetOption(optional: Optional<A, B>, aGen: Gen<A>, bGen: Gen<B>, EQB: Eq<B>): Unit =
+    inline fun <reified A, reified B> getGetOption(optional: Optional<A, B>, aGen: Gen<A>, bGen: Gen<B>, EQB: Eq<B>): Unit =
             forAll(aGen, bGen, { a, b ->
-                optional.getOption(optional.set(b)(a)).exists { EQB.eqv(it, b) }
+                optional.getOption(optional.set(b)(a)).exists {
+                    it.equalUnderTheLaw(b, EQB)
+                }
             })
 
-    fun <A, B> setIdempotent(optional: Optional<A, B>, aGen: Gen<A>, bGen: Gen<B>, EQA: Eq<A>): Unit =
+    inline fun <reified A, reified B> setIdempotent(optional: Optional<A, B>, aGen: Gen<A>, bGen: Gen<B>, EQA: Eq<A>): Unit =
             forAll(aGen, bGen, { a, b ->
-                EQA.eqv(
-                        optional.set(b)(optional.set(b)(a)),
-                        optional.set(b)(a)
-                )
+                optional.set(b)(optional.set(b)(a)).equalUnderTheLaw(optional.set(b)(a), EQA)
             })
 
-    fun <A, B> modifyIdentity(optional: Optional<A, B>, aGen: Gen<A>, EQA: Eq<A>): Unit =
+    inline fun <reified A, reified B> modifyIdentity(optional: Optional<A, B>, aGen: Gen<A>, EQA: Eq<A>): Unit =
             forAll(aGen, { a ->
-                EQA.eqv(
-                        optional.modify(::identity)(a),
-                        a
-                )
+                optional.modify(::identity)(a).equalUnderTheLaw(a, EQA)
             })
 
 
-    fun <A, B> composeModify(optional: Optional<A, B>, aGen: Gen<A>, funcGen: Gen<(B) -> B>, EQA: Eq<A>): Unit =
+    inline fun <reified A, reified B> composeModify(optional: Optional<A, B>, aGen: Gen<A>, funcGen: Gen<(B) -> B>, EQA: Eq<A>): Unit =
             forAll(aGen, funcGen, funcGen, { a, f, g ->
-                EQA.eqv(
-                        optional.modify(g)(optional.modify(f)(a)),
-                        optional.modify(g compose f)(a)
-                )
+                optional.modify(g)(optional.modify(f)(a)).equalUnderTheLaw(optional.modify(g compose f)(a), EQA)
             })
 
-    fun <A, B> consistentSetModify(optional: Optional<A, B>, aGen: Gen<A>, bGen: Gen<B>, EQA: Eq<A>): Unit =
+    inline fun <reified A, reified B> consistentSetModify(optional: Optional<A, B>, aGen: Gen<A>, bGen: Gen<B>, EQA: Eq<A>): Unit =
             forAll(aGen, bGen, { a, b ->
-                EQA.eqv(
-                        optional.set(b)(a),
-                        optional.modify { b }(a)
-                )
+                optional.set(b)(a).equalUnderTheLaw(optional.modify { b }(a), EQA)
             })
 
-    fun <A, B> consistentModifyModifyId(optional: Optional<A, B>, aGen: Gen<A>, funcGen: Gen<(B) -> B>, EQA: Eq<A>): Unit =
+    inline fun <reified A, reified B> consistentModifyModifyId(optional: Optional<A, B>, aGen: Gen<A>, funcGen: Gen<(B) -> B>, EQA: Eq<A>): Unit =
             forAll(aGen, funcGen, { a, f ->
-                EQA.eqv(
-                        optional.modify(f)(a),
-                        optional.modifyF(Id.applicative(), { Id.pure(f(it)) }, a).value()
-                )
+                optional.modify(f)(a).equalUnderTheLaw(optional.modifyF(Id.applicative(), { Id.pure(f(it)) }, a).value(), EQA)
             })
 
-    inline fun <reified A, B> consistentGetOptionModifyId(optional: Optional<A, B>, aGen: Gen<A>, EQB: Eq<B>): Unit =
+    inline fun <reified A, reified B> consistentGetOptionModifyId(optional: Optional<A, B>, aGen: Gen<A>, EQB: Eq<B>): Unit =
             forAll(aGen, { a ->
                 val getOption = optional.getOption(a)
 
@@ -81,7 +65,7 @@ object OptionalLaws {
 
                 getOption.exists { b ->
                     modifyFId.exists {
-                        EQB.eqv(b, it)
+                        it.equalUnderTheLaw(b, EQB)
                     }
                 }
             })
@@ -92,7 +76,7 @@ object OptionalLaws {
         override fun empty(): FirstOption<A> = FirstOption(Option.None)
 
         override fun combine(a: FirstOption<A>, b: FirstOption<A>): FirstOption<A> =
-                if (a.option.isDefined) a else b
+                if (a.option.fold({ false }, { true })) a else b
     }
 
 }

--- a/kategory-test/src/main/kotlin/kategory/laws/PrismLaws.kt
+++ b/kategory-test/src/main/kotlin/kategory/laws/PrismLaws.kt
@@ -6,7 +6,7 @@ import kategory.optics.Prism
 
 object PrismLaws {
 
-    inline fun <A, B, reified F> laws(prism: Prism<A, B>, aGen: Gen<A>, bGen: Gen<B>, funcGen: Gen<(B) -> B>, EQA: Eq<A>, EQB: Eq<B>, FA: Applicative<F>): List<Law> = listOf(
+    inline fun <reified A, reified B, reified F> laws(prism: Prism<A, B>, aGen: Gen<A>, bGen: Gen<B>, funcGen: Gen<(B) -> B>, EQA: Eq<A>, EQB: Eq<B>, FA: Applicative<F>): List<Law> = listOf(
             Law("Prism law: partial round trip one way", { partialRoundTripOneWay(prism, aGen, EQA) }),
             Law("Prism law: round trip other way", { roundTripOtherWay(prism, bGen, EQB) }),
             Law("Prism law: modify identity", { modifyIdentity(prism, aGen, EQA) }),
@@ -15,34 +15,40 @@ object PrismLaws {
             Law("Prism law: consistent get option modify id", { consistentGetOptionModifyId(prism, aGen, FA, EQB) })
     )
 
-    fun <A, B> partialRoundTripOneWay(prism: Prism<A, B>, aGen: Gen<A>, EQA: Eq<A>): Unit =
+    inline fun <reified A, reified B> partialRoundTripOneWay(prism: Prism<A, B>, aGen: Gen<A>, EQA: Eq<A>): Unit =
             forAll(aGen, { a ->
-                EQA.eqv(prism.getOrModify(a).fold(::identity, prism::reverseGet), a)
+                prism.getOrModify(a).fold(::identity, prism::reverseGet).equalUnderTheLaw(a, EQA)
             })
 
-    fun <A, B> roundTripOtherWay(prism: Prism<A, B>, bGen: Gen<B>, EQB: Eq<B>): Unit =
+    inline fun <reified A, reified B> roundTripOtherWay(prism: Prism<A, B>, bGen: Gen<B>, EQB: Eq<B>): Unit =
             forAll(bGen, { b ->
-                prism.getOption(prism.reverseGet(b)).exists { EQB.eqv(it, b) }
+                prism.getOption(prism.reverseGet(b)).exists {
+                    it.equalUnderTheLaw(b, EQB)
+                }
             })
 
-    fun <A, B> modifyIdentity(prism: Prism<A, B>, aGen: Gen<A>, EQA: Eq<A>): Unit =
+    inline fun <reified A, reified B> modifyIdentity(prism: Prism<A, B>, aGen: Gen<A>, EQA: Eq<A>): Unit =
             forAll(aGen, { a ->
-                EQA.eqv(prism.modify(::identity)(a), a)
+                prism.modify(::identity)(a).equalUnderTheLaw(a, EQA)
             })
 
-    fun <A, B> composeModify(prism: Prism<A, B>, aGen: Gen<A>, funcGen: Gen<(B) -> B>, EQA: Eq<A>): Unit =
+    inline fun <reified A, reified B> composeModify(prism: Prism<A, B>, aGen: Gen<A>, funcGen: Gen<(B) -> B>, EQA: Eq<A>): Unit =
             forAll(aGen, funcGen, funcGen, { a, f, g ->
-                EQA.eqv(prism.modify(g)(prism.modify(f)(a)), prism.modify(g compose f)(a))
+                prism.modify(g)(prism.modify(f)(a)).equalUnderTheLaw(prism.modify(g compose f)(a), EQA)
             })
 
-    fun <A, B> consistentSetModify(prism: Prism<A, B>, aGen: Gen<A>, bGen: Gen<B>, EQA: Eq<A>): Unit =
+    inline fun <reified A, reified B> consistentSetModify(prism: Prism<A, B>, aGen: Gen<A>, bGen: Gen<B>, EQA: Eq<A>): Unit =
             forAll(aGen, bGen, { a, b ->
-                EQA.eqv(prism.set(b)(a), prism.modify { b }(a))
+                prism.set(b)(a).equalUnderTheLaw(prism.modify { b }(a), EQA)
             })
 
-    inline fun <A, B, reified F> consistentGetOptionModifyId(prism: Prism<A, B>, aGen: Gen<A>, FA: Applicative<F>, EQB: Eq<B>): Unit =
+    inline fun <reified A, reified B, reified F> consistentGetOptionModifyId(prism: Prism<A, B>, aGen: Gen<A>, FA: Applicative<F>, EQB: Eq<B>): Unit =
             forAll(aGen, { a ->
-                prism.modifyF(FA, { FA.pure(it) }, a).exists { prism.getOption(it).exists { b -> prism.getOption(a).exists { EQB.eqv(b, it) } } }
+                prism.modifyF(FA, { FA.pure(it) }, a).exists {
+                    prism.getOption(it).exists { b ->
+                        prism.getOption(a).exists { it.equalUnderTheLaw(b, EQB) }
+                    }
+                }
             })
 
 }


### PR DESCRIPTION
In OptionalLaws I made an non-reusable First tag. This could be replaced with a type tagging in Kategory. You don't get the same nice syntax as in Scala `Option<A> @@  First` but an type alias could always close the gap if required. Thoughts?

```
data class Tagged<A, T>(val value: A) : ReadOnlyProperty<Any?, A> {

    /**
     * Auto unwrapping by delegation
     */
    override fun getValue(thisRef: Any?, property: KProperty<*>): A = value

}

fun <A, T> A.tag(): Tagged<A, T> = Tagged(this)

sealed class UserToken

data class User(val name: String, val token: Tagged<String, UserToken>)

fun main(args: Array<String>) {


    val taggedString: Tagged<String, UserToken> = "someUserToken".tag()
    println("I was manually unwrapped: ${taggedString.value}")

    val string by taggedString
    println("I was auto unwrapped: $string")

    val user = User("John", taggedString)
    println("I can only be created with a UserToken tagged string: $user")

}
```