### PR TITLE
Validated fixes

### DIFF
--- a/kategory-annotations/src/main/java/kategory/Typeclass.kt
+++ b/kategory-annotations/src/main/java/kategory/Typeclass.kt
@@ -43,18 +43,17 @@ class InstanceParametrizedType(val raw: Type, val typeArgs: List<Type>) : Parame
     override fun equals(other: Any?): Boolean {
         if (other is ParameterizedType) {
             // Check that information is equivalent
-            val that = other
 
-            if (this === that)
+            if (this === other)
                 return true
 
-            val thatOwner = that.ownerType
-            val thatRawType = that.rawType
+            val thatOwner = other.ownerType
+            val thatRawType = other.rawType
 
             return ownerType == thatOwner &&
                     rawType == thatRawType &&
                     Arrays.equals(actualTypeArguments, // avoid clone
-                            that.actualTypeArguments)
+                            other.actualTypeArguments)
         } else {
             return false
         }
@@ -64,7 +63,7 @@ class InstanceParametrizedType(val raw: Type, val typeArgs: List<Type>) : Parame
             hashCode(ownerType) xor
             hashCode(rawType)
 
-    fun hashCode(o: Any?): Int = o?.hashCode() ?: 0
+    private fun hashCode(o: Any?): Int = o?.hashCode() ?: 0
 
 }
 
@@ -175,7 +174,7 @@ private fun instanceFromImplicitObject(t: InstanceParametrizedType): Any? {
     } else {
         targetPackage
     }
-    val providerQualifiedName: String = "$derivationPackage.${on.simpleName.replaceFirst("HK", "")}${of.simpleName}InstanceImplicits"
+    val providerQualifiedName = "$derivationPackage.${on.simpleName.replaceFirst("HK", "")}${of.simpleName}InstanceImplicits"
     val globalInstanceProvider = Class.forName(providerQualifiedName)
     val allCompanionFunctions = globalInstanceProvider.methods
     val factoryFunction = allCompanionFunctions.find { it.name == "instance" }

--- a/kategory-core/src/main/kotlin/kategory/instances/ValidatedInstances.kt
+++ b/kategory-core/src/main/kotlin/kategory/instances/ValidatedInstances.kt
@@ -48,13 +48,12 @@ interface ValidatedTraverseInstance<E> : ValidatedFoldableInstance<E>, Traverse<
 }
 
 @instance(Validated::class)
-interface ValidatedSemigroupKInstance<E, A> : SemigroupK<ValidatedKindPartial<E>> {
+interface ValidatedSemigroupKInstance<E> : SemigroupK<ValidatedKindPartial<E>> {
 
     fun SE(): Semigroup<E>
-    fun SA(): Semigroup<A>
 
-    override fun <A> combineK(x: ValidatedKind<E, A>, y: ValidatedKind<E, A>): Validated<E, A> =
-            x.ev().combineK(y, SE(), SA() as Semigroup<A>)
+    override fun <B> combineK(x: ValidatedKind<E, B>, y: ValidatedKind<E, B>): Validated<E, B> =
+            x.ev().combineK(y, SE())
 
 }
 

--- a/kategory-core/src/main/kotlin/kategory/instances/ValidatedInstances.kt
+++ b/kategory-core/src/main/kotlin/kategory/instances/ValidatedInstances.kt
@@ -48,12 +48,13 @@ interface ValidatedTraverseInstance<E> : ValidatedFoldableInstance<E>, Traverse<
 }
 
 @instance(Validated::class)
-interface ValidatedSemigroupKInstance<E> : SemigroupK<ValidatedKindPartial<E>> {
+interface ValidatedSemigroupKInstance<E, A> : SemigroupK<ValidatedKindPartial<E>> {
 
     fun SE(): Semigroup<E>
+    fun SA(): Semigroup<A>
 
-    override fun <B> combineK(x: ValidatedKind<E, B>, y: ValidatedKind<E, B>): Validated<E, B> =
-            x.ev().combineK(y, SE())
+    override fun <A> combineK(x: ValidatedKind<E, A>, y: ValidatedKind<E, A>): Validated<E, A> =
+            x.ev().combineK(y, SE(), SA() as Semigroup<A>)
 
 }
 

--- a/kategory-core/src/test/kotlin/kategory/data/ValidatedTest.kt
+++ b/kategory-core/src/test/kotlin/kategory/data/ValidatedTest.kt
@@ -27,7 +27,7 @@ class ValidatedTest : UnitSpec() {
         testLaws(ApplicativeLaws.laws(Validated.applicative(StringMonoidInstance), Eq.any()))
         testLaws(TraverseLaws.laws(Validated.traverse(), Validated.applicative(StringMonoidInstance), ::Valid, Eq.any()))
         testLaws(SemigroupKLaws.laws(
-                Validated.semigroupK(IntMonoid, IntMonoid),
+                Validated.semigroupK(IntMonoid),
                 Validated.applicative(IntMonoid),
                 Eq.any()))
 
@@ -196,20 +196,39 @@ class ValidatedTest : UnitSpec() {
         "CombineK should combine Valid Validated" {
             val valid = Valid("Who")
 
-            Validated.semigroupK<String, String>().combineK(valid, valid) shouldBe(Valid("WhoWho"))
+            Validated.semigroupK<String>().combineK(valid, valid) shouldBe(Valid("Who"))
         }
 
         "CombineK should combine Valid and Invalid Validated" {
             val valid = Valid("Who")
             val invalid = Invalid("Nope")
 
-            Validated.semigroupK<String, String>().combineK(valid, invalid) shouldBe(Invalid("Nope"))
+            Validated.semigroupK<String>().combineK(valid, invalid) shouldBe(Valid("Who"))
         }
 
         "CombineK should combine Invalid Validated" {
             val invalid = Invalid("Nope")
 
-            Validated.semigroupK<String, String>().combineK(invalid, invalid) shouldBe(Invalid("NopeNope"))
+            Validated.semigroupK<String>().combineK(invalid, invalid) shouldBe(Invalid("NopeNope"))
+        }
+
+        "Combine should combine Valid Validated" {
+            val valid: Validated<String, String> = Valid("Who")
+
+            valid.combine(valid) shouldBe(Valid("WhoWho"))
+        }
+
+        "Combine should combine Valid and Invalid Validated" {
+            val valid = Valid("Who")
+            val invalid = Invalid("Nope")
+
+            valid.combine(invalid) shouldBe(Invalid("Nope"))
+        }
+
+        "Combine should combine Invalid Validated" {
+            val invalid: Validated<String, String> = Invalid("Nope")
+
+            invalid.combine(invalid) shouldBe(Invalid("NopeNope"))
         }
     }
 }

--- a/kategory-docs/docs/docs/datatypes/ior/README.md
+++ b/kategory-docs/docs/docs/datatypes/ior/README.md
@@ -108,7 +108,7 @@ To extract the values, we can use the `fold` method, which expects a function fo
 ```kotlin:ank
 validateUser("john.doe", "password").fold(
         { "Error: ${it.head}" },
-        { "Success $it"},
+        { "Success $it" },
         { warnings, (name) -> "Warning: $name; The following warnings occurred: ${warnings.show()}" }
 )
 


### PR DESCRIPTION
* Some nits in the Typeclass file
* Added a couple of tests for Validated's `combineK`
* Added `Validated.toIor`
* Added a vanilla `combine` function that performs a slightly different combination than `combineK`, based on [cats' version](https://github.com/typelevel/cats/blob/master/core/src/main/scala/cats/data/Validated.scala#L266).


@kategory/maintainers Please take a look and let me know if I messed it up 😆 