### PR TITLE
Suppress higher kind inline warnings

### DIFF
--- a/kategory-annotations-processor/src/main/java/kategory/higherkinds/HigherKindsFileGenerator.kt
+++ b/kategory-annotations-processor/src/main/java/kategory/higherkinds/HigherKindsFileGenerator.kt
@@ -63,7 +63,7 @@ class HigherKindsFileGenerator(
 
     private fun genEv(hk: HigherKind): String =
             """
-            |@Suppress("UNCHECKED_CAST")
+            |@Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
             |inline fun <${hk.expandedTypeArgs}> ${hk.name}<${hk.expandedTypeArgs}>.ev(): ${hk.kindName}<${hk.expandedTypeArgs}>${hk.typeConstraints} =
             |  this as ${hk.kindName}<${hk.expandedTypeArgs}>
         """.trimMargin()


### PR DESCRIPTION
Currently, the `@higherkind` annotation generates code that creates the following warning: 

```Expected performance impact of inlining ... can be insignificant. Inlining works best for functions with lambda parameters```

This PR fixes this by suppressing that warning in the generated code.