### PR TITLE
Fix release upload archives

### DIFF
--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -24,7 +24,7 @@ def findProperty(String key) {
 }
 
 def getReleaseRepositoryUrl() {
-    return findProperty('RELEASE_REPOSITORY_URL') ?: "https://oss.jfrog.org/artifactory/oss-release-local"
+    return findProperty('RELEASE_REPOSITORY_URL') ?: "https://api.bintray.com/maven/kategory/maven/"+POM_ARTIFACT_ID
 }
 
 def getSnapshotRepositoryUrl() {


### PR DESCRIPTION
Only snapshots build should be at  oss.jfrog.org, modify default release URL to point to Bintray organization project.

With this change, I was able to upload and publish to Bintray from a local machine, and maybe also work in Travis-CI when detecting a release build.

The only behaviour it's some modules that do not have real artifact appears in Bintray:
* kategory-docs
* kategory-effects-test
* kategory-test