### PR TITLE
Fix #459 - rename apply to operator invoke

### DIFF
--- a/kategory-core/src/main/kotlin/kategory/free/Coyoneda.kt
+++ b/kategory-core/src/main/kotlin/kategory/free/Coyoneda.kt
@@ -18,12 +18,12 @@ private typealias AnyFunc = (Any?) -> Any?
 
     fun toYoneda(FF: Functor<F>): Yoneda<F, A> =
             object : Yoneda<F, A>() {
-                override fun <B> apply(f: (A) -> B): HK<F, B> = map(f).lower(FF)
+                override operator fun <B> invoke(f: (A) -> B): HK<F, B> = map(f).lower(FF)
             }
 
     companion object {
         @Suppress("UNCHECKED_CAST")
-        inline fun <reified U, A, B> apply(fa: HK<U, A>, noinline f: (A) -> B): Coyoneda<U, A, B> = unsafeApply(fa, listOf(f as AnyFunc))
+        inline operator fun <reified U, A, B> invoke(fa: HK<U, A>, noinline f: (A) -> B): Coyoneda<U, A, B> = unsafeApply(fa, listOf(f as AnyFunc))
 
         inline fun <reified U, A, B> unsafeApply(fa: HK<U, A>, f: List<AnyFunc>): Coyoneda<U, A, B> = Coyoneda(fa, f)
 

--- a/kategory-core/src/main/kotlin/kategory/free/Yoneda.kt
+++ b/kategory-core/src/main/kotlin/kategory/free/Yoneda.kt
@@ -2,21 +2,21 @@ package kategory
 
 @higherkind abstract class Yoneda<F, A> : YonedaKind<F, A> {
 
-    abstract fun <B> apply(f: (A) -> B): HK<F, B>
+    abstract operator fun <B> invoke(f: (A) -> B): HK<F, B>
 
-    fun lower(): HK<F, A> = apply { a -> a }
+    fun lower(): HK<F, A> = invoke { a -> a }
 
     fun <B> map(ff: (A) -> B, FF: Functor<F>): Yoneda<F, B> =
             object : Yoneda<F, B>() {
-                override fun <C> apply(f: (B) -> C): HK<F, C> = this@Yoneda.apply({ f(ff(it)) })
+                override fun <C> invoke(f: (B) -> C): HK<F, C> = this@Yoneda({ f(ff(it)) })
             }
 
     fun toCoyoneda(): Coyoneda<F, A, A> = Coyoneda(lower(), listOf({ a: Any? -> a }))
 
     companion object {
-        inline fun <reified U, A> apply(fa: HK<U, A>, FF: Functor<U> = kategory.functor()): Yoneda<U, A> =
+        inline operator fun <reified U, A> invoke(fa: HK<U, A>, FF: Functor<U> = kategory.functor()): Yoneda<U, A> =
                 object : Yoneda<U, A>() {
-                    override fun <B> apply(f: (A) -> B): HK<U, B> = FF.map(fa, f)
+                    override fun <B> invoke(f: (A) -> B): HK<U, B> = FF.map(fa, f)
                 }
     }
 }

--- a/kategory-core/src/test/kotlin/kategory/free/CoYonedaTest.kt
+++ b/kategory-core/src/test/kotlin/kategory/free/CoYonedaTest.kt
@@ -18,7 +18,7 @@ class CoyonedaTest : UnitSpec() {
             functor<CoyonedaKindPartial<IdHK, Int>>() shouldNotBe null
         }
 
-        testLaws(FunctorLaws.laws(Coyoneda.functor(), { Coyoneda.apply(Id(0), { it }) }, EQ))
+        testLaws(FunctorLaws.laws(Coyoneda.functor(), { Coyoneda(Id(0), { it }) }, EQ))
 
         "map should be stack-safe" {
             val loops = 10000
@@ -27,7 +27,7 @@ class CoyonedaTest : UnitSpec() {
                     if (n <= 0) acc
                     else loop(n - 1, acc.map { it + 1 })
 
-            val result = loop(loops, Coyoneda.apply(Some(0), { it })).lower(Option.functor())
+            val result = loop(loops, Coyoneda(Some(0), { it })).lower(Option.functor())
             val expected = Some(loops)
 
             expected shouldBe result
@@ -35,9 +35,9 @@ class CoyonedaTest : UnitSpec() {
 
         "toYoneda should convert to an equivalent Yoneda" {
             forAll { x: Int ->
-                val op = Coyoneda.apply(Id(x), Int::toString)
+                val op = Coyoneda(Id(x), Int::toString)
                 val toYoneda = op.toYoneda(Id.functor()).lower().ev()
-                val expected = Yoneda.apply(Id(x.toString())).lower().ev()
+                val expected = Yoneda(Id(x.toString())).lower().ev()
 
                 expected == toYoneda
             }

--- a/kategory-core/src/test/kotlin/kategory/free/YonedaTest.kt
+++ b/kategory-core/src/test/kotlin/kategory/free/YonedaTest.kt
@@ -20,13 +20,13 @@ class YonedaTest : UnitSpec() {
             functor<YonedaKindPartial<IdHK>>() shouldNotBe null
         }
 
-        testLaws(FunctorLaws.laws(F, { Yoneda.apply(kategory.Id(it)) }, EQ))
+        testLaws(FunctorLaws.laws(F, { Yoneda(kategory.Id(it)) }, EQ))
 
         "toCoyoneda should convert to an equivalent Coyoneda" {
             forAll { x: Int ->
-                val op = Yoneda.apply(Id(x.toString()))
+                val op = Yoneda(Id(x.toString()))
                 val toYoneda = op.toCoyoneda().lower(Id.functor()).ev()
-                val expected = Coyoneda.apply(Id(x), Int::toString).lower(Id.functor()).ev()
+                val expected = Coyoneda(Id(x), Int::toString).lower(Id.functor()).ev()
 
                 expected == toYoneda
             }


### PR DESCRIPTION
Renamed `apply` function to `operator invoke` for `Yoneda` and `Coyoneda`. Also updated tests. Build is passing in my machine

There is another `unsafeApply` in `Coyoneda` that I haven't modified.