### PR TITLE
Updated regex in the build scripts

### DIFF
--- a/deploy-scripts/deploy_release.sh
+++ b/deploy-scripts/deploy_release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 . $(dirname $0)/deploy_common.sh
 
-VERSION_PATTERN=^[0-9].[0-9].[0-9]$
+VERSION_PATTERN=^[0-9]+\.[0-9]+\.[0-9]+$
 
 echo "Deploying release '$VERSION_NAME' ..."
 

--- a/deploy-scripts/deploy_snapshot.sh
+++ b/deploy-scripts/deploy_snapshot.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 . $(dirname $0)/deploy_common.sh
 
-VERSION_PATTERN=^[0-9].[0-9].[0-9]-SNAPSHOT$
+VERSION_PATTERN=^[0-9]+\.[0-9]+\.[0-9]+-SNAPSHOT$
 
 echo "Deploying snapshot '$VERSION_NAME' ..."
 


### PR DESCRIPTION
They now support multiple numbers…in the version and not any character in between the version numbers