### PR TITLE
Remove duplicated cancellable binding

### DIFF
--- a/kategory-effects/src/main/kotlin/kategory/effects/typeclass/Async.kt
+++ b/kategory-effects/src/main/kotlin/kategory/effects/typeclass/Async.kt
@@ -1,7 +1,6 @@
 package kategory.effects
 
 import kategory.*
-import kotlin.coroutines.experimental.startCoroutine
 
 /** An asynchronous computation that might fail. **/
 typealias Proc<A> = ((Either<Throwable, A>) -> Unit) -> Unit

--- a/kategory-effects/src/main/kotlin/kategory/effects/typeclass/Async.kt
+++ b/kategory-effects/src/main/kotlin/kategory/effects/typeclass/Async.kt
@@ -29,9 +29,3 @@ inline fun <F, A> runAsyncUnsafe(AC: AsyncContext<F>, crossinline f: () -> Eithe
 
 suspend inline fun <reified F, A> (() -> Either<Throwable, A>).runAsyncUnsafe(AC: AsyncContext<F> = asyncContext()): HK<F, A> =
         runAsyncUnsafe(AC, this)
-
-fun <F, B> MonadError<F, Throwable>.bindingECancellable(M: MonadError<F, Throwable>, c: suspend MonadErrorCancellableContinuation<F, *>.() -> HK<F, B>): HK<F, B> {
-    val continuation = MonadErrorCancellableContinuation<F, B>(M)
-    c.startCoroutine(continuation, continuation)
-    return continuation.returnedMonad()
-}


### PR DESCRIPTION
There's already a copy on MonadErrorCancellableContinuations: https://github.com/kategory/kategory/blob/master/kategory-effects/src/main/kotlin/kategory/effects/typeclass/MonadErrorCancellableContinuations.kt#L75-L79. Oopsie.