### PR TITLE
Release 0.3.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,7 @@ subprojects { project ->
     bintray {
         user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
         key = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey') : System.getenv('BINTRAY_API_KEY')
+        override = project.hasProperty('bintrayOverride') ? project.property('bintrayOverride') : false
         configurations = ['archives']
         pkg {
             repo = 'maven'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Package definitions
 GROUP=io.kategory
-VERSION_NAME=0.3.6-SNAPSHOT
+VERSION_NAME=0.3.6
 
 # Gradle options
 org.gradle.jvmargs=-Xmx2048m

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Package definitions
 GROUP=io.kategory
-VERSION_NAME=0.3.6
+VERSION_NAME=0.3.7-SNAPSHOT
 
 # Gradle options
 org.gradle.jvmargs=-Xmx2048m


### PR DESCRIPTION
PRs included:

#251 Optics module with initial lens impl [by @nomisRev]
#110 Add katz-rx module
#226 Add MonadFilter [by @JorgeCastilloPrz]
#234 Improve Jobs [by @pakoito]
#236 Add ApplicativeError laws [by @pakoito]
#237 Recursion schemes [by @pakoito]
#238 MonadError instance for Option
#239 Release version 0.3.5 [by @Guardiola31337, @pakoito]
#241 Add wrapper and instances for Sequence [by @pt2121, @pakoito]
#242 Add MonadFilter [by @JorgeCastilloPrz]
#247 Add wrapper class for Set [by @victorg1991, @pakoito]
#248 Add MonadCombine [by @JorgeCastilloPrz]
#249 Add Alternative [by @JorgeCastilloPrz]
#250 Remove dependency on kotlinx.coroutines for effects [by @pakoito]
#191 `kategory-docs` module and proposed layout including `Functor` and `Applicative` [by @raulraja]
#256 Add Alternative [by @JorgeCastilloPrz]
#257 Add Bifoldable [by @JorgeCastilloPrz]
#258 Initial prism impl [by @nomisRev, @raulraja]
#259 Bring `kategory-annotations` to the `kategory` repo [by @raulraja]
#260 Add all possible implicit objects to manual instances
#261 Add Alternative, Bifoldable, and MonadCombine [by @JorgeCastilloPrz, @raulraja]
#262 Move SetKW files to the correct folder [by @victorg1991, @pakoito]
#263 Update kotlin-metadata library from 1.1.0 to 1.2.0 [by @Takhion, @raulraja]
#264 Typeclasses implicit objects [by @raulraja]
#266 Alias for applicative builders for Try and other evaluation-based datatypes [by @anstaendig, @pakoito]
#267 Prism processor [by @nomisRev]
#270 Iso and iso generation [by @nomisRev]
#273 Add lacking laws test for monadCombine ListKW instance [by @JorgeCastilloPrz, @raulraja]
#278 #266: Alias constructors for applicative builders for Try, Eval, IO [by @anstaendig, @pakoito]
