### PR TITLE
Fix @instance code generation when Companion has members named Unit

### DIFF
--- a/kategory-annotations-processor/src/main/java/kategory/instances/InstanceFileGenerator.kt
+++ b/kategory-annotations-processor/src/main/java/kategory/instances/InstanceFileGenerator.kt
@@ -185,7 +185,7 @@ class InstanceFileGenerator(
             """|
                 |fun ${i.expandedTypeArgs(reified = false)} ${i.receiverTypeName}.Companion.${i.companionFactoryName}(${(i.args.map {
                 "${it.first}: ${it.second}"
-            } + (if (i.args.isNotEmpty()) listOf("dummy: Unit = Unit") else emptyList())).joinToString(", ")
+            } + (if (i.args.isNotEmpty()) listOf("dummy: kotlin.Unit = kotlin.Unit") else emptyList())).joinToString(", ")
             }): ${i.name}${i.expandedTypeArgs()}${i.typeConstraints()} =
                 |  ${i.implicitObjectName}.instance(${i.args.map { it.first }.joinToString(", ")})
                 |


### PR DESCRIPTION
Instancing Eval creates the following code:
```Kotlin
fun <A> kategory.Eval.Companion.typeclass(TC: Typeclass<A>, dummy: Unit = Unit): EvalTypeclassInstance<A> =
  EvalTypeclassInstanceImplicits.instance(TC)
```
However, this code is invalid. The problem is in `dummy: Unit = Unit`. While the first Unit gets resolved to kotlin.Unit, the second gets resolved to kategory.Eval.Companion.Unit. This causes compilation to fail.

This solution is to generate this code instead:
```Kotlin
fun <A> kategory.Eval.Companion.typeclass(TC: Typeclass<A>, dummy: kotlin.Unit = kotlin.Unit): EvalTypeclassInstance<A> =
  EvalTypeclassInstanceImplicits.instance(TC)
```
Which prevents it from failing if the Companion has a property or local class called Unit (as is the case with Eval).
