### PR TITLE
Release version 0.3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add the dependency into project `build.gradle`
 
 ```groovy
 dependencies {
-    compile 'io.kategory:kategory:0.3.5'
+    compile 'io.kategory:kategory:0.3.8'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ subprojects { project ->
     apply plugin: 'kotlin'
     apply plugin: 'jacoco'
 
-    archivesBaseName = project.name
+    archivesBaseName = POM_ARTIFACT_ID
 
     jacoco {
         toolVersion '0.7.8'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Package definitions
 GROUP=io.kategory
-VERSION_NAME=0.3.6-SNAPSHOT
+VERSION_NAME=0.3.9-SNAPSHOT
 
 # Gradle options
 org.gradle.jvmargs=-Xmx2048m


### PR DESCRIPTION
- `kategory` version `0.3.8` is now available in jcenter 🎉
- Bumps version numbers to `0.3.9-SNAPSHOT`
- Fixes the `archivesBaseName` so it takes the `POM_ARTIFACT_ID` instead of the `project.name` fixing the artifact naming not working properly in `gradle-bintray-plugin` when releasing
- Makes obsolete https://github.com/kategory/kategory/pull/279
- Still remains adding some patchnotes to the release https://github.com/kategory/kategory/releases/tag/0.3.8 👀 https://github.com/kategory/kategory/pull/279

👀 @JorgeCastilloPrz @wiyarmir @pakoito @raulraja 