### PR TITLE
Add ReaderT extension functions to forward to Kleisli using IdHK

### DIFF
--- a/kategory-core/src/main/kotlin/kategory/data/Reader.kt
+++ b/kategory-core/src/main/kotlin/kategory/data/Reader.kt
@@ -8,6 +8,20 @@ fun <D, A> ((D) -> A).reader(): ReaderT<IdHK, D, A> = Reader(this)
 
 fun <D, A> ReaderT<IdHK, D, A>.runId(d: D): A = this.run(d).value()
 
+fun <D, A, B> ReaderT<IdHK, D, A>.map(f: (A) -> B): ReaderT<IdHK, D, B> = map(f, Id.functor())
+
+fun <D, A, B> ReaderT<IdHK, D, A>.flatMap(f: (A) -> ReaderT<IdHK, D, B>): ReaderT<IdHK, D, B> = flatMap(f, Id.monad())
+
+fun <D, A, B> ReaderT<IdHK, D, A>.ap(ff: KleisliKind<IdHK, D, (A) -> B>): ReaderT<IdHK, D, B> = ap(ff, Id.applicative())
+
+fun <D, A, B> ReaderT<IdHK, D, A>.zip(o: ReaderT<IdHK, D, B>): ReaderT<IdHK, D, Tuple2<A, B>> = zip(o, Id.monad())
+
+fun <D, A, C> ReaderT<IdHK, D, A>.andThen(f: ReaderT<IdHK, A, C>): ReaderT<IdHK, D, C> = andThen(f, Id.monad())
+
+fun <D, A, B> ReaderT<IdHK, D, A>.andThen(f: (A) -> HK<IdHK, B>): ReaderT<IdHK, D, B> = andThen(f, Id.monad())
+
+fun <D, A, B> ReaderT<IdHK, D, A>.andThen(a: HK<IdHK, B>): ReaderT<IdHK, D, B> = andThen(a, Id.monad())
+
 object Reader {
 
     operator fun <D, A> invoke(run: (D) -> A): ReaderT<IdHK, D, A> = Kleisli(run.andThen { Id(it) })

--- a/kategory-core/src/test/kotlin/kategory/data/ReaderTest.kt
+++ b/kategory-core/src/test/kotlin/kategory/data/ReaderTest.kt
@@ -11,8 +11,17 @@ class ReaderTest : UnitSpec() {
             Reader<Int, Int> ({ it -> it * 2 }).map ({ it -> it * 3 }, Id.applicative()).runId(2) shouldBe 12
         }
 
+        "map should be callable without explicit functor instance" {
+            Reader<Int, Int> ({ it -> it * 2 }).map ({ it -> it * 3 }).runId(2) shouldBe 12
+        }
+
         "flatMap should map over the inner value" {
             Reader<Int, Int> ({ it -> it * 2 }).flatMap({ a -> Reader.pure<Int, Int>(a * 3) }, Id.monad())
+                    .run(2).value() shouldBe 12
+        }
+
+        "flatMap should be callable without explicit monad instance" {
+            Reader<Int, Int> ({ it -> it * 2 }).flatMap({ a -> Reader.pure<Int, Int>(a * 3) })
                     .run(2).value() shouldBe 12
         }
 
@@ -20,6 +29,12 @@ class ReaderTest : UnitSpec() {
             val r1 = Reader<Int, Int> ({ it -> it * 2 })
             val r2 = Reader<Int, Int> ({ it -> it * 3 })
             r1.zip(r2, Id.monad()).run(2).value() shouldBe Tuple2(4, 6)
+        }
+
+        "zip should be callable without explicit monad instance" {
+            val r1 = Reader<Int, Int> ({ it -> it * 2 })
+            val r2 = Reader<Int, Int> ({ it -> it * 3 })
+            r1.zip(r2).run(2).value() shouldBe Tuple2(4, 6)
         }
 
         "local should switch context to be able to combine Readers with different contexts" {


### PR DESCRIPTION
The new way we have to pass monads / functors / applicatives etc to HKs is by function call and not as class properties is causing me some issues on trying to call `map` , `flatMap` etc methods over the `Reader`. The problems is that I can't call those methods without passing explicit instances of `functor`, `monad` etc.

[Here you can have a look at the problem](https://github.com/JorgeCastilloPrz/KotlinAndroidFunctional/blob/master/nested-monads/src/main/java/com/github/jorgecastillo/kotlinandroid/presentation/SuperHeroesPresentation.kt#L43)

Since the `Reader` is just an alias for `Kleisli<IdHK, D, A>`, I added some utility methods to the aliased type just when F is `IdHK`.

