### PR TITLE
State API update

### DIFF
--- a/kategory-core/src/main/kotlin/kategory/data/State.kt
+++ b/kategory-core/src/main/kotlin/kategory/data/State.kt
@@ -1,7 +1,7 @@
 package kategory
 
 /**
- * Alias that represent stateful computation of the form `(S) -> Tuple2<S, A>`.
+ * Alias that represents stateful computation of the form `(S) -> Tuple2<S, A>`.
  */
 typealias StateFun<S, A> = StateTFun<IdHK, S, A>
 

--- a/kategory-core/src/main/kotlin/kategory/data/State.kt
+++ b/kategory-core/src/main/kotlin/kategory/data/State.kt
@@ -1,44 +1,111 @@
 package kategory
 
 /**
- * Convenience object to make working with `StateT<IdHK, S, A>` more elegant.
+ * Alias that represent stateful computation of the form `(S) -> Tuple2<S, A>`.
  */
-object State {
+typealias StateFun<S, A> = StateTFun<IdHK, S, A>
 
-    /**
-     * Construct a `StateT<IdHK, S, A>` from a function [run] `(S) -> Tuple2<S, A>`.
-     */
-    operator fun <S, A> invoke(run: (S) -> Tuple2<S, A>): StateT<IdHK, S, A> = StateT(Id(run.andThen { Id(it) }))
+/**
+ * Alias that represents wrapped stateful computation in context `Id`.
+ */
+typealias StateFunKind<S, A> = StateTFunKind<IdHK, S, A>
 
-    /**
-     * Lift a value of type `A` into `StateT<IdHK, S, A>`.
-     */
-    fun <S, A> lift(a: A): StateT<IdHK, S, A> = StateT.lift(Id.monad(), Id.pure(a))
+/**
+ * Alias for StateHK
+ */
+typealias StateHK = StateTHK
+
+/**
+ * Alias for StateKind
+ */
+typealias StateKind<S, A> = StateTKind<IdHK, S, A>
+
+/**
+ * Alias to partially apply type parameters [S] to [State]
+ */
+typealias StateKindPartial<S> = StateTKindPartial<IdHK, S>
+
+/**
+ * `State<S, A>` is a stateful computation that yields a value of type `A`.
+ *
+ * @param S the state we are preforming computation upon.
+ * @param A current value of computation.
+ */
+typealias State<S, A> = StateT<IdHK, S, A>
+
+/**
+ * Constructor for State.
+ * State<S, A> is an alias for IndexedStateT<IdHK, S, S, A>
+ *
+ * @param run the stateful function to wrap with [State].
+ */
+@Suppress("FunctionName")
+fun <S, A> State(run: (S) -> Tuple2<S, A>): State<S, A> = StateT(Id(run.andThen { Id(it) }))
+
+/**
+ * Syntax for constructing a `StateT<IdHK, S, A>` from a function `(S) -> Tuple2<S, A>`
+ */
+fun <S, A> StateFun<S, A>.toState(): State<S, A> = State(this)
+
+/**
+ * Syntax for constructing a `StateT<IdHK, S, A>` from a function `(S) -> Tuple2<S, A>`
+ */
+fun <S, A> StateFunKind<S, A>.toState(): State<S, A> = State(this)
+
+/**
+ * Alias for [StateT.run] `StateT<IdHK, S, A>`
+ *
+ * @param initial state to start stateful computation.
+ */
+fun <S, A> StateT<IdHK, S, A>.run(initial: S): Tuple2<S, A> = run(initial, Id.monad()).value()
+
+/**
+ * Alias for [StateT.runA] `StateT<IdHK, S, A>`
+ *
+ * @param initial state to start stateful computation.
+ */
+fun <S, A> StateT<IdHK, S, A>.runA(initial: S): A = run(initial).b
+
+/**
+ * Alias for [StateT.runS] `StateT<IdHK, S, A>`
+ *
+ * @param initial state to start stateful computation.
+ */
+fun <S, A> StateT<IdHK, S, A>.runS(initial: S): S = run(initial).a
+
+/**
+ * Alias for StateId to make working with `StateT<IdHK, S, A>` more elegant.
+ */
+@Suppress("FunctionName")
+fun State() = StateApi
+
+object StateApi {
 
     /**
      * Return input without modifying it.
      */
-    fun <S> get(): StateT<IdHK, S, S> = State { s: S -> s toT s }
+    fun <S> get(): State<S, S> = StateT.get(Id.applicative())
 
     /**
      * Inspect a value of the state [S] with [f] `(S) -> T` without modifying the state.
+     *
+     * @param f the function applied to inspect [T] from [S].
      */
-    fun <S, T> inspect(f: (S) -> T): StateT<IdHK, S, T> = State { s: S -> s toT f(s) }
+    fun <S, T> inspect(f: (S) -> T): State<S, T> = StateT.inspect(Id.applicative(), f)
 
     /**
      * Modify the state with [f] `(S) -> S` and return [Unit].
+     *
+     * @param f the modify function to apply.
      */
-    fun <S> modify(f: (S) -> S): StateT<IdHK, S, Unit> = State { s: S -> f(s) toT Unit }
+    fun <S> modify(f: (S) -> S): State<S, Unit> = StateT.modify(Id.applicative(), f)
 
     /**
      * Set the state to [s] and return [Unit].
+     *
+     * @param s value to set.
      */
-    fun <S> set(s: S): StateT<IdHK, S, Unit> = State { _: S -> s toT Unit }
-
-    /**
-     * Alias for [StateT.Companion.functor]
-     */
-    fun <S> functor() = StateT.functor<IdHK, S>(Id.functor(), dummy = Unit)
+    fun <S> set(s: S): State<S, Unit> = StateT.set(Id.applicative(), s)
 
     /**
      * Alias for[StateT.Companion.applicative]
@@ -46,27 +113,13 @@ object State {
     fun <S> applicative() = StateT.applicative<IdHK, S>(Id.monad(), dummy = Unit)
 
     /**
+     * Alias for [StateT.Companion.functor]
+     */
+    fun <S> functor() = StateT.functor<IdHK, S>(Id.functor(), dummy = Unit)
+
+    /**
      * Alias for [StateT.Companion.monad]
      */
     fun <S> monad() = StateT.monad<IdHK, S>(Id.monad(), dummy = Unit)
+
 }
-
-/**
- * Syntax for getting a `StateT<IdHK, S, A>` from a function `(S) -> Tuple2<S, A>`
- */
-fun <S, A> ((S) -> Tuple2<S, A>).state(): StateT<IdHK, S, A> = State(this)
-
-/**
- * Alias for [StateT.run] `StateT<IdHK, S, A>`
- */
-fun <S, A> StateT<IdHK, S, A>.run(initial: S): Tuple2<S, A> = run(initial, Id.monad()).value()
-
-/**
- * Alias for [StateT.runA] `StateT<IdHK, S, A>`
- */
-fun <S, A> StateT<IdHK, S, A>.runA(s: S): A = run(s).b
-
-/**
- * Alias for [StateT.runS] `StateT<IdHK, S, A>`
- */
-fun <S, A> StateT<IdHK, S, A>.runS(s: S): S = run(s).a

--- a/kategory-core/src/main/kotlin/kategory/data/StateT.kt
+++ b/kategory-core/src/main/kotlin/kategory/data/StateT.kt
@@ -86,7 +86,7 @@ class StateT<F, S, A>(
          *
          *
          * @param AF [Applicative] for the context [F].
-         * @param f the function applied to extrat [T] from [S].
+         * @param f the function applied to inspect [T] from [S].
          */
         fun <F, S, T> inspect(AF: Applicative<F>, f: (S) -> T): StateT<F, S, T> = StateT(AF.pure({ s -> AF.pure(Tuple2(s, f(s))) }))
 

--- a/kategory-docs/docs/docs/datatypes/state/README.md
+++ b/kategory-docs/docs/docs/datatypes/state/README.md
@@ -85,7 +85,7 @@ fun push(s: String) = State<Stack, Unit> { stack ->
 The `flatMap` method on `State<S, A>` lets you use the result of one `State` in a subsequent `State`. The updated state (`S`) after the first call is passed into the second call. These `flatMap` and `map` methods allow us to use `State` in for-comprehensions:
 
 ```kotlin:ank:silent
-fun stackOperations() = StateT.monad<IdHK, Stack>().binding {
+fun stackOperations() = State().monad<Stack>().binding {
     val a = push("a").bind()
     val b = pop().bind()
     val c = pop().bind()
@@ -115,7 +115,7 @@ Available Instances:
 ```kotlin:ank
 import kategory.debug.*
 
-showInstances<StateTHK, Unit>()
+showInstances<StateKindPartial<Stack>, Unit>()
 ```
 
 # Credits

--- a/kategory-docs/docs/docs/datatypes/statet/README.md
+++ b/kategory-docs/docs/docs/datatypes/statet/README.md
@@ -141,7 +141,7 @@ Available Instances:
 ```kotlin:ank
 import kategory.debug.*
 
-showInstances<StateTHK, Unit>()
+showInstances<StateTKindPartial<EitherKindPartial<StackError>, Stack>, Unit>()
 ```
 
 Take a look at the [`EitherT` docs]({{ '/docs/datatypes/eithert' | relative_url }}) or [`OptionT` docs]({{ '/docs/datatypes/optiont' | relative_url }}) for an alternative version monad transformer for achieving different goals.

--- a/kategory-docs/docs/docs/integrations/kotlinxcoroutines/README.md
+++ b/kategory-docs/docs/docs/integrations/kotlinxcoroutines/README.md
@@ -62,7 +62,7 @@ in a way that feels idiomatic, while not having to worry about the semantics of 
 
 You can read more about FP architectures in the section on [Monad Transformers]({{ '/docs/patterns/monad_transformers' | relative_url }}).
 
-### Bringing Deferred to Kategory
+### Bringing Deferred to Kategory
 
 To create a Deferred Kategory Wrapper you can invoke the constructor with any synchronous non-suspending function, the same way you'd use `async`.
 


### PR DESCRIPTION
As discussed in https://github.com/kategory/kategory/pull/457 update to State to improve API.

As you can see to the changes in the docs nothing broke of the existing API (`StateT.monad<IdHK, Stack>().binding` is also still valid).

Now you can specify return types as `State<S, A>` instead of `StateT<IdHK, S, A>` and you can use `State()` to access the methods that are defined on `StateT.Companion` with `F` fixed to `IdHK`.

If this is approved I will do the same for `Reader`