### PR TITLE
Fix release deployment script

### DIFF
--- a/deploy-scripts/deploy.sh
+++ b/deploy-scripts/deploy.sh
@@ -7,9 +7,9 @@ VERSION_PATTERN_RELEASE=^[0-9]+\.[0-9]+\.[0-9]+$
 VERSION_PATTERN_SNAPSHOT=^[0-9]+\.[0-9]+\.[0-9]+-SNAPSHOT$
 
 if [ "$TRAVIS_BRANCH" == "master" ]; then
-    if [ "$VERSION_NAME" ~= VERSION_PATTERN_RELEASE ]; then
+    if [ "$VERSION_NAME" =~ "$VERSION_PATTERN_RELEASE" ]; then
         . $(dirname $0)/deploy_release.sh
-    elif [ "$VERSION_NAME" =~ $VERSION_PATTERN_SNAPSHOT ]; then
+    elif [ "$VERSION_NAME" =~ "$VERSION_PATTERN_SNAPSHOT" ]; then
         . $(dirname $0)/deploy_snapshot.sh
     fi
 else


### PR DESCRIPTION
Release deployment is failing 👀

```
0.01s$ ./deploy-scripts/deploy.sh
Branch 'master'
./deploy-scripts/deploy.sh: line 10: [: ~=: binary operator expected
./deploy-scripts/deploy.sh: line 12: [: =~: binary operator expected
```

- This PR addresses ☝️

👀 @pablisco 