### PR TITLE
Print classpath as task not config

### DIFF
--- a/kategory-docs/build.gradle
+++ b/kategory-docs/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     compile "io.kotlintest:kotlintest:$kotlinTestVersion"
 }
 
-task printcp {
+task printcp << {
     println sourceSets.main.runtimeClasspath.each { println it }
 }
 


### PR DESCRIPTION
Currently the classpath is printed in every gradle configuration phase. `<<` or `doLast` would fix that.