### PR TITLE
(fix) Readme: Wrong URL to Maven repository for Kategory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add it in your root `build.gradle` at the end of repositories.
 allprojects {
     repositories {
         jcenter()
-        maven { url 'https://kotlin.bintray.com/kotlinx' }
+        maven { url 'https://dl.bintray.com/kategory/maven' }
     }
 }
 ```


### PR DESCRIPTION
Gradle had problems finding `kategory-effects` and `kategory-optics` artifacts.