### PR TITLE
Add fix to 3 MonadLaws that were not executing their clauses

### DIFF
--- a/kategory-effects-rx2/src/main/kotlin/kategory/effects/data/FlowableKW.kt
+++ b/kategory-effects-rx2/src/main/kotlin/kategory/effects/data/FlowableKW.kt
@@ -83,21 +83,11 @@ data class FlowableKW<A>(val flowable: Flowable<A>) : FlowableKWKind<A> {
         fun monadConcat(): FlowableKWMonadInstance = object : FlowableKWMonadInstance {
             override fun <A, B> flatMap(fa: FlowableKWKind<A>, f: (A) -> FlowableKWKind<B>): FlowableKW<B> =
                     fa.ev().concatMap { f(it).ev() }
-
-            override fun <A, B> tailRecM(a: A, f: (A) -> FlowableKWKind<Either<A, B>>): FlowableKW<B> =
-                    f(a).ev().concatMap {
-                        it.fold({ tailRecM(a, f).ev() }, { pure(it).ev() })
-                    }
         }
 
         fun monadSwitch(): FlowableKWMonadInstance = object : FlowableKWMonadInstance {
             override fun <A, B> flatMap(fa: FlowableKWKind<A>, f: (A) -> FlowableKWKind<B>): FlowableKW<B> =
                     fa.ev().switchMap { f(it).ev() }
-
-            override fun <A, B> tailRecM(a: A, f: (A) -> FlowableKWKind<Either<A, B>>): FlowableKW<B> =
-                    f(a).ev().switchMap {
-                        it.fold({ tailRecM(a, f).ev() }, { pure(it).ev() })
-                    }
         }
 
         fun monadErrorFlat(): FlowableKWMonadErrorInstance = FlowableKWMonadErrorInstanceImplicits.instance()
@@ -105,21 +95,11 @@ data class FlowableKW<A>(val flowable: Flowable<A>) : FlowableKWKind<A> {
         fun monadErrorConcat(): FlowableKWMonadErrorInstance = object : FlowableKWMonadErrorInstance {
             override fun <A, B> flatMap(fa: FlowableKWKind<A>, f: (A) -> FlowableKWKind<B>): FlowableKW<B> =
                     fa.ev().concatMap { f(it).ev() }
-
-            override fun <A, B> tailRecM(a: A, f: (A) -> FlowableKWKind<Either<A, B>>): FlowableKW<B> =
-                    f(a).ev().concatMap {
-                        it.fold({ tailRecM(a, f).ev() }, { Companion.pure(it).ev() })
-                    }
         }
 
         fun monadErrorSwitch(): FlowableKWMonadErrorInstance = object : FlowableKWMonadErrorInstance {
             override fun <A, B> flatMap(fa: FlowableKWKind<A>, f: (A) -> FlowableKWKind<B>): FlowableKW<B> =
                     fa.ev().switchMap { f(it).ev() }
-
-            override fun <A, B> tailRecM(a: A, f: (A) -> FlowableKWKind<Either<A, B>>): FlowableKW<B> =
-                    f(a).ev().switchMap {
-                        it.fold({ tailRecM(a, f).ev() }, { Companion.pure(it).ev() })
-                    }
         }
 
         fun asyncContextBuffer(): FlowableKWAsyncContextInstance = FlowableKWAsyncContextInstanceImplicits.instance()

--- a/kategory-effects-rx2/src/main/kotlin/kategory/effects/data/ObservableKW.kt
+++ b/kategory-effects-rx2/src/main/kotlin/kategory/effects/data/ObservableKW.kt
@@ -82,21 +82,11 @@ data class ObservableKW<A>(val observable: Observable<A>) : ObservableKWKind<A> 
         fun monadConcat(): ObservableKWMonadInstance = object : ObservableKWMonadInstance {
             override fun <A, B> flatMap(fa: ObservableKWKind<A>, f: (A) -> ObservableKWKind<B>): ObservableKW<B> =
                     fa.ev().concatMap { f(it).ev() }
-
-            override fun <A, B> tailRecM(a: A, f: (A) -> ObservableKWKind<Either<A, B>>): ObservableKW<B> =
-                    f(a).ev().concatMap {
-                        it.fold({ tailRecM(a, f).ev() }, { pure(it).ev() })
-                    }
         }
 
         fun monadSwitch(): ObservableKWMonadInstance = object : ObservableKWMonadErrorInstance {
             override fun <A, B> flatMap(fa: ObservableKWKind<A>, f: (A) -> ObservableKWKind<B>): ObservableKW<B> =
                     fa.ev().switchMap { f(it).ev() }
-
-            override fun <A, B> tailRecM(a: A, f: (A) -> ObservableKWKind<Either<A, B>>): ObservableKW<B> =
-                    f(a).ev().switchMap {
-                        it.fold({ tailRecM(a, f).ev() }, { pure(it).ev() })
-                    }
         }
 
         fun monadErrorFlat(): ObservableKWMonadErrorInstance = ObservableKWMonadErrorInstanceImplicits.instance()
@@ -104,21 +94,11 @@ data class ObservableKW<A>(val observable: Observable<A>) : ObservableKWKind<A> 
         fun monadErrorConcat(): ObservableKWMonadErrorInstance = object : ObservableKWMonadErrorInstance {
             override fun <A, B> flatMap(fa: ObservableKWKind<A>, f: (A) -> ObservableKWKind<B>): ObservableKW<B> =
                     fa.ev().concatMap { f(it).ev() }
-
-            override fun <A, B> tailRecM(a: A, f: (A) -> ObservableKWKind<Either<A, B>>): ObservableKW<B> =
-                    f(a).ev().concatMap {
-                        it.fold({ tailRecM(a, f).ev() }, { pure(it).ev() })
-                    }
         }
 
         fun monadErrorSwitch(): ObservableKWMonadErrorInstance = object : ObservableKWMonadErrorInstance {
             override fun <A, B> flatMap(fa: ObservableKWKind<A>, f: (A) -> ObservableKWKind<B>): ObservableKW<B> =
                     fa.ev().switchMap { f(it).ev() }
-
-            override fun <A, B> tailRecM(a: A, f: (A) -> ObservableKWKind<Either<A, B>>): ObservableKW<B> =
-                    f(a).ev().switchMap {
-                        it.fold({ tailRecM(a, f).ev() }, { pure(it).ev() })
-                    }
         }
     }
 }

--- a/kategory-effects-rx2/src/test/kotlin/kategory/effects/data/FlowableKWTests.kt
+++ b/kategory-effects-rx2/src/test/kotlin/kategory/effects/data/FlowableKWTests.kt
@@ -2,7 +2,6 @@ package kategory.effects
 
 import io.kotlintest.KTestJUnitRunner
 import io.kotlintest.matchers.shouldNotBe
-import io.kotlintest.properties.Gen
 import io.reactivex.Flowable
 import io.reactivex.schedulers.Schedulers
 import io.reactivex.subscribers.TestSubscriber
@@ -66,8 +65,10 @@ class FlowableKWTests : UnitSpec() {
         testLaws(AsyncLaws.laws(FlowableKW.asyncContextMissing(), FlowableKW.monadErrorConcat(), EQ(), EQ()))
         testLaws(AsyncLaws.laws(FlowableKW.asyncContextMissing(), FlowableKW.monadErrorSwitch(), EQ(), EQ()))
 
-        testLaws(FoldableLaws.laws(FlowableKW.foldable(), { FlowableKW.pure(it) }, Eq.any()))
-        testLaws(TraverseLaws.laws(FlowableKW.traverse(), FlowableKW.functor(), { FlowableKW.pure(it)  }, EQ()))
+        testLaws(
+                FoldableLaws.laws(FlowableKW.foldable(), { FlowableKW.pure(it) }, Eq.any()),
+                TraverseLaws.laws(FlowableKW.traverse(), FlowableKW.functor(), { FlowableKW.pure(it) }, EQ())
+        )
 
         "Multi-thread Flowables finish correctly" {
             val value: Flowable<Long> = FlowableKW.monadErrorFlat().bindingE {

--- a/kategory-effects-rx2/src/test/kotlin/kategory/effects/data/ObservableKWTests.kt
+++ b/kategory-effects-rx2/src/test/kotlin/kategory/effects/data/ObservableKWTests.kt
@@ -47,13 +47,13 @@ class ObservableKWTest : UnitSpec() {
             traverse<ObservableKWHK>() shouldNotBe null
         }
 
-        testLaws(
-            AsyncLaws.laws(ObservableKW.asyncContext(), ObservableKW.monadErrorFlat(), EQ(), EQ()),
-            AsyncLaws.laws(ObservableKW.asyncContext(), ObservableKW.monadErrorConcat(), EQ(), EQ()),
-            AsyncLaws.laws(ObservableKW.asyncContext(), ObservableKW.monadErrorSwitch(), EQ(), EQ()),
+        testLaws(AsyncLaws.laws(ObservableKW.asyncContext(), ObservableKW.monadErrorFlat(), EQ(), EQ()))
+        testLaws(AsyncLaws.laws(ObservableKW.asyncContext(), ObservableKW.monadErrorConcat(), EQ(), EQ()))
+        testLaws(AsyncLaws.laws(ObservableKW.asyncContext(), ObservableKW.monadErrorSwitch(), EQ(), EQ()))
 
-            FoldableLaws.laws(ObservableKW.foldable(), { ObservableKW.pure(it) }, Eq.any()),
-            TraverseLaws.laws(ObservableKW.traverse(), ObservableKW.functor(), { ObservableKW.pure(it)  }, EQ())
+        testLaws(
+                FoldableLaws.laws(ObservableKW.foldable(), { ObservableKW.pure(it) }, Eq.any()),
+                TraverseLaws.laws(ObservableKW.traverse(), ObservableKW.functor(), { ObservableKW.pure(it) }, EQ())
         )
 
         "Multi-thread Observables finish correctly" {

--- a/kategory-test/src/main/kotlin/kategory/laws/MonadLaws.kt
+++ b/kategory-test/src/main/kotlin/kategory/laws/MonadLaws.kt
@@ -45,15 +45,17 @@ object MonadLaws {
                 M.flatMap(fa, { M.pure(f(it)) }).equalUnderTheLaw(M.map(fa, f), EQ)
             })
 
-    inline fun <reified F> stackSafety(iterations: Int = 5000, M: Monad<F> = monad<F>(), EQ: Eq<HK<F, Int>>): Unit {
-        val res = M.tailRecM(0, { i -> M.pure(if (i < iterations) Left(i + 1) else Right(i)) })
-        res.equalUnderTheLaw(M.pure(iterations), EQ)
-    }
+    inline fun <reified F> stackSafety(iterations: Int = 5000, M: Monad<F> = monad<F>(), EQ: Eq<HK<F, Int>>): Unit =
+            forFew(1, Gen.oneOf(listOf(iterations))) { iter ->
+                val res = M.tailRecM(0, { i -> M.pure(if (i < iter) Left(i + 1) else Right(i)) })
+                res.equalUnderTheLaw(M.pure(iter), EQ)
+            }
 
-    inline fun <reified F> stackSafetyComprehensions(iterations: Int = 5000, M: Monad<F> = monad<F>(), EQ: Eq<HK<F, Int>>): Unit {
-        val res = stackSafeTestProgram(M, 0, iterations)
-        res.run(M).equalUnderTheLaw(M.pure(iterations), EQ)
-    }
+    inline fun <reified F> stackSafetyComprehensions(iterations: Int = 5000, M: Monad<F> = monad<F>(), EQ: Eq<HK<F, Int>>): Unit =
+            forFew(1, Gen.oneOf(listOf(iterations))) { iter ->
+                val res = stackSafeTestProgram(M, 0, iter)
+                res.run(M).equalUnderTheLaw(M.pure(iter), EQ)
+            }
 
     inline fun <reified F> equivalentComprehensions(M: Monad<F> = monad<F>(), EQ: Eq<HK<F, Int>>): Unit =
             forAll(Gen.int(), { num: Int ->
@@ -69,8 +71,8 @@ object MonadLaws {
                     val c = pure(b + 1).bind()
                     yields(c)
                 }.run(M)
-                aa.equalUnderTheLaw(bb, EQ)
-                aa.equalUnderTheLaw(M.pure(num + 2), EQ)
+                aa.equalUnderTheLaw(bb, EQ) &&
+                        aa.equalUnderTheLaw(M.pure(num + 2), EQ)
             })
 
     inline fun <reified F> monadComprehensions(M: Monad<F> = monad<F>(), EQ: Eq<HK<F, Int>>): Unit =


### PR DESCRIPTION
I realized while working on https://github.com/kategory/kategory/pull/475 that stackSafety and stackSafeComprehensions weren't being checked by the laws. Let's fix that.