### PR TITLE
Support type arg bounds in @higherkind

### DIFF
--- a/kategory-annotations-processor/src/main/java/kategory/common/utils/ProcessorUtils.kt
+++ b/kategory-annotations-processor/src/main/java/kategory/common/utils/ProcessorUtils.kt
@@ -97,3 +97,23 @@ fun ProtoBuf.Type.extractFullName(
         outputTypeAlias = outputTypeAlias,
         throwOnGeneric = if (!failOnGeneric) null else KnownException("Generic $implicitAnnotationName types are not yet supported", null)
     )
+
+fun ClassOrPackageDataWrapper.typeConstraints(): String =
+        typeParameters.flatMap { typeParameter ->
+            val name = nameResolver.getString(typeParameter.name)
+            typeParameter.upperBoundList.map { constraint ->
+                name to constraint
+                        .extractFullName(this, failOnGeneric = false)
+                        .removeBackticks()
+            }
+        }.let { constraints ->
+            if (constraints.isNotEmpty()) {
+                constraints.joinToString(
+                        prefix = " where ",
+                        separator = ", ",
+                        transform = { (a, b) -> "$a : $b" }
+                )
+            } else {
+                ""
+            }
+        }

--- a/kategory-annotations-processor/src/main/java/kategory/higherkinds/HigherKindsFileGenerator.kt
+++ b/kategory-annotations-processor/src/main/java/kategory/higherkinds/HigherKindsFileGenerator.kt
@@ -1,9 +1,10 @@
 package kategory.higherkinds
 
-import java.io.File
 import kategory.common.Package
 import kategory.common.utils.knownError
+import kategory.common.utils.typeConstraints
 import org.jetbrains.kotlin.serialization.ProtoBuf
+import java.io.File
 import javax.lang.model.element.Name
 
 val KindPostFix = "Kind"
@@ -19,6 +20,7 @@ data class HigherKind(
     val typeArgs: List<String> = target.classOrPackageProto.typeParameters.map { target.classOrPackageProto.nameResolver.getString(it.name) }
     val expandedTypeArgs: String = target.classOrPackageProto.typeParameters.joinToString(
             separator = ", ", transform = { target.classOrPackageProto.nameResolver.getString(it.name) })
+    val typeConstraints = target.classOrPackageProto.typeConstraints()
     val name: String = "${kindName}$KindPostFix"
     val markerName = "${kindName}$HKMarkerPostFix"
 }
@@ -62,7 +64,7 @@ class HigherKindsFileGenerator(
     private fun genEv(hk: HigherKind): String =
             """
             |@Suppress("UNCHECKED_CAST")
-            |inline fun <${hk.expandedTypeArgs}> ${hk.name}<${hk.expandedTypeArgs}>.ev(): ${hk.kindName}<${hk.expandedTypeArgs}> =
+            |inline fun <${hk.expandedTypeArgs}> ${hk.name}<${hk.expandedTypeArgs}>.ev(): ${hk.kindName}<${hk.expandedTypeArgs}>${hk.typeConstraints} =
             |  this as ${hk.kindName}<${hk.expandedTypeArgs}>
         """.trimMargin()
 

--- a/kategory-annotations-processor/src/main/java/kategory/instances/InstanceFileGenerator.kt
+++ b/kategory-annotations-processor/src/main/java/kategory/instances/InstanceFileGenerator.kt
@@ -5,6 +5,7 @@ import kategory.common.Package
 import kategory.common.utils.ClassOrPackageDataWrapper
 import kategory.common.utils.extractFullName
 import kategory.common.utils.removeBackticks
+import kategory.common.utils.typeConstraints
 import me.eugeniomarletti.kotlin.metadata.modality
 import org.jetbrains.kotlin.serialization.ProtoBuf
 import org.jetbrains.kotlin.serialization.deserialization.TypeTable
@@ -48,25 +49,7 @@ data class Instance(
                 ""
             }
 
-    fun typeConstraints(): String =
-            target.classOrPackageProto.typeParameters.flatMap { typeParameter ->
-                val name = target.classOrPackageProto.nameResolver.getString(typeParameter.name)
-                typeParameter.upperBoundList.map { constraint ->
-                    name to constraint
-                            .extractFullName(target.classOrPackageProto, failOnGeneric = false)
-                            .removeBackticks()
-                }
-            }.let { constraints ->
-                if (constraints.isNotEmpty()) {
-                    constraints.joinToString(
-                            prefix = " where ",
-                            separator = ", ",
-                            transform = { (a, b) -> "$a : $b" }
-                    )
-                } else {
-                    ""
-                }
-            }
+    fun typeConstraints() = target.classOrPackageProto.typeConstraints()
 
     private val abstractFunctions: List<FunctionMapping> =
             getTypeclassReturningFunctions().fold(emptyList(), normalizeOverridenFunctions())


### PR DESCRIPTION
Closes #374

```Kotlin
@higherkind
class AsyncResult<D: SuperHeroesContext, A>(val value: Result<D, A>) : AsyncResultKind<D, A>
```

generates

```Kotlin
class AsyncResultHK private constructor()

typealias AsyncResultKind<D, A> = kategory.HK2<AsyncResultHK, D, A>

typealias AsyncResultKindPartial<D> = kategory.HK<AsyncResultHK, D>

@Suppress("UNCHECKED_CAST")
inline fun <D, A> AsyncResultKind<D, A>.ev(): AsyncResult<D, A> where D : kategory.SuperHeroesContext =
  this as AsyncResult<D, A>
```

Uses the same mechanism as #410