### PR TITLE
Fold optic

### DIFF
--- a/kategory-optics/src/main/kotlin/kategory/optics/Fold.kt
+++ b/kategory-optics/src/main/kotlin/kategory/optics/Fold.kt
@@ -1,0 +1,201 @@
+package kategory.optics
+
+import kategory.Const
+import kategory.Either
+import kategory.Foldable
+import kategory.HK
+import kategory.IntMonoid
+import kategory.ListKW
+import kategory.Monoid
+import kategory.Option
+import kategory.foldable
+import kategory.identity
+import kategory.left
+import kategory.monoid
+import kategory.none
+import kategory.right
+import kategory.some
+
+/**
+ * A [Fold] is an optic that allows to see into structure and get multiple results.
+ *
+ * [Fold] is a generalisation of [kategory.Foldable] and can be seen as a representation of foldMap,
+ * forall methods are defined in terms of foldMap.
+ *
+ * @param S the source of a [Fold]
+ * @param A the target of a [Fold]
+ */
+abstract class Fold<S, A> {
+
+    /**
+     * Map each target to a type R and use a Monoid to fold the results
+     */
+    abstract fun <R> foldMap(M: Monoid<R>, s: S, f: (A) -> R): R
+
+    inline fun <reified R> foldMap(s: S, noinline f: (A) -> R): R = foldMap(monoid(), s, f)
+
+    companion object {
+
+        fun <A> id() = Iso.id<A>().asFold()
+
+        /**
+         * [Fold] that takes either S or S and strips the choice of A.
+         */
+        inline fun <reified S> codiagonal() = object : Fold<Either<S, S>, S>() {
+            override fun <R> foldMap(M: Monoid<R>, s: Either<S, S>, f: (S) -> R): R = s.fold(f, f)
+        }
+
+        /**
+         * Creates a [Fold] based on a predicate of the source [S]
+         */
+        fun <S> select(p: (S) -> Boolean): Fold<S, S> = object : Fold<S, S>() {
+            override fun <R> foldMap(M: Monoid<R>, s: S, f: (S) -> R): R = if (p(s)) f(s) else M.empty()
+        }
+
+        /**
+         * [Fold] that points to nothing
+         */
+        fun <A, B> void() = Optional.void<A, B>().asFold()
+
+        /**
+         * Create a [Fold] from a [kategory.Foldable]
+         */
+        inline fun <reified F, S> fromFoldable(Foldable: Foldable<F> = foldable()) = object : Fold<HK<F, S>, S>() {
+            override fun <R> foldMap(M: Monoid<R>, s: HK<F, S>, f: (S) -> R): R = Foldable.foldMap(M, s, f)
+        }
+
+    }
+
+    /**
+     * Calculate the number of targets
+     */
+    fun length(s: S) = foldMap(IntMonoid, s = s, f = { _ -> 1 })
+
+    /**
+     * Find the first target matching the predicate
+     */
+    inline fun find(s: S, crossinline p: (A) -> Boolean): Option<A> =
+            foldMap(firstOptionMonoid<A>(), s, { b -> (if (p(b)) Const(b.some()) else Const(none())) }).value
+
+    /**
+     * Get the first target
+     */
+    fun headOption(s: S): Option<A> = foldMap(firstOptionMonoid<A>(), s, { b -> Const(b.some()) }).value
+
+    /**
+     * Get the last target
+     */
+    fun lastOption(s: S): Option<A> = foldMap(lastOptionMonoid<A>(), s, { b -> Const(b.some()) }).value
+
+    /**
+     * Check if forall targets satisfy the predicate
+     */
+    fun forall(s: S, p: (A) -> Boolean): Boolean = foldMap(addMonoid, s, p)
+
+    /**
+     * Check if there is no target
+     */
+    fun isEmpty(s: S): Boolean = foldMap(addMonoid, s, { _ -> false })
+
+    /**
+     * Check if there is at least one target
+     */
+    fun nonEmpty(s: S): Boolean = !isEmpty(s)
+
+    /**
+     * Join two [Fold] with the same target
+     */
+    fun <C> choice(other: Fold<C, A>): Fold<Either<S, C>, A> = object : Fold<Either<S, C>, A>() {
+        override fun <R> foldMap(M: Monoid<R>, s: Either<S, C>, f: (A) -> R): R =
+                s.fold({ ac -> this@Fold.foldMap(M, ac, f) }, { c -> other.foldMap(M, c, f) })
+    }
+
+    fun <C> left(): Fold<Either<S, C>, Either<A, C>> = object : Fold<Either<S, C>, Either<A, C>>() {
+        override fun <R> foldMap(M: Monoid<R>, s: Either<S, C>, f: (Either<A, C>) -> R): R =
+                s.fold({ a1: S -> this@Fold.foldMap(M, a1, { b -> f(b.left()) }) }, { c -> f(c.right()) })
+    }
+
+    fun <C> right(): Fold<Either<C, S>, Either<C, A>> = object : Fold<Either<C, S>, Either<C, A>>() {
+        override fun <R> foldMap(M: Monoid<R>, s: Either<C, S>, f: (Either<C, A>) -> R): R =
+                s.fold({ c -> f(c.left()) }, { a1 -> this@Fold.foldMap(M, a1, { b -> f(b.right()) }) })
+    }
+
+    /**
+     * Compose a [Fold] with a [Fold]
+     */
+    infix fun <C> composeFold(other: Fold<A, C>): Fold<S, C> = object : Fold<S, C>() {
+        override fun <R> foldMap(M: Monoid<R>, s: S, f: (C) -> R): R =
+                this@Fold.foldMap(M, s, { c -> other.foldMap(M, c, f) })
+    }
+
+    /**
+     * Compose a [Fold] with a [Getter]
+     */
+    infix fun <C> composeGetter(other: Getter<A, C>): Fold<S, C> = composeFold(other.asFold())
+
+    /**
+     * Compose a [Fold] with a [Optional]
+     */
+    infix fun <C> composeOptional(other: Optional<A, C>): Fold<S, C> = composeFold(other.asFold())
+
+    /**
+     * Compose a [[Fold]] with a [Prism]
+     */
+    infix fun <C> composePrism(other: Prism<A, C>): Fold<S, C> = composeFold(other.asFold())
+
+    /**
+     * Compose a [Fold] with a [Lens]
+     */
+    infix fun <C> composeLens(other: Lens<A, C>): Fold<S, C> = composeFold(other.asFold())
+
+    /**
+     * Compose a [Fold] with a [Iso]
+     */
+    infix fun <C> composeIso(other: Iso<A, C>): Fold<S, C> = composeFold(other.asFold())
+
+    /**
+     * Plus operator  overload to compose lenses
+     */
+    operator fun <C> plus(other: Fold<A, C>): Fold<S, C> = composeFold(other)
+
+    operator fun <C> plus(other: Optional<A, C>): Fold<S, C> = composeOptional(other)
+
+    operator fun <C> plus(other: Getter<A, C>): Fold<S, C> = composeGetter(other)
+
+    operator fun <C> plus(other: Prism<A, C>): Fold<S, C> = composePrism(other)
+
+    operator fun <C> plus(other: Lens<A, C>): Fold<S, C> = composeLens(other)
+
+    operator fun <C> plus(other: Iso<A, C>): Fold<S, C> = composeIso(other)
+}
+
+inline fun <A, reified B> Fold<A, B>.fold(M: Monoid<B> = monoid(), a: A): B = foldMap(M, a, ::identity)
+
+inline fun <A, reified B> Fold<A, B>.getAll(M: Monoid<ListKW<B>> = monoid(), a: A): ListKW<B> = foldMap(M, a, { ListKW.pure(it) })
+
+internal val addMonoid = object : Monoid<Boolean> {
+    override fun combine(a: Boolean, b: Boolean): Boolean = a && b
+
+    override fun empty(): Boolean = true
+}
+
+internal sealed class First
+internal sealed class Last
+
+@PublishedApi internal fun <A> firstOptionMonoid() = object : Monoid<Const<Option<A>, First>> {
+
+    override fun empty() = Const<Option<A>, First>(Option.None)
+
+    override fun combine(a: Const<Option<A>, First>, b: Const<Option<A>, First>) =
+            if (a.value.fold({ false }, { true })) a else b
+
+}
+
+internal fun <A> lastOptionMonoid() = object : Monoid<Const<Option<A>, Last>> {
+
+    override fun empty() = Const<Option<A>, Last>(Option.None)
+
+    override fun combine(a: Const<Option<A>, Last>, b: Const<Option<A>, Last>) =
+            if (b.value.fold({ false }, { true })) b else a
+
+}

--- a/kategory-optics/src/main/kotlin/kategory/optics/Getter.kt
+++ b/kategory-optics/src/main/kotlin/kategory/optics/Getter.kt
@@ -1,6 +1,7 @@
 package kategory.optics
 
 import kategory.Either
+import kategory.Monoid
 import kategory.Option
 import kategory.Tuple2
 import kategory.compose
@@ -36,8 +37,8 @@ abstract class Getter<A, B> {
      * Find if the target satisfies the predicate.
      */
     inline fun find(a: A, crossinline p: (B) -> Boolean): Option<B> = get(a).let { b ->
-            if (p(b)) b.some() else none()
-        }
+        if (p(b)) b.some() else none()
+    }
 
     /**
      * Check if the target satisfies the predicate
@@ -100,6 +101,10 @@ abstract class Getter<A, B> {
 
     operator fun <C> plus(other: Lens<B,C>): Getter<A, C> = composeLens(other)
 
-    operator fun <C> plus(other: Iso<B,C>): Getter<A, C> = composeIso(other)
+    operator fun <C> plus(other: Iso<B, C>): Getter<A, C> = composeIso(other)
+
+    fun asFold(): Fold<A, B> = object : Fold<A, B>() {
+        override fun <R> foldMap(M: Monoid<R>, s: A, f: (B) -> R): R = f(get(s))
+    }
 
 }

--- a/kategory-optics/src/main/kotlin/kategory/optics/Iso.kt
+++ b/kategory-optics/src/main/kotlin/kategory/optics/Iso.kt
@@ -3,6 +3,7 @@ package kategory.optics
 import kategory.Either
 import kategory.Functor
 import kategory.HK
+import kategory.Monoid
 import kategory.Option
 import kategory.Tuple2
 import kategory.compose
@@ -204,4 +205,11 @@ abstract class PIso<S, T, A, B> {
      * View a [PIso] as a [PSetter]
      */
     fun asSetter(): PSetter<S, T, A, B> = PSetter { f -> { s -> modify(s, f) } }
+
+    /**
+     * View a [PIso] as a [Fold]
+     */
+    fun asFold(): Fold<S, A> = object : Fold<S, A>() {
+        override fun <R> foldMap(M: Monoid<R>, s: S, f: (A) -> R): R = f(get(s))
+    }
 }

--- a/kategory-optics/src/main/kotlin/kategory/optics/Lens.kt
+++ b/kategory-optics/src/main/kotlin/kategory/optics/Lens.kt
@@ -3,6 +3,7 @@ package kategory.optics
 import kategory.Either
 import kategory.Functor
 import kategory.HK
+import kategory.Monoid
 import kategory.Option
 import kategory.Tuple2
 import kategory.functor
@@ -170,5 +171,12 @@ abstract class PLens<S, T, A, B> {
      * View a [PLens] as a [PSetter]
      */
     fun asSetter(): PSetter<S, T, A, B> = PSetter { f -> { s -> modify(s, f) } }
+
+    /**
+     * View a [PLens] as a [Fold]
+     */
+    fun asFold(): Fold<S, A> = object : Fold<S, A>() {
+        override fun <R> foldMap(M: Monoid<R>, s: S, f: (A) -> R): R = f(get(s))
+    }
 
 }

--- a/kategory-optics/src/main/kotlin/kategory/optics/Optional.kt
+++ b/kategory-optics/src/main/kotlin/kategory/optics/Optional.kt
@@ -3,9 +3,11 @@ package kategory.optics
 import kategory.Applicative
 import kategory.Either
 import kategory.HK
+import kategory.Monoid
 import kategory.Option
 import kategory.Tuple2
 import kategory.flatMap
+import kategory.getOrElse
 import kategory.identity
 import kategory.left
 import kategory.none
@@ -191,5 +193,12 @@ abstract class POptional<S, T, A, B> {
      * View a [POptional] as a [PSetter]
      */
     fun asSetter(): PSetter<S, T, A, B> = PSetter { f -> { s -> modify(s, f) } }
+
+    /**
+     * View a [POptional] as a [Fold]
+     */
+    fun asFold() = object : Fold<S, A>() {
+        override fun <R> foldMap(M: Monoid<R>, s: S, f: (A) -> R): R = getOption(s).map(f).getOrElse(M::empty)
+    }
 
 }

--- a/kategory-optics/src/main/kotlin/kategory/optics/Prism.kt
+++ b/kategory-optics/src/main/kotlin/kategory/optics/Prism.kt
@@ -4,11 +4,13 @@ import kategory.Applicative
 import kategory.Either
 import kategory.Eq
 import kategory.HK
+import kategory.Monoid
 import kategory.Option
 import kategory.Tuple2
 import kategory.compose
 import kategory.eq
 import kategory.flatMap
+import kategory.getOrElse
 import kategory.identity
 import kategory.left
 import kategory.none
@@ -175,6 +177,13 @@ abstract class PPrism<S, T, A, B> {
      * View a [PPrism] as a [PSetter]
      */
     fun asSetter(): PSetter<S, T, A, B> = PSetter { f -> { s -> modify(s,f) } }
+
+    /**
+     * View a [PPrism] as a [Fold]
+     */
+    fun asFold(): Fold<S, A> = object : Fold<S, A>() {
+        override fun <R> foldMap(M: Monoid<R>, s: S, f: (A) -> R): R = getOption(s).map(f).getOrElse(M::empty)
+    }
 
 }
 

--- a/kategory-optics/src/test/kotlin/kategory/optics/FoldTest.kt
+++ b/kategory-optics/src/test/kotlin/kategory/optics/FoldTest.kt
@@ -1,0 +1,83 @@
+package kategory.optics
+
+import io.kotlintest.KTestJUnitRunner
+import io.kotlintest.properties.Gen
+import io.kotlintest.properties.forAll
+import kategory.IntMonoid
+import kategory.ListKWHK
+import kategory.ListKWKind
+import kategory.ListKWMonoidInstance
+import kategory.UnitSpec
+import kategory.k
+import kategory.none
+import kategory.some
+import org.junit.runner.RunWith
+
+@RunWith(KTestJUnitRunner::class)
+class FoldTest : UnitSpec() {
+
+    init {
+
+        val intFold = Fold.fromFoldable<ListKWHK, Int>()
+        val stringFold = Fold.fromFoldable<ListKWHK, String>()
+
+        "fold select" {
+            val select = Fold.select<List<Int>> { it.contains(1) }
+
+            forAll(Gen.list(Gen.int()), { ints ->
+                select.getAll<List<Int>, List<Int>>(object : ListKWMonoidInstance<List<Int>> {}, a = ints).list.firstOrNull() ==
+                        ints.let { if (it.contains(1)) it else null }
+            })
+        }
+
+        "folding a list of ints" {
+            forAll(Gen.list(Gen.int()), { ints ->
+                intFold.fold(a = ints.k()) == ints.sum()
+            })
+        }
+
+        "folding and mapping a list of strings" {
+            forAll(Gen.list(Gen.int()), { ints ->
+                stringFold.foldMap(IntMonoid, ints.map(Int::toString).k(), String::toInt) == ints.sum()
+            })
+        }
+
+        "getting forall values" {
+            forAll(Gen.list(Gen.int()), { ints ->
+                intFold.getAll<ListKWKind<Int>, Int>(object : ListKWMonoidInstance<Int> {}, ints.k()) == ints.k()
+            })
+        }
+
+        "Getting the length" {
+            forAll(Gen.list(Gen.int()), { ints ->
+                intFold.length(ints.k()) == ints.size
+            })
+        }
+
+        "find" {
+            forAll(Gen.list(Gen.int()), { ints ->
+                intFold.find(ints.k()) { it > 10 } == ints.firstOrNull { it > 2 }?.some() ?: none()
+            })
+        }
+
+        "forall" {
+            forAll(Gen.list(Gen.int()), { ints ->
+                intFold.forall(ints.k()) { it % 2 == 0 } == ints.all { it % 2 == 0 }
+            })
+        }
+
+        "empty" {
+            forAll(Gen.list(Gen.int()), { ints ->
+                intFold.isEmpty(ints.k()) == ints.isEmpty()
+            })
+        }
+
+        "nonEmpty" {
+            forAll(Gen.list(Gen.int()), { ints ->
+                intFold.nonEmpty(ints.k()) == ints.isNotEmpty()
+            })
+        }
+
+    }
+
+}

--- a/kategory-optics/src/test/kotlin/kategory/optics/FoldTest.kt
+++ b/kategory-optics/src/test/kotlin/kategory/optics/FoldTest.kt
@@ -48,9 +48,9 @@ class FoldTest : UnitSpec() {
             })
         }
 
-        "Getting the length" {
+        "Getting the size" {
             forAll(Gen.list(Gen.int()), { ints ->
-                intFold.length(ints.k()) == ints.size
+                intFold.size(ints.k()) == ints.size
             })
         }
 

--- a/reports/baseline.xml
+++ b/reports/baseline.xml
@@ -24,6 +24,7 @@
     <ID>LabeledExpression:ContinuationUtils.kt$this@completion</ID>
     <ID>LabeledExpression:MonoidK.kt$MonoidK.&lt;no name provided&gt;$this@MonoidK</ID>
     <ID>LabeledExpression:MonoidK.kt$MonoidK.&lt;no name provided&gt;$this@MonoidK</ID>
+    <ID>LabeledExpression:Fold.kt$Fold.&lt;no name provided&gt;$this@Fold</ID>
     <ID>ComplexMethod:AndThen.kt$AndThen$ @Suppress("UNCHECKED_CAST") internal fun runLoop(_success: A?, _failure: Throwable?, _isSuccess: Boolean): B</ID>
     <ID>EmptyClassBlock:Typeclass.kt$&lt;no name provided&gt; : TypeLiteral</ID>
     <ID>LateinitUsage:Comonad.kt$ComonadContinuation$internal lateinit var returnedMonad: A</ID>


### PR DESCRIPTION
I am having some issues with `ListKWMonoidInstance` but I am not sure why.
```kotlin
val intFold = Fold.fromFoldable<ListKWHK, Int>()
intFold.getAll<ListKWKind<Int>, Int>(object : ListKWMonoidInstance<Int> {}, a= listOf(1,2,3).k()) == listOf(1,2,3).k()
//true

intFold.getAll<ListKWKind<Int>, Int>(a= listOf(1,2,3).k()) == listOf(1,2,3).k()
// java.lang.ClassCastException: kategory.ListKW cannot be cast to java.lang.Number
```

Any1 can guide me where I should look?

Opinions on an overload with reified Monoid lookup? I tried an internal abstract method but then it's impossible for a user to make a custom Fold.

```kotlin
/**
 * Map each target to a type R and use a Monoid to fold the results
 */
abstract fun <R> foldMap(M: Monoid<R>, s: S, f: (A) -> R): R

inline fun <reified R> foldMap(s: S, noinline f: (A) -> R): R = foldMap(monoid(), s, f)
```